### PR TITLE
CORE-397: Improve handling of paper key / phrase in Java

### DIFF
--- a/Java/CoreCrypto/src/androidTest/java/com/breadwallet/corecrypto/AccountAIT.java
+++ b/Java/CoreCrypto/src/androidTest/java/com/breadwallet/corecrypto/AccountAIT.java
@@ -2,6 +2,7 @@ package com.breadwallet.corecrypto;
 
 import org.junit.Test;
 
+import java.nio.charset.StandardCharsets;
 import java.util.Date;
 
 import static org.junit.Assert.*;
@@ -10,10 +11,10 @@ public class AccountAIT {
 
     @Test
     public void testAccountCreateFromPhrase() {
-        String phrase = "ginger settle marine tissue robot crane night number ramp coast roast critic";
+        byte[] phrase = "ginger settle marine tissue robot crane night number ramp coast roast critic".getBytes(StandardCharsets.UTF_8);
         String uids = "5766b9fa-e9aa-4b6d-9b77-b5f1136e5e96";
         Date timestamp = new Date(0);
-        Account account = Account.create(phrase, timestamp, uids);
+        Account account = Account.createFromPhrase(phrase, timestamp, uids);
         assertEquals(timestamp.getTime(), account.getTimestamp().getTime());
 
         // TODO: Add addressAsETH
@@ -21,11 +22,11 @@ public class AccountAIT {
 
     @Test
     public void testAccountDeriveSeed() {
-        String phrase = "ginger settle marine tissue robot crane night number ramp coast roast critic";
+        byte[] phrase = "ginger settle marine tissue robot crane night number ramp coast roast critic".getBytes(StandardCharsets.UTF_8);
         byte[] seed = Account.deriveSeed(phrase);
         String uids = "5766b9fa-e9aa-4b6d-9b77-b5f1136e5e96";
         Date timestamp = new Date(0);
-        Account account = Account.create(seed, timestamp, uids);
+        Account account = Account.createFromSeed(seed, timestamp, uids);
         assertEquals(timestamp.getTime(), account.getTimestamp().getTime());
 
         // TODO: Add addressAsETH

--- a/Java/CoreCrypto/src/main/java/com/breadwallet/corecrypto/Account.java
+++ b/Java/CoreCrypto/src/main/java/com/breadwallet/corecrypto/Account.java
@@ -14,11 +14,33 @@ import java.util.Date;
 /* package */
 final class Account implements com.breadwallet.crypto.Account {
 
+    /**
+     * Create an account using a BIP32 phrase.
+     *
+     * @apiNote The caller should take appropriate security measures, like enclosing this method's call in a
+     * try-finally block that wipes the phraseUtf8 value, to ensure that it is purged from memory
+     * upon completion.
+     *
+     * @param phraseUtf8 The UTF-8 NFKD normalized BIP32 phrase
+     * @param timestamp The timestamp of when this account was first created
+     * @param uids The unique identifier of this account
+     */
     /* package */
     static Account createFromPhrase(byte[] phraseUtf8, Date timestamp, String uids) {
         return new Account(CoreBRCryptoAccount.createFromPhrase(phraseUtf8), timestamp, uids);
     }
 
+    /**
+     * Create an account using a BIP32 seed.
+     *
+     * @apiNote The caller should take appropriate security measures, like enclosing this method's call in a
+     * try-finally block that wipes the seed value, to ensure that it is purged from memory
+     * upon completion.
+     *
+     * @param seed The 512-bit BIP32 seed value
+     * @param timestamp The timestamp of when this account was first created
+     * @param uids The unique identifier of this account
+     */
     /* package */
     static Account createFromSeed(byte[] seed, Date timestamp, String uids) {
         return new Account(CoreBRCryptoAccount.createFromSeed(seed), timestamp, uids);

--- a/Java/CoreCrypto/src/main/java/com/breadwallet/corecrypto/Account.java
+++ b/Java/CoreCrypto/src/main/java/com/breadwallet/corecrypto/Account.java
@@ -15,18 +15,18 @@ import java.util.Date;
 final class Account implements com.breadwallet.crypto.Account {
 
     /* package */
-    static Account create(String phrase, Date timestamp, String uids) {
-        return new Account(CoreBRCryptoAccount.create(phrase), timestamp, uids);
+    static Account createFromPhrase(byte[] phraseUtf8, Date timestamp, String uids) {
+        return new Account(CoreBRCryptoAccount.createFromPhrase(phraseUtf8), timestamp, uids);
     }
 
     /* package */
-    static Account create(byte[] seed, Date timestamp, String uids) {
+    static Account createFromSeed(byte[] seed, Date timestamp, String uids) {
         return new Account(CoreBRCryptoAccount.createFromSeed(seed), timestamp, uids);
     }
 
     /* package */
-    static byte[] deriveSeed(String phrase) {
-        return CoreBRCryptoAccount.deriveSeed(phrase);
+    static byte[] deriveSeed(byte[] phraseUtf8) {
+        return CoreBRCryptoAccount.deriveSeed(phraseUtf8);
     }
 
     /* package */

--- a/Java/CoreCrypto/src/main/java/com/breadwallet/corecrypto/CryptoApiProvider.java
+++ b/Java/CoreCrypto/src/main/java/com/breadwallet/corecrypto/CryptoApiProvider.java
@@ -27,13 +27,13 @@ public final class CryptoApiProvider implements CryptoApi.Provider {
     private static final CryptoApi.AccountProvider accountProvider = new CryptoApi.AccountProvider() {
 
         @Override
-        public Account create(String phrase, Date timestamp, String uids) {
-            return Account.create(phrase, timestamp, uids);
+        public Account createFromPhrase(byte[] phraseUtf8, Date timestamp, String uids) {
+            return Account.createFromPhrase(phraseUtf8, timestamp, uids);
         }
 
         @Override
-        public Account create(byte[] seed, Date timestamp, String uids) {
-            return Account.create(seed, timestamp, uids);
+        public Account createFromSeed(byte[] seed, Date timestamp, String uids) {
+            return Account.createFromSeed(seed, timestamp, uids);
         }
     };
 

--- a/Java/CoreCrypto/src/main/java/com/breadwallet/corecrypto/WalletManager.java
+++ b/Java/CoreCrypto/src/main/java/com/breadwallet/corecrypto/WalletManager.java
@@ -165,10 +165,10 @@ final class WalletManager implements com.breadwallet.crypto.WalletManager {
     }
 
     @Override
-    public void submit(com.breadwallet.crypto.Transfer transfer, String paperKey) {
+    public void submit(com.breadwallet.crypto.Transfer transfer, byte[] phraseUtf8) {
         Transfer cryptoTransfer = Transfer.from(transfer);
         Wallet cryptoWallet = cryptoTransfer.getWallet();
-        core.submit(cryptoWallet.getCoreBRCryptoWallet(), cryptoTransfer.getCoreBRCryptoTransfer(), paperKey);
+        core.submit(cryptoWallet.getCoreBRCryptoWallet(), cryptoTransfer.getCoreBRCryptoTransfer(), phraseUtf8);
     }
 
     @Override

--- a/Java/CoreNative/src/main/java/com/breadwallet/corenative/CryptoLibrary.java
+++ b/Java/CoreNative/src/main/java/com/breadwallet/corenative/CryptoLibrary.java
@@ -34,6 +34,8 @@ import com.sun.jna.Pointer;
 import com.sun.jna.StringArray;
 import com.sun.jna.ptr.IntByReference;
 
+import java.nio.ByteBuffer;
+
 public interface CryptoLibrary extends Library {
 
     String JNA_LIBRARY_NAME = "crypto";
@@ -41,9 +43,9 @@ public interface CryptoLibrary extends Library {
     CryptoLibrary INSTANCE = Native.load(CryptoLibrary.JNA_LIBRARY_NAME, CryptoLibrary.class);
 
     // crypto/BRCryptoAccount.h
-    UInt512.ByValue cryptoAccountDeriveSeed(String phrase);
-    BRCryptoAccount cryptoAccountCreate(String paperKey);
-    BRCryptoAccount cryptoAccountCreateFromSeedBytes(byte[] bytes);
+    UInt512.ByValue cryptoAccountDeriveSeed(ByteBuffer phrase);
+    BRCryptoAccount cryptoAccountCreate(ByteBuffer phrase);
+    BRCryptoAccount cryptoAccountCreateFromSeedBytes(ByteBuffer seed);
     long cryptoAccountGetTimestamp(BRCryptoAccount account);
     void cryptoAccountSetTimestamp(BRCryptoAccount account, long timestamp);
     void cryptoAccountGive(BRCryptoAccount obj);
@@ -183,7 +185,7 @@ public interface CryptoLibrary extends Library {
     void cryptoWalletManagerConnect(BRCryptoWalletManager cwm);
     void cryptoWalletManagerDisconnect(BRCryptoWalletManager cwm);
     void cryptoWalletManagerSync(BRCryptoWalletManager cwm);
-    void cryptoWalletManagerSubmit(BRCryptoWalletManager cwm, BRCryptoWallet wid, BRCryptoTransfer tid, String paperKey);
+    void cryptoWalletManagerSubmit(BRCryptoWalletManager cwm, BRCryptoWallet wid, BRCryptoTransfer tid, ByteBuffer paperKey);
     void cwmAnnounceGetBlockNumberSuccessAsInteger(BRCryptoWalletManager cwm, BRCryptoCWMClientCallbackState callbackState,long blockNumber);
     void cwmAnnounceGetBlockNumberSuccessAsString(BRCryptoWalletManager cwm, BRCryptoCWMClientCallbackState callbackState, String blockNumber);
     void cwmAnnounceGetBlockNumberFailure(BRCryptoWalletManager cwm, BRCryptoCWMClientCallbackState callbackState);

--- a/Java/CoreNative/src/main/java/com/breadwallet/corenative/crypto/BRCryptoWalletManager.java
+++ b/Java/CoreNative/src/main/java/com/breadwallet/corenative/crypto/BRCryptoWalletManager.java
@@ -11,10 +11,13 @@ import com.breadwallet.corenative.CryptoLibrary;
 import com.breadwallet.corenative.utility.SizeT;
 import com.google.common.primitives.UnsignedInteger;
 import com.google.common.primitives.UnsignedLong;
+import com.sun.jna.Memory;
 import com.sun.jna.Pointer;
 import com.sun.jna.PointerType;
 import com.sun.jna.StringArray;
 
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
 import java.util.List;
 
 public class BRCryptoWalletManager extends PointerType implements CoreBRCryptoWalletManager {
@@ -78,8 +81,18 @@ public class BRCryptoWalletManager extends PointerType implements CoreBRCryptoWa
     }
 
     @Override
-    public void submit(CoreBRCryptoWallet wallet, CoreBRCryptoTransfer transfer, String paperKey) {
-        CryptoLibrary.INSTANCE.cryptoWalletManagerSubmit(this, wallet.asBRCryptoWallet(), transfer.asBRCryptoTransfer(), paperKey);
+    public void submit(CoreBRCryptoWallet wallet, CoreBRCryptoTransfer transfer, String phrase) {
+        byte[] phraseBytes = (phrase + "\0").getBytes(StandardCharsets.UTF_8);
+
+        Memory phraseMemory = new Memory(phraseBytes.length);
+        try {
+            phraseMemory.write(0, phraseBytes, 0, phraseBytes.length);
+            ByteBuffer phraseBuffer = phraseMemory.getByteBuffer(0, phraseBytes.length);
+
+            CryptoLibrary.INSTANCE.cryptoWalletManagerSubmit(this, wallet.asBRCryptoWallet(), transfer.asBRCryptoTransfer(), phraseBuffer);
+        } finally {
+            phraseMemory.clear();
+        }
     }
 
     @Override

--- a/Java/CoreNative/src/main/java/com/breadwallet/corenative/crypto/BRCryptoWalletManager.java
+++ b/Java/CoreNative/src/main/java/com/breadwallet/corenative/crypto/BRCryptoWalletManager.java
@@ -84,16 +84,17 @@ public class BRCryptoWalletManager extends PointerType implements CoreBRCryptoWa
     public void submit(CoreBRCryptoWallet wallet, CoreBRCryptoTransfer transfer, byte[] phraseUtf8) {
         // ensure string is null terminated
         phraseUtf8 = Arrays.copyOf(phraseUtf8, phraseUtf8.length + 1);
-
-        Memory phraseMemory = new Memory(phraseUtf8.length);
         try {
-            phraseMemory.write(0, phraseUtf8, 0, phraseUtf8.length);
-            ByteBuffer phraseBuffer = phraseMemory.getByteBuffer(0, phraseUtf8.length);
+            Memory phraseMemory = new Memory(phraseUtf8.length);
+            try {
+                phraseMemory.write(0, phraseUtf8, 0, phraseUtf8.length);
+                ByteBuffer phraseBuffer = phraseMemory.getByteBuffer(0, phraseUtf8.length);
 
-            CryptoLibrary.INSTANCE.cryptoWalletManagerSubmit(this, wallet.asBRCryptoWallet(), transfer.asBRCryptoTransfer(), phraseBuffer);
+                CryptoLibrary.INSTANCE.cryptoWalletManagerSubmit(this, wallet.asBRCryptoWallet(), transfer.asBRCryptoTransfer(), phraseBuffer);
+            } finally {
+                phraseMemory.clear();
+            }
         } finally {
-            phraseMemory.clear();
-
             // clear out our copy; caller responsible for original array
             Arrays.fill(phraseUtf8, (byte) 0);
         }

--- a/Java/CoreNative/src/main/java/com/breadwallet/corenative/crypto/CoreBRCryptoAccount.java
+++ b/Java/CoreNative/src/main/java/com/breadwallet/corenative/crypto/CoreBRCryptoAccount.java
@@ -11,24 +11,28 @@ import com.breadwallet.corenative.CryptoLibrary;
 import com.sun.jna.Memory;
 
 import java.nio.ByteBuffer;
-import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
 import java.util.Date;
 
 import static com.google.common.base.Preconditions.checkArgument;
 
 public interface CoreBRCryptoAccount {
 
-    static CoreBRCryptoAccount create(String phrase) {
-        byte[] phraseBytes = (phrase + "\0").getBytes(StandardCharsets.UTF_8);
+    static CoreBRCryptoAccount createFromPhrase(byte[] phraseUtf8) {
+        // ensure string is null terminated
+        phraseUtf8 = Arrays.copyOf(phraseUtf8, phraseUtf8.length + 1);
 
-        Memory phraseMemory = new Memory(phraseBytes.length);
+        Memory phraseMemory = new Memory(phraseUtf8.length);
         try {
-            phraseMemory.write(0, phraseBytes, 0, phraseBytes.length);
-            ByteBuffer phraseBuffer = phraseMemory.getByteBuffer(0, phraseBytes.length);
+            phraseMemory.write(0, phraseUtf8, 0, phraseUtf8.length);
+            ByteBuffer phraseBuffer = phraseMemory.getByteBuffer(0, phraseUtf8.length);
 
             return new OwnedBRCryptoAccount(CryptoLibrary.INSTANCE.cryptoAccountCreate(phraseBuffer));
         } finally {
             phraseMemory.clear();
+
+            // clear out our copy; caller responsible for original array
+            Arrays.fill(phraseUtf8, (byte) 0);
         }
     }
 
@@ -46,17 +50,21 @@ public interface CoreBRCryptoAccount {
         }
     }
 
-    static byte[] deriveSeed(String phrase) {
-        byte[] phraseBytes = (phrase + "\0").getBytes(StandardCharsets.UTF_8);
+    static byte[] deriveSeed(byte[] phraseUtf8) {
+        // ensure string is null terminated
+        phraseUtf8 = Arrays.copyOf(phraseUtf8, phraseUtf8.length + 1);
 
-        Memory phraseMemory = new Memory(phraseBytes.length);
+        Memory phraseMemory = new Memory(phraseUtf8.length);
         try {
-            phraseMemory.write(0, phraseBytes, 0, phraseBytes.length);
-            ByteBuffer phraseBuffer = phraseMemory.getByteBuffer(0, phraseBytes.length);
+            phraseMemory.write(0, phraseUtf8, 0, phraseUtf8.length);
+            ByteBuffer phraseBuffer = phraseMemory.getByteBuffer(0, phraseUtf8.length);
 
             return CryptoLibrary.INSTANCE.cryptoAccountDeriveSeed(phraseBuffer).u8.clone();
         } finally {
             phraseMemory.clear();
+
+            // clear out our copy; caller responsible for original array
+            Arrays.fill(phraseUtf8, (byte) 0);
         }
     }
 

--- a/Java/CoreNative/src/main/java/com/breadwallet/corenative/crypto/CoreBRCryptoAccount.java
+++ b/Java/CoreNative/src/main/java/com/breadwallet/corenative/crypto/CoreBRCryptoAccount.java
@@ -8,21 +8,56 @@
 package com.breadwallet.corenative.crypto;
 
 import com.breadwallet.corenative.CryptoLibrary;
+import com.sun.jna.Memory;
 
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
 import java.util.Date;
+
+import static com.google.common.base.Preconditions.checkArgument;
 
 public interface CoreBRCryptoAccount {
 
     static CoreBRCryptoAccount create(String phrase) {
-        return new OwnedBRCryptoAccount(CryptoLibrary.INSTANCE.cryptoAccountCreate(phrase));
+        byte[] phraseBytes = (phrase + "\0").getBytes(StandardCharsets.UTF_8);
+
+        Memory phraseMemory = new Memory(phraseBytes.length);
+        try {
+            phraseMemory.write(0, phraseBytes, 0, phraseBytes.length);
+            ByteBuffer phraseBuffer = phraseMemory.getByteBuffer(0, phraseBytes.length);
+
+            return new OwnedBRCryptoAccount(CryptoLibrary.INSTANCE.cryptoAccountCreate(phraseBuffer));
+        } finally {
+            phraseMemory.clear();
+        }
     }
 
     static CoreBRCryptoAccount createFromSeed(byte[] seed) {
-        return new OwnedBRCryptoAccount(CryptoLibrary.INSTANCE.cryptoAccountCreateFromSeedBytes(seed));
+        checkArgument(seed.length == 64);
+
+        Memory seedMemory = new Memory(seed.length);
+        try {
+            seedMemory.write(0, seed, 0, seed.length);
+            ByteBuffer seedBuffer = seedMemory.getByteBuffer(0, seed.length);
+
+            return new OwnedBRCryptoAccount(CryptoLibrary.INSTANCE.cryptoAccountCreateFromSeedBytes(seedBuffer));
+        } finally {
+            seedMemory.clear();
+        }
     }
 
     static byte[] deriveSeed(String phrase) {
-        return CryptoLibrary.INSTANCE.cryptoAccountDeriveSeed(phrase).u8.clone();
+        byte[] phraseBytes = (phrase + "\0").getBytes(StandardCharsets.UTF_8);
+
+        Memory phraseMemory = new Memory(phraseBytes.length);
+        try {
+            phraseMemory.write(0, phraseBytes, 0, phraseBytes.length);
+            ByteBuffer phraseBuffer = phraseMemory.getByteBuffer(0, phraseBytes.length);
+
+            return CryptoLibrary.INSTANCE.cryptoAccountDeriveSeed(phraseBuffer).u8.clone();
+        } finally {
+            phraseMemory.clear();
+        }
     }
 
     Date getTimestamp();

--- a/Java/CoreNative/src/main/java/com/breadwallet/corenative/crypto/CoreBRCryptoAccount.java
+++ b/Java/CoreNative/src/main/java/com/breadwallet/corenative/crypto/CoreBRCryptoAccount.java
@@ -21,16 +21,17 @@ public interface CoreBRCryptoAccount {
     static CoreBRCryptoAccount createFromPhrase(byte[] phraseUtf8) {
         // ensure string is null terminated
         phraseUtf8 = Arrays.copyOf(phraseUtf8, phraseUtf8.length + 1);
-
-        Memory phraseMemory = new Memory(phraseUtf8.length);
         try {
-            phraseMemory.write(0, phraseUtf8, 0, phraseUtf8.length);
-            ByteBuffer phraseBuffer = phraseMemory.getByteBuffer(0, phraseUtf8.length);
+            Memory phraseMemory = new Memory(phraseUtf8.length);
+            try {
+                phraseMemory.write(0, phraseUtf8, 0, phraseUtf8.length);
+                ByteBuffer phraseBuffer = phraseMemory.getByteBuffer(0, phraseUtf8.length);
 
-            return new OwnedBRCryptoAccount(CryptoLibrary.INSTANCE.cryptoAccountCreate(phraseBuffer));
+                return new OwnedBRCryptoAccount(CryptoLibrary.INSTANCE.cryptoAccountCreate(phraseBuffer));
+            } finally {
+                phraseMemory.clear();
+            }
         } finally {
-            phraseMemory.clear();
-
             // clear out our copy; caller responsible for original array
             Arrays.fill(phraseUtf8, (byte) 0);
         }
@@ -53,16 +54,17 @@ public interface CoreBRCryptoAccount {
     static byte[] deriveSeed(byte[] phraseUtf8) {
         // ensure string is null terminated
         phraseUtf8 = Arrays.copyOf(phraseUtf8, phraseUtf8.length + 1);
-
-        Memory phraseMemory = new Memory(phraseUtf8.length);
         try {
-            phraseMemory.write(0, phraseUtf8, 0, phraseUtf8.length);
-            ByteBuffer phraseBuffer = phraseMemory.getByteBuffer(0, phraseUtf8.length);
+            Memory phraseMemory = new Memory(phraseUtf8.length);
+            try {
+                phraseMemory.write(0, phraseUtf8, 0, phraseUtf8.length);
+                ByteBuffer phraseBuffer = phraseMemory.getByteBuffer(0, phraseUtf8.length);
 
-            return CryptoLibrary.INSTANCE.cryptoAccountDeriveSeed(phraseBuffer).u8.clone();
+                return CryptoLibrary.INSTANCE.cryptoAccountDeriveSeed(phraseBuffer).u8.clone();
+            } finally {
+                phraseMemory.clear();
+            }
         } finally {
-            phraseMemory.clear();
-
             // clear out our copy; caller responsible for original array
             Arrays.fill(phraseUtf8, (byte) 0);
         }

--- a/Java/CoreNative/src/main/java/com/breadwallet/corenative/crypto/CoreBRCryptoWalletManager.java
+++ b/Java/CoreNative/src/main/java/com/breadwallet/corenative/crypto/CoreBRCryptoWalletManager.java
@@ -46,7 +46,7 @@ public interface CoreBRCryptoWalletManager {
 
     void sync();
 
-    void submit(CoreBRCryptoWallet wallet, CoreBRCryptoTransfer transfer, String paperKey);
+    void submit(CoreBRCryptoWallet wallet, CoreBRCryptoTransfer transfer, byte[] phraseUtf8);
 
     void announceGetBlockNumberSuccess(BRCryptoCWMClientCallbackState callbackState, UnsignedLong blockchainHeight);
 

--- a/Java/CoreNative/src/main/java/com/breadwallet/corenative/crypto/OwnedBRCryptoWalletManager.java
+++ b/Java/CoreNative/src/main/java/com/breadwallet/corenative/crypto/OwnedBRCryptoWalletManager.java
@@ -83,8 +83,8 @@ class OwnedBRCryptoWalletManager implements CoreBRCryptoWalletManager {
     }
 
     @Override
-    public void submit(CoreBRCryptoWallet wallet, CoreBRCryptoTransfer transfer, String paperKey) {
-        core.submit(wallet, transfer, paperKey);
+    public void submit(CoreBRCryptoWallet wallet, CoreBRCryptoTransfer transfer, byte[] phraseUtf8) {
+        core.submit(wallet, transfer, phraseUtf8);
     }
 
     @Override

--- a/Java/Crypto/src/main/java/com/breadwallet/crypto/Account.java
+++ b/Java/Crypto/src/main/java/com/breadwallet/crypto/Account.java
@@ -13,10 +13,32 @@ import java.util.Date;
 
 public interface Account {
 
+    /**
+     * Create an account using a BIP32 phrase.
+     *
+     * @apiNote The caller should take appropriate security measures, like enclosing this method's call in a
+     * try-finally block that wipes the phraseUtf8 value, to ensure that it is purged from memory
+     * upon completion.
+     *
+     * @param phraseUtf8 The UTF-8 NFKD normalized BIP32 phrase
+     * @param timestamp The timestamp of when this account was first created
+     * @param uids The unique identifier of this account
+     */
     static Account createFromPhrase(byte[] phraseUtf8, Date timestamp, String uids) {
         return CryptoApi.getProvider().accountProvider().createFromPhrase(phraseUtf8, timestamp, uids);
     }
 
+    /**
+     * Create an account using a BIP32 seed.
+     *
+     * @apiNote The caller should take appropriate security measures, like enclosing this method's call in a
+     * try-finally block that wipes the seed value, to ensure that it is purged from memory
+     * upon completion.
+     *
+     * @param seed The 512-bit BIP32 seed
+     * @param timestamp The timestamp of when this account was first created
+     * @param uids The unique identifier of this account
+     */
     static Account createFromSeed(byte[] seed, Date timestamp, String uids) {
         return CryptoApi.getProvider().accountProvider().createFromSeed(seed, timestamp, uids);
     }

--- a/Java/Crypto/src/main/java/com/breadwallet/crypto/Account.java
+++ b/Java/Crypto/src/main/java/com/breadwallet/crypto/Account.java
@@ -13,12 +13,12 @@ import java.util.Date;
 
 public interface Account {
 
-    static Account createFrom(String phrase, Date timestamp, String uids) {
-        return CryptoApi.getProvider().accountProvider().create(phrase, timestamp, uids);
+    static Account createFromPhrase(byte[] phraseUtf8, Date timestamp, String uids) {
+        return CryptoApi.getProvider().accountProvider().createFromPhrase(phraseUtf8, timestamp, uids);
     }
 
-    static Account createFrom(byte[] seed, Date timestamp, String uids) {
-        return CryptoApi.getProvider().accountProvider().create(seed, timestamp, uids);
+    static Account createFromSeed(byte[] seed, Date timestamp, String uids) {
+        return CryptoApi.getProvider().accountProvider().createFromSeed(seed, timestamp, uids);
     }
 
     Date getTimestamp();

--- a/Java/Crypto/src/main/java/com/breadwallet/crypto/CryptoApi.java
+++ b/Java/Crypto/src/main/java/com/breadwallet/crypto/CryptoApi.java
@@ -19,8 +19,8 @@ import static com.google.common.base.Preconditions.checkState;
 public final class CryptoApi {
 
     public interface AccountProvider {
-        Account create(String phrase, Date timestamp, String uids);
-        Account create(byte[] seed, Date timestamp, String uids);
+        Account createFromPhrase(byte[] phraseUtf8, Date timestamp, String uids);
+        Account createFromSeed(byte[] seed, Date timestamp, String uids);
     }
 
     public interface AmountProvider {

--- a/Java/Crypto/src/main/java/com/breadwallet/crypto/WalletManager.java
+++ b/Java/Crypto/src/main/java/com/breadwallet/crypto/WalletManager.java
@@ -19,7 +19,7 @@ public interface WalletManager {
 
     void sync();
 
-    void submit(Transfer transfer, String paperKey);
+    void submit(Transfer transfer, byte[] phraseUtf8);
 
     boolean isActive();
 

--- a/Java/CryptoDemo/src/main/java/com/breadwallet/cryptodemo/CoreCryptoApplication.java
+++ b/Java/CryptoDemo/src/main/java/com/breadwallet/cryptodemo/CoreCryptoApplication.java
@@ -48,7 +48,7 @@ public class CoreCryptoApplication extends Application {
 
     private static System system;
     private static CoreSystemListener listener;
-    private static String paperKey;
+    private static byte[] paperKey;
 
     private static AtomicBoolean runOnce = new AtomicBoolean(false);
 
@@ -68,7 +68,8 @@ public class CoreCryptoApplication extends Application {
         if (!runOnce.getAndSet(true)) {
             Intent intent = startingActivity.getIntent();
 
-            paperKey = intent.hasExtra(EXTRA_PAPER_KEY) ? intent.getStringExtra(EXTRA_PAPER_KEY) : DEFAULT_PAPER_KEY;
+            paperKey = (intent.hasExtra(EXTRA_PAPER_KEY) ? intent.getStringExtra(EXTRA_PAPER_KEY) : DEFAULT_PAPER_KEY)
+                    .getBytes(StandardCharsets.UTF_8);
 
             boolean wipe = intent.getBooleanExtra(EXTRA_WIPE, DEFAULT_WIPE);
             long timestamp = intent.getLongExtra(EXTRA_TIMESTAMP, DEFAULT_TIMESTAMP);
@@ -84,8 +85,8 @@ public class CoreCryptoApplication extends Application {
 
             listener = new CoreSystemListener(mode);
 
-            String uids = UUID.nameUUIDFromBytes(paperKey.getBytes(StandardCharsets.UTF_8)).toString();
-            Account account = Account.createFrom(paperKey, new Date(TimeUnit.SECONDS.toMillis(timestamp)), uids);
+            String uids = UUID.nameUUIDFromBytes(paperKey).toString();
+            Account account = Account.createFromPhrase(paperKey, new Date(TimeUnit.SECONDS.toMillis(timestamp)), uids);
 
             BlockchainDb query = new BlockchainDb(new OkHttpClient(), BDB_BASE_URL, API_BASE_URL);
             system = System.create(Executors.newSingleThreadExecutor(), listener, account, storageFile.getAbsolutePath(), query);
@@ -103,7 +104,7 @@ public class CoreCryptoApplication extends Application {
         return listener;
     }
 
-    public static String getPaperKey() {
+    public static byte[] getPaperKey() {
         return paperKey;
     }
 


### PR DESCRIPTION
In Java, Strings are immutable so they can't be explicitly be cleared in memory. We'd be relying on the JVM to eventually clear it out based on its internal memory usage.

Instead, switch to requiring secret material to be passed as UTF-8 encoded byte arrays. This allows the caller to explicitly zero out the array in question once the secret has been used.

In addition, don't rely on JNA's marshalling for handling the byte array to avoid the potential for copies to be made. Instead, allow the memory directly, fill it and clear it after use.