### PR TITLE
CORE-388: Change the serialize functions

### DIFF
--- a/ripple/BRRippleAccount.c
+++ b/ripple/BRRippleAccount.c
@@ -231,11 +231,11 @@ extern BRRippleAddress rippleAccountGetPrimaryAddress (BRRippleAccount account)
     return account->raw;
 }
 
-extern BRRippleSerializedTransaction
+extern size_t
 rippleTransactionSerializeAndSign(BRRippleTransaction transaction, BRKey *privateKey,
                                   BRKey *publicKey, uint32_t sequence, uint32_t lastLedgerSequence);
 
-extern const BRRippleSerializedTransaction
+extern size_t
 rippleAccountSignTransaction(BRRippleAccount account, BRRippleTransaction transaction, const char *paperKey)
 {
     assert(account);
@@ -245,16 +245,16 @@ rippleAccountSignTransaction(BRRippleAccount account, BRRippleTransaction transa
     // Create the private key from the paperKey
     BRKey key = getKey(paperKey);
 
-    BRRippleSerializedTransaction signedBytes =
+    size_t tx_size =
         rippleTransactionSerializeAndSign(transaction, &key, &account->publicKey,
                                           account->sequence, account->lastLedgerSequence);
 
     // Increment the sequence number if we were able to sign the bytes
-    if (signedBytes) {
+    if (tx_size > 0) {
         account->sequence++;
     }
 
-    return signedBytes;
+    return tx_size;
 }
 
 extern int rippleAddressStringToAddress(const char* input, BRRippleAddress *address)

--- a/ripple/BRRippleAccount.h
+++ b/ripple/BRRippleAccount.h
@@ -83,13 +83,9 @@ extern void rippleAccountSetLastLedgerSequence(BRRippleAccount account,
  * @param transaction     the transaction to serialize
  * @param paperKey        paper key of the sending account
  *
- * @return handle         BRRippleSerializedTransaction handle, use this to get the size and bytes
- *                        NOTE: If successful then the sequence number in the account is incremented
- *                        NOTE: is the handle is NULL then the serialization failed AND the sequence
- *                              was not incremented
+ * @return size           size of serialized/siged bytes
  */
-extern
-const BRRippleSerializedTransaction /* do NOT free, owned by transaction */
+extern size_t
 rippleAccountSignTransaction(BRRippleAccount account, BRRippleTransaction transaction, const char *paperKey);
 
 // Accessor function for the account address (Ripple ID)

--- a/ripple/BRRippleTransaction.h
+++ b/ripple/BRRippleTransaction.h
@@ -15,7 +15,6 @@
 #include "BRKey.h"
 
 typedef struct BRRippleTransactionRecord *BRRippleTransaction;
-typedef struct BRRippleSerializedTransactionRecord *BRRippleSerializedTransaction;
 
 /**
  * Create a Ripple transaction
@@ -59,21 +58,16 @@ rippleTransactionCreateFromBytes(uint8_t *bytes, int length);
 extern void rippleTransactionFree(BRRippleTransaction transaction);
 
 /**
- * Get the size of a serialized/signed transaction
+ * Get a copy of the serialized/signed bytes for a transaction
  *
- * @param  s     serialized transaction
- * @return size
- */
-extern uint32_t rippleTransactionGetSerializedSize(BRRippleSerializedTransaction s);
-
-/**
- * Get the raw bytes of a serialized/signed transaction
+ * @param  transaction   handle to a serialized/signed transaction
+ * @param size           the number of bytes for the newly allocated buffer
  *
- * @param  s     serialized transaction
- * @return bytes uint8_t *
+ * @return buffer        pointer to buffer (caller must free) with serialized/signed bytes
+ *                       or NULL if the transaction has not yet been serialized.
  */
-extern uint8_t* /* DO NOT FREE - owned by the transaction object */
-rippleTransactionGetSerializedBytes(BRRippleSerializedTransaction s);
+extern uint8_t * // Caller MUST free these bytes
+rippleTransactionSerialize(BRRippleTransaction transaction, size_t * bufferSize);
 
 /**
  * Get the hash of a ripple transaction

--- a/ripple/testRipple.c
+++ b/ripple/testRipple.c
@@ -274,10 +274,10 @@ testSerializeWithSignature () {
     rippleAccountSetSequence(account, sequence_number);
 
     // Serialize and sign
-    BRRippleSerializedTransaction s = rippleAccountSignTransaction(account, transaction, paper_key);
-    assert(s);
-    int signed_size = rippleTransactionGetSerializedSize(s);
-    uint8_t *signed_bytes = rippleTransactionGetSerializedBytes(s);
+    size_t s_size = rippleAccountSignTransaction(account, transaction, paper_key);
+    size_t signed_size;
+    uint8_t *signed_bytes = rippleTransactionSerialize(transaction, &signed_size);
+    assert(s_size == signed_size);
     // Print out the bytes as a string
     if (debug_log) {
         for (int i = 0; i < signed_size; i++) {
@@ -303,6 +303,7 @@ testSerializeWithSignature () {
     
     rippleTransactionFree(transaction);
     rippleAccountFree(account);
+    free(signed_bytes);
 }
 
 extern BRRippleSignatureRecord rippleTransactionGetSignature(BRRippleTransaction transaction);
@@ -531,8 +532,7 @@ testTransactionHash (void /* ... */) {
 
     // Serialize and sign
     rippleAccountSetSequence(account, 25);
-    BRRippleSerializedTransaction s = rippleAccountSignTransaction(account, transaction, paper_key);
-    assert(s);
+    rippleAccountSignTransaction(account, transaction, paper_key);
     
     // Compare the transaction hash
     uint8_t expected_hash[] = {
@@ -667,7 +667,13 @@ static void runDeserializeTests(const char* tx_list_name, const char* tx_list[],
     int xrp_currency = 0;
     int other_currency = 0;
     for(int i = 0; i <= num_elements - 2; i += 2) {
+        size_t input_size = strlen(tx_list[i+1]) / 2;
+        size_t output_size;
         BRRippleTransaction transaction = transactionDeserialize(tx_list[i+1], NULL);
+        uint8_t * signed_bytes = rippleTransactionSerialize(transaction, &output_size);
+        assert(input_size == output_size);
+        free(signed_bytes);
+
         assert(transaction);
         
         // Check if this is a transaction


### PR DESCRIPTION
1. Remove the unneeded BRRippleSeralizedTransaction structure
and just have methods on the transaction to get at the bytes

2. When a user asks for serialized bytes, allocate a new buffer,
copy the bytes and then they can simply free a uint8_t pointer

3. When a user creates a transaction via raw bytes from the server,
store those bytes with the transaction so they can retrieve later