### PR TITLE
Regtest

### DIFF
--- a/BRAddress.c
+++ b/BRAddress.c
@@ -247,6 +247,8 @@ size_t BRAddressFromScriptPubKey(char *addr, size_t addrLen, const uint8_t *scri
     data[0] = BITCOIN_PUBKEY_ADDRESS;
 #if BITCOIN_TESTNET
     data[0] = BITCOIN_PUBKEY_ADDRESS_TEST;
+#elif BITCOIN_REGTEST
+        data[0] = BITCOIN_SCRIPT_ADDRESS_REGTEST;
 #endif
     
     if (count == 5 && *elems[0] == OP_DUP && *elems[1] == OP_HASH160 && *elems[2] == 20 &&
@@ -261,6 +263,8 @@ size_t BRAddressFromScriptPubKey(char *addr, size_t addrLen, const uint8_t *scri
         data[0] = BITCOIN_SCRIPT_ADDRESS;
 #if BITCOIN_TESTNET
         data[0] = BITCOIN_SCRIPT_ADDRESS_TEST;
+#elif BITCOIN_REGTEST
+        data[0] = BITCOIN_SCRIPT_ADDRESS_REGTEST;
 #endif
         d = BRScriptData(elems[1], &l);
         if (l != 20) d = NULL;
@@ -290,6 +294,8 @@ size_t BRAddressFromScriptSig(char *addr, size_t addrLen, const uint8_t *script,
     data[0] = BITCOIN_PUBKEY_ADDRESS;
 #if BITCOIN_TESTNET
     data[0] = BITCOIN_PUBKEY_ADDRESS_TEST;
+#elif BITCOIN_REGTEST
+    data[0] = BITCOIN_PUBKEY_ADDRESS_REGTEST;
 #endif
     
     if (count >= 2 && *elems[count - 2] <= OP_PUSHDATA4 &&
@@ -303,6 +309,8 @@ size_t BRAddressFromScriptSig(char *addr, size_t addrLen, const uint8_t *script,
         data[0] = BITCOIN_SCRIPT_ADDRESS;
 #if BITCOIN_TESTNET
         data[0] = BITCOIN_SCRIPT_ADDRESS_TEST;
+#elif BITCOIN_REGTEST
+        data[0] = BITCOIN_SCRIPT_ADDRESS_REGTEST;
 #endif
         d = BRScriptData(elems[count - 1], &l);
         if (d) BRHash160(&data[1], d, l);
@@ -327,6 +335,9 @@ size_t BRAddressScriptPubKey(uint8_t *script, size_t scriptLen, const char *addr
 #if BITCOIN_TESTNET
     pubkeyAddress = BITCOIN_PUBKEY_ADDRESS_TEST;
     scriptAddress = BITCOIN_SCRIPT_ADDRESS_TEST;
+#elif BITCOIN_REGTEST
+    pubkeyAddress = BITCOIN_PUBKEY_ADDRESS_REGTEST;
+    scriptAddress = BITCOIN_SCRIPT_ADDRESS_REGTEST;
 #endif
     
     if (BRBase58CheckDecode(data, sizeof(data), addr) == 21) {
@@ -370,6 +381,8 @@ int BRAddressIsValid(const char *addr)
     
 #if BITCOIN_TESTNET
         r = (data[0] == BITCOIN_PUBKEY_ADDRESS_TEST || data[0] == BITCOIN_SCRIPT_ADDRESS_TEST);
+#elif BITCOIN_REGTEST
+        r = (data[0] == BITCOIN_PUBKEY_ADDRESS_REGTEST || data[0] == BITCOIN_SCRIPT_ADDRESS_REGTEST);
 #endif
     }
     

--- a/BRAddress.h
+++ b/BRAddress.h
@@ -36,6 +36,8 @@ extern "C" {
 
 #if BITCOIN_TESTNET
 #pragma message "testnet build"
+#elif BITCOIN_REGTEST
+#pragma message "regtest build"
 #endif
 
 // bitcoin address prefixes

--- a/BRAddress.h
+++ b/BRAddress.h
@@ -43,6 +43,8 @@ extern "C" {
 #define BITCOIN_SCRIPT_ADDRESS      5
 #define BITCOIN_PUBKEY_ADDRESS_TEST 111
 #define BITCOIN_SCRIPT_ADDRESS_TEST 196
+#define BITCOIN_PUBKEY_ADDRESS_REGTEST 111
+#define BITCOIN_SCRIPT_ADDRESS_REGTEST 196
 
 // bitcoin script opcodes: https://en.bitcoin.it/wiki/Script#Constants
 #define OP_0           0x00

--- a/BRBIP32Sequence.c
+++ b/BRBIP32Sequence.c
@@ -29,8 +29,17 @@
 #include <assert.h>
 
 #define BIP32_SEED_KEY "Bitcoin seed"
+
+#if BITCOIN_TESTNET
+#define BIP32_XPRV     "\x04\x35\x83\x94"
+#define BIP32_XPUB     "\x04\x35\x87\xCF"
+#elif BITCOIN_REGTEST
+#define BIP32_XPRV     "\x04\x35\x83\x94"
+#define BIP32_XPUB     "\x04\x35\x87\xCF"
+#else
 #define BIP32_XPRV     "\x04\x88\xAD\xE4"
 #define BIP32_XPUB     "\x04\x88\xB2\x1E"
+#endif
 
 // BIP32 is a scheme for deriving chains of addresses from a seed value
 // https://github.com/bitcoin/bips/blob/master/bip-0032.mediawiki

--- a/BRKey.c
+++ b/BRKey.c
@@ -32,6 +32,7 @@
 
 #define BITCOIN_PRIVKEY      128
 #define BITCOIN_PRIVKEY_TEST 239
+#define BITCOIN_PRIVKEY_REGTEST        239
 
 #if __BIG_ENDIAN__ || (defined(__BYTE_ORDER__) && __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__) ||\
     __ARMEB__ || __THUMBEB__ || __AARCH64EB__ || __MIPSEB__
@@ -132,6 +133,8 @@ int BRPrivKeyIsValid(const char *privKey)
     if (dataLen == 33 || dataLen == 34) { // wallet import format: https://en.bitcoin.it/wiki/Wallet_import_format
 #if BITCOIN_TESTNET
         r = (data[0] == BITCOIN_PRIVKEY_TEST);
+#elif BITCOIN_REGTEST
+        r = (data[0] == BITCOIN_PRIVKEY_REGTEST);
 #else
         r = (data[0] == BITCOIN_PRIVKEY);
 #endif
@@ -174,6 +177,8 @@ int BRKeySetPrivKey(BRKey *key, const char *privKey)
     
 #if BITCOIN_TESTNET
     version = BITCOIN_PRIVKEY_TEST;
+#elif BITCOIN_REGTEST
+    version = BITCOIN_PRIVKEY_REGTEST;
 #endif
 
     assert(key != NULL);
@@ -235,6 +240,8 @@ size_t BRKeyPrivKey(const BRKey *key, char *privKey, size_t pkLen)
         data[0] = BITCOIN_PRIVKEY;
 #if BITCOIN_TESTNET
         data[0] = BITCOIN_PRIVKEY_TEST;
+#elif BITCOIN_REGTEST
+        data[0] = BITCOIN_PRIVKEY_REGTEST;
 #endif
         
         UInt256Set(&data[1], key->secret);
@@ -294,6 +301,8 @@ size_t BRKeyAddress(BRKey *key, char *addr, size_t addrLen)
     data[0] = BITCOIN_PUBKEY_ADDRESS;
 #if BITCOIN_TESTNET
     data[0] = BITCOIN_PUBKEY_ADDRESS_TEST;
+#elif BITCOIN_REGTEST
+    data[0] = BITCOIN_PUBKEY_ADDRESS_REGTEST;
 #endif
     UInt160Set(&data[1], hash);
 

--- a/BRMerkleBlock.c
+++ b/BRMerkleBlock.c
@@ -324,8 +324,11 @@ int BRMerkleBlockVerifyDifficulty(const BRMerkleBlock *block, const BRMerkleBloc
 #if BITCOIN_TESTNET
     // TODO: implement testnet difficulty rule check
     return r; // don't worry about difficulty on testnet for now
+#elif BITCOIN_REGTEST
+    // TODO: implement testnet difficulty rule check
+    return r; // don't worry about difficulty on testnet for now
 #endif
-    
+
     if (r && (block->height % BLOCK_DIFFICULTY_INTERVAL) == 0) {
         // target is in "compact" format, where the most significant byte is the size of resulting value in bytes, next
         // bit is the sign, and the remaining 23bits is the value after having been right shifted by (size - 3)*8 bits

--- a/BRMerkleBlock.c
+++ b/BRMerkleBlock.c
@@ -31,7 +31,11 @@
 #include <string.h>
 #include <assert.h>
 
+#if BITCOIN_REGTEST
+#define MAX_PROOF_OF_WORK 0x207fffff
+#else
 #define MAX_PROOF_OF_WORK 0x1d00ffff    // highest value for difficulty target (higher values are less difficult)
+#endif
 #define TARGET_TIMESPAN   (14*24*60*60) // the targeted timespan between difficulty target adjustments
 
 inline static int _ceil_log2(int x)

--- a/BRPeer.c
+++ b/BRPeer.c
@@ -45,6 +45,8 @@
 
 #if BITCOIN_TESTNET
 #define MAGIC_NUMBER 0x0709110b
+#elif BITCOIN_REGTEST
+#define MAGIC_NUMBER 0xdab5bffa
 #else
 #define MAGIC_NUMBER 0xd9b4bef9
 #endif

--- a/BRPeer.h
+++ b/BRPeer.h
@@ -54,6 +54,8 @@ extern "C" {
 
 #if BITCOIN_TESTNET
 #define STANDARD_PORT 18333
+#elif BITCOIN_REGTEST
+#define STANDARD_PORT 18444
 #else
 #define STANDARD_PORT 8333
 #endif

--- a/BRPeerManager.c
+++ b/BRPeerManager.c
@@ -69,6 +69,16 @@ static const char *dns_seeds[] = {
     "testnet-seed.bitcoin.schildbach.de."
 };
 
+#elif BITCOIN_REGTEST
+
+static const struct { uint32_t height; const char *hash; uint32_t timestamp; uint32_t target; } checkpoint_array[] = {
+    {      0, "0f9188f13cb7b2c71f2a335e3a4fc328bf5beb436012afca590b1a11466e2206", 1296688602, 0x207fffff }
+    };
+
+static const char *dns_seeds[] = {
+    "example.com"
+    };
+
 #else // main net
 
 // blockchain checkpoints - these are also used as starting points for partial chain downloads, so they need to be at


### PR DESCRIPTION
Add support to RegTest network.

* Preprocessor macro BITCOIN_REGTEST: to discriminate regtest code. 
* Add BITCOIN_REGTEST=1 in "Preprocessor macro" in order to compile.
* Define your own dns_seeds in BRPeerManager.c.
* Define your port STANDARD_PORT in BRPeer.h
* Add regtest macro:
```
#define BITCOIN_PUBKEY_ADDRESS_REGTEST 111
#define BITCOIN_SCRIPT_ADDRESS_REGTEST 196
#define BITCOIN_PRIVKEY_REGTEST        239
#define BIP32_XPRV     "\x04\x35\x83\x94"
#define BIP32_XPUB     "\x04\x35\x87\xCF"
#define MAX_PROOF_OF_WORK 0x207fffff
#define MAGIC_NUMBER 0xdab5bffa
#define STANDARD_PORT 18444

static const struct { uint32_t height; const char *hash; uint32_t timestamp; uint32_t target; } checkpoint_array[] = {
    {      0, "0f9188f13cb7b2c71f2a335e3a4fc328bf5beb436012afca590b1a11466e2206", 1296688602, 0x207fffff }
    };

static const char *dns_seeds[] = {
    "example.com"
   };
```
