### PR TITLE
Fix 0 change output

### DIFF
--- a/BRWallet.c
+++ b/BRWallet.c
@@ -642,7 +642,7 @@ BRTransaction *BRWalletCreateTxForOutputs(BRWallet *wallet, const BRTxOutput out
         BRTransactionFree(transaction);
         transaction = NULL;
     }
-    else if (transaction && balance - (amount + feeAmount) >= minAmount) { // add change output
+    else if (transaction && balance - (amount + feeAmount) > minAmount) { // add change output
         BRWalletUnusedAddrs(wallet, &addr, 1, 1);
         uint8_t script[BRAddressScriptPubKey(NULL, 0, addr.s)];
         size_t scriptLen = BRAddressScriptPubKey(script, sizeof(script), addr.s);


### PR DESCRIPTION
The transaction has an 0BTC change amount, in the following condition:

current wallet balance == amount to spend && feeAmount == minAmount 

In this case, the following condition is TRUE (at line 645) and it adds the 0BTC change output:
```
else if (transaction && balance - (amount + feeAmount) >= minAmount) { // add change output
```
Note: same problem if the balance satisfied the following condition:
balance == minAmount + amount + feeAmount