### PR TITLE
CORE-389: For “bch” use “Bitcoin Cash”

### DIFF
--- a/Java/Crypto/src/main/java/com/breadwallet/crypto/blockchaindb/models/bdb/Blockchain.java
+++ b/Java/Crypto/src/main/java/com/breadwallet/crypto/blockchaindb/models/bdb/Blockchain.java
@@ -23,15 +23,15 @@ public class Blockchain {
 
     public static List<Blockchain> DEFAULT_BLOCKCHAINS = ImmutableList.of(
             // Mainnet
-            new Blockchain("bitcoin-mainnet", "Bitcoin", "mainnet", true, "btc", UnsignedLong.valueOf(654321), ImmutableList.of()),
-            new Blockchain("bitcash-mainnet", "Bitcash", "mainnet", true, "bch", UnsignedLong.valueOf(1000000), ImmutableList.of()),
-            new Blockchain("ethereum-mainnet", "Ethereum", "mainnet", true, "eth", UnsignedLong.valueOf(8000000), ImmutableList.of()),
+            new Blockchain("bitcoin-mainnet",      "Bitcoin",      "mainnet", true, "btc", UnsignedLong.valueOf(654321),  ImmutableList.of()),
+            new Blockchain("bitcoin-cash-mainnet", "Bitcoin Cash", "mainnet", true, "bch", UnsignedLong.valueOf(1000000), ImmutableList.of()),
+            new Blockchain("ethereum-mainnet",     "Ethereum",     "mainnet", true, "eth", UnsignedLong.valueOf(8000000), ImmutableList.of()),
 
             // Testnet
-            new Blockchain("bitcoin-testnet", "Bitcoin", "testnet", false, "btc", UnsignedLong.valueOf(900000), ImmutableList.of()),
-            new Blockchain("bitcash-testnet", "Bitcash", "testnet", false, "bch", UnsignedLong.valueOf(1200000), ImmutableList.of()),
-            new Blockchain("ethereum-testnet", "Ethereum", "testnet", false, "eth", UnsignedLong.valueOf(1000000), ImmutableList.of()),
-            new Blockchain("ethereum-rinkeby", "Ethereum", "rinkeby", false, "eth", UnsignedLong.valueOf(2000000), ImmutableList.of())
+            new Blockchain("bitcoin-testnet",      "Bitcoin Test",      "testnet", false, "btc", UnsignedLong.valueOf(900000),  ImmutableList.of()),
+            new Blockchain("bitcoin-cash-testnet", "Bitcoin Cash Test", "testnet", false, "bch", UnsignedLong.valueOf(1200000), ImmutableList.of()),
+            new Blockchain("ethereum-testnet",     "Ethereum Testnet",  "testnet", false, "eth", UnsignedLong.valueOf(1000000), ImmutableList.of()),
+            new Blockchain("ethereum-rinkeby",     "Ethereum Rinkeby",  "rinkeby", false, "eth", UnsignedLong.valueOf(2000000), ImmutableList.of())
     );
 
     public static Optional<Blockchain> asBlockchain(JSONObject json) {

--- a/Java/Crypto/src/main/java/com/breadwallet/crypto/blockchaindb/models/bdb/Currency.java
+++ b/Java/Crypto/src/main/java/com/breadwallet/crypto/blockchaindb/models/bdb/Currency.java
@@ -31,7 +31,7 @@ public class Currency {
             new Currency("Bitcoin", "Bitcoin", "btc", "native", "bitcoin-mainnet", null,
                     ImmutableList.of(CurrencyDenomination.BTC_SATOSHI, CurrencyDenomination.BTC_BITCOIN)),
 
-            new Currency("Bitcash", "Bitcash", "bch", "native", "bitcash-mainnet", null,
+            new Currency("Bitcoin-Cash", "Bitcoin Cash", "bch", "native", "bitcoin-cash-mainnet", null,
                     ImmutableList.of(CurrencyDenomination.BTC_SATOSHI, CurrencyDenomination.BCH_BITCOIN)),
 
             new Currency("Ethereum", "Ethereum", "eth", "native", "ethereum-mainnet", null,
@@ -45,17 +45,17 @@ public class Currency {
                     ImmutableList.of(CurrencyDenomination.EOS_INT, CurrencyDenomination.EOS_EOS)),
 
             // Testnet
-            new Currency("Bitcoin-Testnet", "Bitcoin", "btc", "native", "bitcoin-testnet", null,
+            new Currency("Bitcoin-Testnet", "Bitcoin Test", "btc", "native", "bitcoin-testnet", null,
                     ImmutableList.of(CurrencyDenomination.BTC_SATOSHI, CurrencyDenomination.BTC_BITCOIN)),
 
-            new Currency("Bitcash-Testnet", "Bitcash", "bch", "native", "bitcash-testnet", null,
+            new Currency("Bitcoin-Cash-Testnet", "Bitcoin Cash Test", "bch", "native", "bitcoin-cash-testnet", null,
                     ImmutableList.of(CurrencyDenomination.BTC_SATOSHI, CurrencyDenomination.BCH_BITCOIN)),
 
-            new Currency("Ethereum-Testnet", "Ethereum", "eth", "native", "ethereum-testnet", null,
+            new Currency("Ethereum-Testnet", "Ethereum Testnet", "eth", "native", "ethereum-testnet", null,
                     ImmutableList.of(CurrencyDenomination.ETH_WEI, CurrencyDenomination.ETH_GWEI,
                             CurrencyDenomination.ETH_ETHER)),
 
-            new Currency("BRD Token Testnet", "BRD Token", "BRD", "erc20", "ethereum-testnet", ADDRESS_BRD_TESTNET,
+            new Currency("BRD Token Testnet", "BRD Token Testnet", "BRD", "erc20", "ethereum-testnet", ADDRESS_BRD_TESTNET,
                     ImmutableList.of(CurrencyDenomination.BRD_INT, CurrencyDenomination.BRD_BRD))
     );
 

--- a/Java/Crypto/src/main/java/com/breadwallet/crypto/blockchaindb/models/bdb/CurrencyDenomination.java
+++ b/Java/Crypto/src/main/java/com/breadwallet/crypto/blockchaindb/models/bdb/CurrencyDenomination.java
@@ -34,7 +34,7 @@ public class CurrencyDenomination {
 
 
     public static CurrencyDenomination BCH_BITCOIN = new CurrencyDenomination(
-            "bitcoin", "bch", UnsignedInteger.valueOf(8), lookupSymbol("bch"));
+            "bitcoin cash", "bch", UnsignedInteger.valueOf(8), lookupSymbol("bch"));
 
 
     public static CurrencyDenomination ETH_WEI = new CurrencyDenomination(

--- a/Swift/BRCrypto/common/BRBlockChainDB.swift
+++ b/Swift/BRCrypto/common/BRBlockChainDB.swift
@@ -249,15 +249,15 @@ public class BlockChainDB {
         /// specfication includes `blockHeight` (which can never be correct).
         static public let defaultBlockchains: [Blockchain] = [
             // Mainnet
-            (id: "bitcoin-mainnet",  name: "Bitcoin",  network: "mainnet", isMainnet: true,  currency: "btc", blockHeight:  654321, feeEstimates: []),
-            (id: "bitcash-mainnet",  name: "Bitcash",  network: "mainnet", isMainnet: true,  currency: "bch", blockHeight: 1000000, feeEstimates: []),
-            (id: "ethereum-mainnet", name: "Ethereum", network: "mainnet", isMainnet: true,  currency: "eth", blockHeight: 8000000, feeEstimates: []),
+            (id: "bitcoin-mainnet",       name: "Bitcoin",       network: "mainnet", isMainnet: true,  currency: "btc", blockHeight:  654321, feeEstimates: []),
+            (id: "bitcoin-cash-mainnet",  name: "Bitcoin Cash",  network: "mainnet", isMainnet: true,  currency: "bch", blockHeight: 1000000, feeEstimates: []),
+            (id: "ethereum-mainnet",      name: "Ethereum",      network: "mainnet", isMainnet: true,  currency: "eth", blockHeight: 8000000, feeEstimates: []),
 
             // Testnet
-            (id: "bitcoin-testnet",  name: "Bitcoin",  network: "testnet", isMainnet: false, currency: "btc", blockHeight:  900000, feeEstimates: []),
-            (id: "bitcash-testnet",  name: "Bitcash",  network: "testnet", isMainnet: false, currency: "bch", blockHeight: 1200000, feeEstimates: []),
-            (id: "ethereum-testnet", name: "Ethereum", network: "testnet", isMainnet: false, currency: "eth", blockHeight: 1000000, feeEstimates: []),
-            (id: "ethereum-rinkeby", name: "Ethereum", network: "rinkeby", isMainnet: false, currency: "eth", blockHeight: 2000000, feeEstimates: [])
+            (id: "bitcoin-testnet",       name: "Bitcoin Test",      network: "testnet", isMainnet: false, currency: "btc", blockHeight:  900000, feeEstimates: []),
+            (id: "bitcoin-cash-testnet",  name: "Bitcoin Cash Test", network: "testnet", isMainnet: false, currency: "bch", blockHeight: 1200000, feeEstimates: []),
+            (id: "ethereum-testnet",      name: "Ethereum Testnet",  network: "testnet", isMainnet: false, currency: "eth", blockHeight: 1000000, feeEstimates: []),
+            (id: "ethereum-rinkeby",      name: "Ethereum Rinkeby",  network: "rinkeby", isMainnet: false, currency: "eth", blockHeight: 2000000, feeEstimates: [])
         ]
 
         /// Currency & CurrencyDenomination
@@ -320,9 +320,9 @@ public class BlockChainDB {
              demoninations: [(name: "satoshi", code: "sat", decimals: 0, symbol: lookupSymbol ("sat")),
                              (name: "bitcoin", code: "btc", decimals: 8, symbol: lookupSymbol ("btc"))]),
 
-            (id: "Bitcash", name: "Bitcash", code: "bch", type: "native", blockchainID: "bitcash-mainnet", address: nil,
-             demoninations: [(name: "satoshi", code: "sat", decimals: 0, symbol: lookupSymbol ("sat")),
-                             (name: "bitcoin", code: "bch", decimals: 8, symbol: lookupSymbol ("bch"))]),
+            (id: "Bitcoin-Cash", name: "Bitcoin Cash", code: "bch", type: "native", blockchainID: "bitcoin-cash-mainnet", address: nil,
+             demoninations: [(name: "satoshi",      code: "sat", decimals: 0, symbol: lookupSymbol ("sat")),
+                             (name: "bitcoin cash", code: "bch", decimals: 8, symbol: lookupSymbol ("bch"))]),
 
             (id: "Ethereum", name: "Ethereum", code: "eth", type: "native", blockchainID: "ethereum-mainnet", address: nil,
              demoninations: [(name: "wei",   code: "wei",  decimals:  0, symbol: lookupSymbol ("wei")),
@@ -342,9 +342,9 @@ public class BlockChainDB {
              demoninations: [(name: "satoshi", code: "sat", decimals: 0, symbol: lookupSymbol ("sat")),
                              (name: "bitcoin", code: "btc", decimals: 8, symbol: lookupSymbol ("btc"))]),
 
-            (id: "Bitcash-Testnet", name: "Bitcash", code: "bch", type: "native", blockchainID: "bitcash-testnet", address: nil,
-             demoninations: [(name: "satoshi", code: "sat", decimals: 0, symbol: lookupSymbol ("sat")),
-                             (name: "bitcoin", code: "bch", decimals: 8, symbol: lookupSymbol ("bch"))]),
+            (id: "Bitcoin-Cash-Testnet", name: "Bitcoin Cash Test", code: "bch", type: "native", blockchainID: "bitcoin-cash-testnet", address: nil,
+             demoninations: [(name: "satoshi",           code: "sat", decimals: 0, symbol: lookupSymbol ("sat")),
+                             (name: "bitcoin cash test", code: "bch", decimals: 8, symbol: lookupSymbol ("bch"))]),
 
             (id: "Ethereum-Testnet", name: "Ethereum", code: "eth", type: "native", blockchainID: "ethereum-testnet", address: nil,
              demoninations: [(name: "wei",   code: "wei",  decimals:  0, symbol: lookupSymbol ("wei")),

--- a/Swift/BRCryptoTests/BRBlockChainDBTest.swift
+++ b/Swift/BRCryptoTests/BRBlockChainDBTest.swift
@@ -39,7 +39,7 @@ class BRBlockChainDBTest: XCTestCase {
 
         expectation = XCTestExpectation (description: "blockchains")
 
-        db.getBlockchains { (res: Result<[BlockChainDB.Model.Blockchain], BlockChainDB.QueryError>) in
+        db.getBlockchains (mainnet: false) { (res: Result<[BlockChainDB.Model.Blockchain], BlockChainDB.QueryError>) in
             guard case let .success (blockchains) = res
                 else { XCTAssert(false); return }
 


### PR DESCRIPTION
Reword the builtin blockchain and currencies to use the correct name for BCH