### PR TITLE
Up Token Gas Limit Default

### DIFF
--- a/ethereum/BREthereumToken.h
+++ b/ethereum/BREthereumToken.h
@@ -32,7 +32,7 @@
 
 // For tokenBRD define defaults for Gas Limit and Price.  These are arguably never up to date
 // and thus should be changed in programmatically using walletSetDefaultGas{Price,Limit}().
-#define TOKEN_BRD_DEFAULT_GAS_LIMIT  92000
+#define TOKEN_BRD_DEFAULT_GAS_LIMIT  112000
 #define TOKEN_BRD_DEFAULT_GAS_PRICE_IN_WEI_UINT64 (2000000000) // 2.0 GWEI
 
 #ifdef __cplusplus


### PR DESCRIPTION

#### Changes
Our users are having issues redeeming TrueUSD for USD from Bread Wallet because the default token gas limit is too low.
For example, [this transaction](https://etherscan.io/tx/0xb2aded438eb18524c26c0832016cabaefb6bb62aa37cce65c54577a79d741256) required more than 100 kgas before refund.
This increases the gas limit to a value high enough for TrueUSD redemptions.
Reviewers @EBGToo