### PR TITLE
CORE-368: Synchronize BREthereumEWM::addTokenByReference.

### DIFF
--- a/Java/Core/src/main/java/com/breadwallet/core/ethereum/BREthereumEWM.java
+++ b/Java/Core/src/main/java/com/breadwallet/core/ethereum/BREthereumEWM.java
@@ -479,7 +479,7 @@ public class BREthereumEWM extends BRCoreJniReference {
         return tokensByReference.get(reference);
     }
 
-    protected BREthereumToken addTokenByReference (long reference) {
+    protected synchronized BREthereumToken addTokenByReference (long reference) {
         BREthereumToken token = new BREthereumToken (reference);
         tokensByReference.put (token.getIdentifier(),            token);
         tokensByAddress.put   (token.getAddress().toLowerCase(), token);


### PR DESCRIPTION
That method is called in a JNI callback ‘trampoline’ thread and modifies the `tokensByReference` and `tokensByAddress` HashMaps.  That modification leads to a `java.util.ConcurrentModificationException` when other threads are reading the HashMaps.