### PR TITLE
BIP38 Uses Base58Check to do its validation not bech32

### DIFF
--- a/BRBIP38Key.c
+++ b/BRBIP38Key.c
@@ -180,7 +180,7 @@ int BRKeySetBIP38Key(BRKey *key, const char *bip38Key, const char *passphrase)
     
     BRKeySetSecret(key, &secret, flag & BIP38_COMPRESSED_FLAG);
     var_clean(&secret);
-    BRKeyAddress(key, address.s, sizeof(address));
+    BRKeyLegacyAddr(key, address.s, sizeof(address));
     BRSHA256_2(&hash, address.s, strlen(address.s));
     if (! address.s[0] || memcmp(&hash, addresshash, sizeof(uint32_t)) != 0) r = 0;
     return r;


### PR DESCRIPTION
Source https://github.com/bitcoin/bips/blob/master/bip-0038.mediawiki#specification

This fixes sweeping private keys with a password.