### PR TITLE
CORE-384: For Java Core Ethereum, expose a Transfer’s error status.

### DIFF
--- a/Java/Core/src/main/cpp/jni/ethereum/com_breadwallet_core_ethereum_BREthereumEWM.c
+++ b/Java/Core/src/main/cpp/jni/ethereum/com_breadwallet_core_ethereum_BREthereumEWM.c
@@ -1442,8 +1442,36 @@ Java_com_breadwallet_core_ethereum_BREthereumEWM_jniTransactionIsSubmitted
     return (jboolean) (ETHEREUM_BOOLEAN_TRUE == ewmTransferIsSubmitted (node, transfer)
                        ? JNI_TRUE
                        : JNI_FALSE);
-
 }
+
+/*
+ * Class:     com_breadwallet_core_ethereum_BREthereumEWM
+ * Method:    jniTransactionIsErrored
+ * Signature: (J)Z
+ */
+JNIEXPORT jboolean JNICALL
+Java_com_breadwallet_core_ethereum_BREthereumEWM_jniTransactionIsErrored
+        (JNIEnv *env, jobject thisObject, jlong tid) {
+    BREthereumEWM node = (BREthereumEWM) getJNIReference(env, thisObject);
+    BREthereumTransfer transfer = getTransfer (env, tid);
+    return (jboolean) (TRANSFER_STATUS_ERRORED == ewmTransferGetStatus (node, transfer)
+                       ? JNI_TRUE
+                       : JNI_FALSE);
+}
+
+/*
+ * Class:     com_breadwallet_core_ethereum_BREthereumEWM
+ * Method:    jniTransactionGetErrorDescription
+ * Signature: (J)Ljava/lang/String;
+ */
+JNIEXPORT jstring JNICALL Java_com_breadwallet_core_ethereum_BREthereumEWM_jniTransactionGetErrorDescription
+        (JNIEnv *env, jobject thisObject, jlong tid) {
+    BREthereumEWM node = (BREthereumEWM) getJNIReference(env, thisObject);
+    BREthereumTransfer transfer = getTransfer (env, tid);
+    char *errorDescription = ewmTransferStatusGetError(node, transfer);
+    return NULL == errorDescription ? NULL : asJniString(env, errorDescription);
+}
+
 
 /*
  * Class:     com_breadwallet_core_ethereum_BREthereumEWM

--- a/Java/Core/src/main/cpp/jni/ethereum/com_breadwallet_core_ethereum_BREthereumEWM.h
+++ b/Java/Core/src/main/cpp/jni/ethereum/com_breadwallet_core_ethereum_BREthereumEWM.h
@@ -441,6 +441,23 @@ JNIEXPORT jboolean JNICALL Java_com_breadwallet_core_ethereum_BREthereumEWM_jniT
 
 /*
  * Class:     com_breadwallet_core_ethereum_BREthereumEWM
+ * Method:    jniTransactionIsErrored
+ * Signature: (J)Z
+ */
+JNIEXPORT jboolean JNICALL Java_com_breadwallet_core_ethereum_BREthereumEWM_jniTransactionIsErrored
+        (JNIEnv *, jobject, jlong);
+
+/*
+ * Class:     com_breadwallet_core_ethereum_BREthereumEWM
+ * Method:    jniTransactionGetErrorDescription
+ * Signature: (J)Ljava/lang/String;
+ */
+JNIEXPORT jstring JNICALL Java_com_breadwallet_core_ethereum_BREthereumEWM_jniTransactionGetErrorDescription
+        (JNIEnv *, jobject, jlong);
+
+
+/*
+ * Class:     com_breadwallet_core_ethereum_BREthereumEWM
  * Method:    jniUpdateTokens
  * Signature: ()V
  */

--- a/Java/Core/src/main/java/com/breadwallet/core/ethereum/BREthereumEWM.java
+++ b/Java/Core/src/main/java/com/breadwallet/core/ethereum/BREthereumEWM.java
@@ -719,6 +719,10 @@ public class BREthereumEWM extends BRCoreJniReference {
 
     protected native boolean jniTransactionIsSubmitted(long transactionId);
 
+    protected native boolean jniTransactionIsErrored(long transactionId);
+
+    protected native String jniTransactionGetErrorDescription(long transactionId);
+
     //
     // JNI: Tokens
     //

--- a/Java/Core/src/main/java/com/breadwallet/core/ethereum/BREthereumTransfer.java
+++ b/Java/Core/src/main/java/com/breadwallet/core/ethereum/BREthereumTransfer.java
@@ -35,6 +35,10 @@ public class BREthereumTransfer extends BREthereumEWM.ReferenceWithDefaultUnit {
         return ewm.get().jniTransactionIsSubmitted(identifier);
     }
 
+    public boolean isErrored () {
+        return ewm.get().jniTransactionIsErrored(identifier);
+    }
+
     public String getSourceAddress () {
         return ewm.get().jniTransactionSourceAddress(identifier);
     }
@@ -199,5 +203,9 @@ public class BREthereumTransfer extends BREthereumEWM.ReferenceWithDefaultUnit {
 
     public long getBlockConfirmations () {
         return ewm.get().jniTransactionGetBlockConfirmations(identifier);
+    }
+
+    public String getErrorDescription () {
+        return ewm.get().jniTransactionGetErrorDescription(identifier);
     }
 }


### PR DESCRIPTION
Added Transfer:isErrored (analogous to isConfirmed() and isSubmitted()) and Transfer:getErrorDescription (NULL if not isErrored()).

This change does not touch BTC code.  This change parallels existing functions in Java/JNI.