### PR TITLE
Code Cleanup

### DIFF
--- a/BRChainParams.h
+++ b/BRChainParams.h
@@ -49,12 +49,12 @@ typedef struct {
 } BRChainParams;
 
 static const char *BRMainNetDNSSeeds[] = {
-    "seed.breadwallet.com.", "seed.bitcoin.sipa.be.", "dnsseed.bluematt.me.", "dnsseed.bitcoin.dashjr.org.",
+    "seed.bitcoin.sipa.be.", "dnsseed.bluematt.me.", "dnsseed.bitcoin.dashjr.org.",
     "seed.bitcoinstats.com.", "bitseed.xf2.org.", "seed.bitcoin.jonasschnelli.ch.", NULL
 };
 
 static const char *BRTestNetDNSSeeds[] = {
-    "testnet-seed.breadwallet.com.", "testnet-seed.bitcoin.petertodd.org.", "testnet-seed.bluematt.me.",
+    "testnet-seed.bitcoin.petertodd.org.", "testnet-seed.bluematt.me.",
     "testnet-seed.bitcoin.schildbach.de.", NULL
 };
 


### PR DESCRIPTION
Given that "there’s nothing actually at http://seed.breadwallet.com  it was used a few years back to evaluate whether or not hosting our own nodes would help with SPV syncing performance."  https://twitter.com/zadikafka/status/1089352887795400705 and to prevent this random DNS server to ever include any Bitcoin node potentially opening users wallets to be used as test data without their concern.

I've removed `testnet-seed.breadwallet.com.` and `seed.breadwallet.com.` from the DNS seed list.