### PR TITLE
Larger cast to avoid narrowing

### DIFF
--- a/Java/Core/src/main/cpp/jni/com_breadwallet_core_BRCoreTransactionInput.c
+++ b/Java/Core/src/main/cpp/jni/com_breadwallet_core_BRCoreTransactionInput.c
@@ -31,7 +31,7 @@ JNIEXPORT jlong JNICALL Java_com_breadwallet_core_BRCoreTransactionInput_createT
 
     input->txHash = UInt256Get((const void *) hashData);
     input->index = (uint32_t) index;
-    input->amount = (uint32_t) amount;
+    input->amount = (uint64_t) amount;
 
     // script
     input->script = NULL;


### PR DESCRIPTION
If you create an input using large Satoshi amounts, for example anything over the maximum amount for uint32_t, the resulting input will be returned with an amount value less than expected. uint32_t is not large enough for this cast and the type being cast to is type uint64_t, so it seems sensible to change the cast to be the same.

https://github.com/breadwallet/breadwallet-core/blob/4081fc8967a59949a04b7023fb643aff91c215be/bitcoin/BRTransaction.h#L54

createTransactionOutput already casts the jlong amount to uint64_t.

https://github.com/breadwallet/breadwallet-core/blob/4081fc8967a59949a04b7023fb643aff91c215be/Java/Core/src/main/cpp/jni/com_breadwallet_core_BRCoreTransactionOutput.c#L35