### PR TITLE
Bugfix/core 319

### DIFF
--- a/Swift/BRCrypto/implS/BRSystem.swift
+++ b/Swift/BRCrypto/implS/BRSystem.swift
@@ -102,12 +102,12 @@ public final class SystemBase: System {
             // events will be ignored because the array system.managers cannot possiby include
             // 'manager' - which must exist to properly dispatch the listener announcement.
             // Thus the events are lost.  We'll send them again.
-            manager = WalletManagerImplS (system: self,
-                                          listener: listener!,
-                                          account: account,
-                                          network: network,
-                                          mode: mode,
-                                          storagePath: path)
+            manager = WalletManagerImplS.create (system: self,
+                                                 listener: listener!,
+                                                 account: account,
+                                                 network: network,
+                                                 mode: mode,
+                                                 storagePath: path)
 
             if network.currency.code == Currency.codeAsETH {
                 // think about adding tokens/currencies for ERC20, others.

--- a/Swift/BRCrypto/implS/BRWalletManager.swift
+++ b/Swift/BRCrypto/implS/BRWalletManager.swift
@@ -354,6 +354,8 @@ class WalletManagerImplS: WalletManager {
 
         internal func initialize(manager: WalletManagerImplS) {
             switch self {
+            case let .ethereum (ewm):
+                ewmInitialize (ewm)
             case let .bitcoin (bwm):
                 BRWalletManagerInit (bwm)
                 // Hacky?

--- a/Swift/CorePerf/main.c
+++ b/Swift/CorePerf/main.c
@@ -55,6 +55,7 @@ runSyncMany (BREthereumNetwork newtork,
         clients[i] = runEWM_createClient();
 
         ewm = ewmCreate (ethereumMainnet, account, timestamp, mode, clients[i], storagePath);
+        ewmInitialize (ewm);
         ewms[i] = ewm;
 
         char *address = ewmGetAccountPrimaryAddress(ewm);

--- a/bitcoin/BRWalletManager.h
+++ b/bitcoin/BRWalletManager.h
@@ -198,6 +198,9 @@ BRWalletManagerNew (BRWalletManagerClient client,
                     const char *storagePath);
 
 extern void
+BRWalletManagerInit (BRWalletManager manager);
+
+extern void
 BRWalletManagerFree (BRWalletManager manager);
 
 extern void

--- a/bitcoin/test.c
+++ b/bitcoin/test.c
@@ -3123,6 +3123,8 @@ extern int BRRunTestWalletManagerSync (const char *paperKey,
 
     BRWalletManager manager = BRWalletManagerNew (client, mpk, params, epoch, mode, storagePath);
 
+    BRWalletManagerInit(manager);
+
     BRPeerManager *pm = BRWalletManagerGetPeerManager(manager);
 
     syncDone = 0;

--- a/crypto/pending/BRCryptoWalletManager.c
+++ b/crypto/pending/BRCryptoWalletManager.c
@@ -175,6 +175,8 @@ cryptoWalletManagerCreate (BRCryptoCWMListener listener,
                                              mode,
                                              cwmPath);
 
+            BRWalletManagerInit(cwm->u.btc);
+
             cwm->wallet = cryptoWalletCreateAsBTC (unit, unit, BRWalletManagerGetWallet (cwm->u.btc));
             break;
         }

--- a/crypto/pending/BRCryptoWalletManager.c
+++ b/crypto/pending/BRCryptoWalletManager.c
@@ -212,6 +212,8 @@ cryptoWalletManagerCreate (BRCryptoCWMListener listener,
                                     client,
                                     cwmPath);
 
+            ewmInitialize (cwm->u.eth);
+
             cwm->wallet = cryptoWalletCreateAsETH (unit, unit, ewmGetWallet (cwm->u.eth));
             break;
         }

--- a/ethereum/bcs/BREthereumBCS.c
+++ b/ethereum/bcs/BREthereumBCS.c
@@ -135,8 +135,8 @@ bcsCreateInitializeBlocks (BREthereumBCS bcs,
 }
 
 static void
-bcsCreateInitializeTransactions (BREthereumBCS bcs,
-                                 BRSetOf(BREthereumTransaction) transactions) {
+bcsInitializeTransactions (BREthereumBCS bcs,
+                           OwnershipGiven BRSetOf(BREthereumTransaction) transactions) {
     if (NULL == transactions) return;
     else if (0 == BRSetCount(transactions)) { BRSetFree (transactions); return; }
 
@@ -154,8 +154,8 @@ bcsCreateInitializeTransactions (BREthereumBCS bcs,
 }
 
 static void
-bcsCreateInitializeLogs (BREthereumBCS bcs,
-                         BRSetOf(BREthereumLog) logs) {
+bcsInitializeLogs (BREthereumBCS bcs,
+                   OwnershipGiven BRSetOf(BREthereumLog) logs) {
     if (NULL == logs) return;
     else if (0 == BRSetCount(logs)) { BRSetFree (logs); return; }
 
@@ -178,9 +178,7 @@ bcsCreate (BREthereumNetwork network,
            BREthereumBCSListener listener,
            BREthereumMode mode,
            OwnershipGiven BRSetOf(BREthereumNodeConfig) peers,
-           OwnershipGiven BRSetOf(BREthereumBlock) blocks,
-           OwnershipGiven BRSetOf(BREthereumTransaction) transactions,
-           OwnershipGiven BRSetOf(BREthereumLog) logs) {
+           OwnershipGiven BRSetOf(BREthereumBlock) blocks) {
 
     BREthereumBCS bcs = (BREthereumBCS) calloc (1, sizeof(struct BREthereumBCSStruct));
 
@@ -247,8 +245,6 @@ bcsCreate (BREthereumNetwork network,
 
     // Initialize blocks, transactions and logs from saved state.
     bcsCreateInitializeBlocks(bcs, blocks);
-    bcsCreateInitializeTransactions(bcs, transactions);
-    bcsCreateInitializeLogs(bcs, logs);
 
     // Initialize LES and SYNC - we must create LES from a block where the totalDifficulty is
     // computed.  In practice, we need all the blocks from bcs->chain back to a checkpoint - and
@@ -300,6 +296,15 @@ bcsCreate (BREthereumNetwork network,
     bcs->pow = proofOfWorkCreate();
 
     return bcs;
+}
+
+extern void
+bcsInitialize (BREthereumBCS bcs,
+               OwnershipGiven BRSetOf(BREthereumTransaction) transactions,
+               OwnershipGiven BRSetOf(BREthereumLog) logs) {
+    // Initialize ransactions and logs from saved state.
+    bcsInitializeTransactions(bcs, transactions);
+    bcsInitializeLogs(bcs, logs);
 }
 
 extern void

--- a/ethereum/bcs/BREthereumBCS.h
+++ b/ethereum/bcs/BREthereumBCS.h
@@ -163,9 +163,12 @@ bcsCreate (BREthereumNetwork network,
            BREthereumBCSListener listener,
            BREthereumMode syncMode,
            BRSetOf(BREthereumNodeConfig) peers,
-           BRSetOf(BREthereumBlock) blocks,
-           BRSetOf(BREthereumTransaction) transactions,
-           BRSetOf(BREthereumLog) logs);
+           BRSetOf(BREthereumBlock) blocks);
+
+extern void
+bcsInitialize (BREthereumBCS bcs,
+               OwnershipGiven BRSetOf(BREthereumTransaction) transactions,
+               OwnershipGiven BRSetOf(BREthereumLog) logs);
 
 extern void
 bcsStart (BREthereumBCS bcs);

--- a/ethereum/ewm/BREthereumEWM.h
+++ b/ethereum/ewm/BREthereumEWM.h
@@ -48,6 +48,9 @@ ewmCreateWithPublicKey (BREthereumNetwork network,
                         const char *storagePath);
 
 extern void
+ewmInitialize (BREthereumEWM ewm);
+
+extern void
 ewmDestroy (BREthereumEWM ewm);
 
 extern BREthereumNetwork

--- a/ethereum/ewm/testEwm.c
+++ b/ethereum/ewm/testEwm.c
@@ -587,6 +587,8 @@ runEWM_CONNECT_test (const char *paperKey,
                                                storagePath);
     assert (NULL != ewm);
 
+    ewmInitialize (ewm);
+
     BREthereumWallet wallet = ewmGetWallet(ewm);
     assert (NULL != wallet);
 
@@ -650,6 +652,9 @@ void prepareTransaction (const char *paperKey,
                                                P2P_ONLY,
                                                client,
                                                storagePath);
+
+    ewmInitialize (ewm);
+
     // A wallet amount Ether
     BREthereumWallet wallet = ewmGetWallet(ewm);
     // END - One Time Code Block
@@ -710,6 +715,9 @@ testReallySend (const char *storagePath) {
                                                P2P_ONLY,
                                                client,
                                                storagePath);
+
+    ewmInitialize (ewm);
+
     BREthereumAccount account = ewmGetAccount(ewm);
     
     // A wallet amount Ether
@@ -783,6 +791,9 @@ runEWM_TOKEN_test (const char *paperKey,
                                                P2P_ONLY,
                                                client,
                                                storagePath);
+
+    ewmInitialize (ewm);
+
     BREthereumWallet wid = ewmGetWalletHoldingToken(ewm, token);
     
     BREthereumAmount amount = ewmCreateTokenAmountString(ewm, token,
@@ -818,6 +829,9 @@ runEWM_PUBLIC_KEY_test (BREthereumNetwork network,
                                                 P2P_ONLY,
                                                 client,
                                                 storagePath);
+
+    ewmInitialize (ewm1);
+
     BRKey publicKey = ewmGetAccountPrimaryAddressPublicKey (ewm1);
     char *addr1 = ewmGetAccountPrimaryAddress (ewm1);
     
@@ -825,6 +839,9 @@ runEWM_PUBLIC_KEY_test (BREthereumNetwork network,
                                                  P2P_ONLY,
                                                  client,
                                                  storagePath);
+
+    ewmInitialize (ewm2);
+
     char *addr2 = ewmGetAccountPrimaryAddress (ewm2);
     
     
@@ -855,6 +872,7 @@ runSyncTest (BREthereumNetwork network,
 
     ewm = ewmCreate (ethereumMainnet, account, accountTimestamp, mode, client, storagePath);
 
+    ewmInitialize (ewm);
     
     char *address = ewmGetAccountPrimaryAddress(ewm);
     printf ("ETH: TST:\nETH: TST: Address: %s\nETH: TST:\n", address);


### PR DESCRIPTION
Split off the creation and initialization (which can result in callbacks being triggered) into two distinct methods for Ethereum and Bitcoin (i.e. New and Init operations).

This allows the pointer returned by the New calls to be used when callbacks are triggered via the Init calls.