### PR TITLE
CORE-401: Account serialization

### DIFF
--- a/Java/CoreCrypto/src/androidTest/java/com/breadwallet/corecrypto/AccountAIT.java
+++ b/Java/CoreCrypto/src/androidTest/java/com/breadwallet/corecrypto/AccountAIT.java
@@ -1,8 +1,11 @@
 package com.breadwallet.corecrypto;
 
+import com.google.common.base.Optional;
+
 import org.junit.Test;
 
 import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
 import java.util.Date;
 
 import static org.junit.Assert.*;
@@ -16,19 +19,24 @@ public class AccountAIT {
         Date timestamp = new Date(0);
         Account account = Account.createFromPhrase(phrase, timestamp, uids);
         assertEquals(timestamp.getTime(), account.getTimestamp().getTime());
-
-        // TODO: Add addressAsETH
     }
 
     @Test
-    public void testAccountDeriveSeed() {
+    public void testAccountSerialization() {
         byte[] phrase = "ginger settle marine tissue robot crane night number ramp coast roast critic".getBytes(StandardCharsets.UTF_8);
-        byte[] seed = Account.deriveSeed(phrase);
         String uids = "5766b9fa-e9aa-4b6d-9b77-b5f1136e5e96";
         Date timestamp = new Date(0);
-        Account account = Account.createFromSeed(seed, timestamp, uids);
-        assertEquals(timestamp.getTime(), account.getTimestamp().getTime());
+        Account accountFromPhrase = Account.createFromPhrase(phrase, timestamp, uids);
+        assertEquals(timestamp.getTime(), accountFromPhrase.getTimestamp().getTime());
 
-        // TODO: Add addressAsETH
+        byte[] serialization = accountFromPhrase.serialize();
+        assertArrayEquals(serialization, accountFromPhrase.serialize());
+
+        Optional<Account> optAccount = Account.createFromSerialization(serialization, uids);
+        assertTrue(optAccount.isPresent());
+
+        Account accountFromSerialization = optAccount.get();
+        assertEquals(accountFromPhrase.getTimestamp(), accountFromSerialization.getTimestamp());
+        assertArrayEquals(accountFromPhrase.serialize(), accountFromSerialization.serialize());
     }
 }

--- a/Java/CoreCrypto/src/main/java/com/breadwallet/corecrypto/CryptoApiProvider.java
+++ b/Java/CoreCrypto/src/main/java/com/breadwallet/corecrypto/CryptoApiProvider.java
@@ -14,6 +14,7 @@ import com.breadwallet.crypto.events.system.SystemListener;
 import com.google.common.base.Optional;
 
 import java.util.Date;
+import java.util.List;
 import java.util.concurrent.ExecutorService;
 
 public final class CryptoApiProvider implements CryptoApi.Provider {
@@ -25,15 +26,19 @@ public final class CryptoApiProvider implements CryptoApi.Provider {
     }
 
     private static final CryptoApi.AccountProvider accountProvider = new CryptoApi.AccountProvider() {
-
         @Override
-        public Account createFromPhrase(byte[] phraseUtf8, Date timestamp, String uids) {
+        public com.breadwallet.crypto.Account createFromPhrase(byte[] phraseUtf8, Date timestamp, String uids) {
             return Account.createFromPhrase(phraseUtf8, timestamp, uids);
         }
 
         @Override
-        public Account createFromSeed(byte[] seed, Date timestamp, String uids) {
-            return Account.createFromSeed(seed, timestamp, uids);
+        public Optional<com.breadwallet.crypto.Account> createFromSerialization(byte[] serialization, String uids) {
+            return Account.createFromSerialization(serialization, uids).transform(a -> a);
+        }
+
+        @Override
+        public String generatePhrase(List<String> words) {
+            return Account.generatePhrase(words);
         }
     };
 
@@ -55,9 +60,8 @@ public final class CryptoApiProvider implements CryptoApi.Provider {
     };
 
     private static final CryptoApi.SystemProvider systemProvider = new CryptoApi.SystemProvider() {
-
         @Override
-        public System create(ExecutorService listenerExecutor, SystemListener listener, com.breadwallet.crypto.Account account, String path, BlockchainDb query) {
+        public com.breadwallet.crypto.System create(ExecutorService listenerExecutor, SystemListener listener, com.breadwallet.crypto.Account account, String path, BlockchainDb query) {
             return System.create(listenerExecutor, listener, account, path, query);
         }
     };

--- a/Java/CoreNative/src/main/java/com/breadwallet/corenative/CryptoLibrary.java
+++ b/Java/CoreNative/src/main/java/com/breadwallet/corenative/CryptoLibrary.java
@@ -42,10 +42,11 @@ public interface CryptoLibrary extends Library {
     CryptoLibrary INSTANCE = Native.load(CryptoLibrary.JNA_LIBRARY_NAME, CryptoLibrary.class);
 
     // crypto/BRCryptoAccount.h
-    UInt512.ByValue cryptoAccountDeriveSeed(ByteBuffer phrase);
     BRCryptoAccount cryptoAccountCreate(ByteBuffer phrase, long timestamp);
-    BRCryptoAccount cryptoAccountCreateFromSeedBytes(ByteBuffer seed, long timestamp);
+    BRCryptoAccount cryptoAccountCreateFromSerialization(byte[] serialization, SizeT serializationLength);
+    Pointer cryptoAccountGeneratePaperKey(StringArray words);
     long cryptoAccountGetTimestamp(BRCryptoAccount account);
+    Pointer cryptoAccountSerialize(BRCryptoAccount account, SizeTByReference count);
     void cryptoAccountGive(BRCryptoAccount obj);
 
     // crypto/BRCryptoAddress.h

--- a/Java/CoreNative/src/main/java/com/breadwallet/corenative/crypto/BRCryptoAccount.java
+++ b/Java/CoreNative/src/main/java/com/breadwallet/corenative/crypto/BRCryptoAccount.java
@@ -8,6 +8,9 @@
 package com.breadwallet.corenative.crypto;
 
 import com.breadwallet.corenative.CryptoLibrary;
+import com.breadwallet.corenative.utility.SizeTByReference;
+import com.google.common.primitives.UnsignedInts;
+import com.sun.jna.Native;
 import com.sun.jna.Pointer;
 import com.sun.jna.PointerType;
 
@@ -27,6 +30,16 @@ public class BRCryptoAccount extends PointerType implements CoreBRCryptoAccount 
     @Override
     public Date getTimestamp() {
         return new Date(TimeUnit.SECONDS.toMillis(CryptoLibrary.INSTANCE.cryptoAccountGetTimestamp(this)));
+    }
+    @Override
+    public byte[] serialize() {
+        SizeTByReference bytesCount = new SizeTByReference();
+        Pointer serializationPtr = CryptoLibrary.INSTANCE.cryptoAccountSerialize(this, bytesCount);
+        try {
+            return serializationPtr.getByteArray(0, UnsignedInts.checkedCast(bytesCount.getValue().longValue()));
+        } finally {
+            Native.free(Pointer.nativeValue(serializationPtr));
+        }
     }
 
     @Override

--- a/Java/CoreNative/src/main/java/com/breadwallet/corenative/crypto/OwnedBRCryptoAccount.java
+++ b/Java/CoreNative/src/main/java/com/breadwallet/corenative/crypto/OwnedBRCryptoAccount.java
@@ -36,6 +36,11 @@ class OwnedBRCryptoAccount implements CoreBRCryptoAccount {
     }
 
     @Override
+    public byte[] serialize() {
+        return core.serialize();
+    }
+
+    @Override
     public BRCryptoAccount asBRCryptoAccount() {
         return core;
     }

--- a/Java/Crypto/src/main/java/com/breadwallet/crypto/Account.java
+++ b/Java/Crypto/src/main/java/com/breadwallet/crypto/Account.java
@@ -9,18 +9,22 @@
  */
 package com.breadwallet.crypto;
 
+import com.google.common.base.Optional;
+
 import java.util.Date;
+import java.util.List;
+import java.lang.String;
 
 public interface Account {
 
     /**
-     * Create an account using a BIP32 phrase.
+     * Recover an account from a BIP-39 'paper key'.
      *
      * @apiNote The caller should take appropriate security measures, like enclosing this method's call in a
      * try-finally block that wipes the phraseUtf8 value, to ensure that it is purged from memory
      * upon completion.
      *
-     * @param phraseUtf8 The UTF-8 NFKD normalized BIP32 phrase
+     * @param phraseUtf8 The UTF-8 NFKD normalized BIP-39 paper key
      * @param timestamp The timestamp of when this account was first created
      * @param uids The unique identifier of this account
      */
@@ -29,19 +33,37 @@ public interface Account {
     }
 
     /**
-     * Create an account using a BIP32 seed.
+     * Create an account based on an account serialization.
      *
-     * @apiNote The caller should take appropriate security measures, like enclosing this method's call in a
-     * try-finally block that wipes the seed value, to ensure that it is purged from memory
-     * upon completion.
-     *
-     * @param seed The 512-bit BIP32 seed
-     * @param timestamp The timestamp of when this account was first created
+     * @param serialization The result of a prior call to {@link Account#serialize()}
      * @param uids The unique identifier of this account
+     *
+     * @return The serialization's corresponding account or {@link Optional#absent()} if the serialization is invalid.
+     *         If the serialization is invalid then the account <b>must be recreated</b> from the `phrase`
+     *         (aka 'Paper Key').  A serialization will be invald when the serialization format changes
+     *         which will <b>always occur</b> when a new blockchain is added.  For example, when XRP is added
+     *         the XRP public key must be serialized; the old serialization w/o the XRP public key will
+     *         be invalid and the `phrase` is <b>required</b> in order to produce the XRP public key.
      */
-    static Account createFromSeed(byte[] seed, Date timestamp, String uids) {
-        return CryptoApi.getProvider().accountProvider().createFromSeed(seed, timestamp, uids);
+    static Optional<Account> createFromSerialization(byte[] serialization, String uids) {
+        return CryptoApi.getProvider().accountProvider().createFromSerialization(serialization, uids);
+    }
+
+    /**
+     * Generate a BIP-39 'paper Key'
+     *
+     * Use {@link Account#createFromPhrase(byte[], Date, String)} to get the account
+     *
+     * @return The 12 word 'paper key
+     */
+    static String generatePhrase(List<String> words) {
+        return CryptoApi.getProvider().accountProvider().generatePhrase(words);
     }
 
     Date getTimestamp();
+
+    /**
+     * Serialize an account.  The serialization is <b>always</b> in the current, default format.
+     */
+    byte[] serialize();
 }

--- a/Java/Crypto/src/main/java/com/breadwallet/crypto/CryptoApi.java
+++ b/Java/Crypto/src/main/java/com/breadwallet/crypto/CryptoApi.java
@@ -12,6 +12,7 @@ import com.breadwallet.crypto.events.system.SystemListener;
 import com.google.common.base.Optional;
 
 import java.util.Date;
+import java.util.List;
 import java.util.concurrent.ExecutorService;
 
 import static com.google.common.base.Preconditions.checkState;
@@ -20,7 +21,8 @@ public final class CryptoApi {
 
     public interface AccountProvider {
         Account createFromPhrase(byte[] phraseUtf8, Date timestamp, String uids);
-        Account createFromSeed(byte[] seed, Date timestamp, String uids);
+        Optional<Account> createFromSerialization(byte[] serialization, String uids);
+        String generatePhrase(List<String> words);
     }
 
     public interface AmountProvider {

--- a/Swift/BRCrypto/BRCryptoAccount.swift
+++ b/Swift/BRCrypto/BRCryptoAccount.swift
@@ -66,11 +66,17 @@ public final class Account {
     }
 
     ///
-    /// Generate a BIP-39 'paper Key'.  Use Account.createFrom(paperKey:) to get the account
+    /// Generate a BIP-39 'paper Key'.  Use Account.createFrom(paperKey:) to get the account.  The
+    /// wordList is the locale-specifc BIP-39-defined array of BIP39_WORDLIST_COUNT words.  This
+    /// function has a precondition on the size of the wordList.
     ///
-    /// - Returns: the 12 word 'paper key'
+    /// - Parameter wordList: A local-specific BIP-39-defined array of BIP39_WORDLIST_COUNT words.
     ///
-    public static func generatePhrase (wordList: [String]) -> (String,Date) {
+    /// - Returns: A 12 word 'paper key'
+    ///
+    public static func generatePhrase (wordList: [String]) -> (String,Date)? {
+        precondition (CRYPTO_TRUE == cryptoAccountValidateWordsList (Int32(wordList.count)))
+
         var words = wordList.map { UnsafePointer<Int8> (strdup($0)) }
         defer { words.forEach { free(UnsafeMutablePointer (mutating: $0)) } }
         return (asUTF8String (cryptoAccountGeneratePaperKey (&words)), Date())

--- a/Swift/BRCrypto/BRCryptoAccount.swift
+++ b/Swift/BRCrypto/BRCryptoAccount.swift
@@ -24,27 +24,61 @@ public final class Account {
         return Date.init(timeIntervalSince1970: TimeInterval (cryptoAccountGetTimestamp (core)))
     }
 
-    internal init (core: BRCryptoAccount, uids: String) {
-        self.core = core
-        self.uids = uids
+    ///
+    /// Serialize an account.  The serialization is *always* in the current, default format
+    ///
+    public var serialize: Data {
+        var bytesCount: Int = 0
+        let bytes = cryptoAccountSerialize (core, &bytesCount)
+        return Data (bytes: bytes!, count: bytesCount)
     }
 
+    ///
+    /// Recover an account from a BIP-39 'paper key'
+    ///
+    /// - Parameter paperKey: the 12 word paper key
+    /// - Parameter timestamp:
+    ///
+    /// - Returns: the paperKey's corresponding account, or NIL if the paperKey is invalid.
+    ///
     public static func createFrom (phrase: String, timestamp: Date, uids: String) -> Account? {
         let timestampAsInt = UInt64 (timestamp.timeIntervalSince1970)
         return cryptoAccountCreate (phrase, timestampAsInt)
             .map { Account (core: $0, uids: uids) }
     }
 
-    public static func createFrom (seed: Data, timestamp: Date, uids: String) -> Account? {
-        let timestampAsInt = UInt64 (timestamp.timeIntervalSince1970)
-        let bytes = [UInt8](seed)
-        return cryptoAccountCreateFromSeedBytes (bytes, timestampAsInt)
+    ///
+    /// Create an account based on an account serialization
+    ///
+    /// - Parameter serialization: The result of a prior call to account.serialize.
+    ///
+    /// - Returns: The serialization's corresponding account or NIL if the serialization is invalid.
+    ///    If the serialization is invalid then the account *must be recreated* from the `phrase`
+    ///    (aka 'Paper Key').  A serialization will be invald when the serialization format changes
+    ///    which will *always occur* when a new blockchain is added.  For example, when XRP is added
+    ///    the XRP public key must be serialized; the old serialization w/o the XRP public key will
+    ///    be invalid and the `phrase` is *required* in order to produce the XRP public key.
+    ///
+    public static func createFrom (serialization: Data, uids: String) -> Account? {
+        var bytes = [UInt8](serialization)
+        return cryptoAccountCreateFromSerialization (&bytes, bytes.count)
             .map { Account (core: $0, uids: uids) }
     }
 
-    public static func deriveSeed (phrase: String) -> Data {
-        var seed = cryptoAccountDeriveSeed(phrase)
-        return Data (bytes: &seed, count: MemoryLayout<UInt512>.size);
+    ///
+    /// Generate a BIP-39 'paper Key'.  Use Account.createFrom(paperKey:) to get the account
+    ///
+    /// - Returns: the 12 word 'paper key'
+    ///
+    public static func generatePhrase (wordList: [String]) -> (String,Date) {
+        var words = wordList.map { UnsafePointer<Int8> (strdup($0)) }
+        defer { words.forEach { free(UnsafeMutablePointer (mutating: $0)) } }
+        return (asUTF8String (cryptoAccountGeneratePaperKey (&words)), Date())
+    }
+
+    internal init (core: BRCryptoAccount, uids: String) {
+        self.core = core
+        self.uids = uids
     }
 
     deinit {

--- a/Swift/BRCryptoTests/BRCryptoAccountTests.swift
+++ b/Swift/BRCryptoTests/BRCryptoAccountTests.swift
@@ -34,13 +34,14 @@ class BRCryptoAccountTests: XCTestCase {
         guard let a1 = Account.createFrom (phrase: phrase, timestamp: timestamp, uids: walletId)
             else { XCTAssert(false); return}
 
-        XCTAssert (a1.addressAsETH == address)
+        XCTAssertEqual (a1.addressAsETH, address)
         XCTAssertEqual (timestamp, a1.timestamp)
 
+        let serialization = a1.serialize
+        guard let a2 = Account.createFrom (serialization: serialization, uids: walletId)
+            else { XCTAssert(false); return }
 
-        let d2 = Account.deriveSeed (phrase: phrase)
-        guard let a2 = Account.createFrom (seed: d2, timestamp: timestamp, uids: walletId) else { XCTAssert (false); return }
-        XCTAssert (a2.addressAsETH == address)
+        XCTAssertEqual (a2.addressAsETH, a1.addressAsETH);
     }
 
     func testAddressETH () {

--- a/Swift/BRCryptoTests/BRCryptoAccountTests.swift
+++ b/Swift/BRCryptoTests/BRCryptoAccountTests.swift
@@ -37,8 +37,7 @@ class BRCryptoAccountTests: XCTestCase {
         XCTAssertEqual (a1.addressAsETH, address)
         XCTAssertEqual (timestamp, a1.timestamp)
 
-        let serialization = a1.serialize
-        guard let a2 = Account.createFrom (serialization: serialization, uids: walletId)
+        guard let a2 = Account.createFrom (serialization: a1.serialize, uids: walletId)
             else { XCTAssert(false); return }
 
         XCTAssertEqual (a2.addressAsETH, a1.addressAsETH);

--- a/crypto/BRCryptoAccount.c
+++ b/crypto/BRCryptoAccount.c
@@ -31,6 +31,9 @@
 #include "support/BRKey.h"
 #include "ethereum/BREthereum.h"
 
+static uint16_t
+checksumFletcher16 (const uint8_t *data, size_t count);
+
 #define ACCOUNT_SERIALIZE_DEFAULT_VERSION  1
 
 static void
@@ -108,58 +111,83 @@ cryptoAccountCreate (const char *phrase, uint64_t timestamp) {
     return cryptoAccountCreateFromSeedInternal (cryptoAccountDeriveSeedInternal(phrase), timestamp);
 }
 
+
+/**
+ * Deserialize into an Account.  The serialization format is:
+ *  <checksum16><size32><version><BTC size><BTC master public key><ETH size><ETH public key>
+ *
+ *
+ * @param bytes the serialized bytes
+ * @param bytesCount the number of serialized bytes
+ *
+ * @return An Account, or NULL.
+ */
 extern BRCryptoAccount
 cryptoAccountCreateFromSerialization (const uint8_t *bytes, size_t bytesCount) {
     uint8_t *bytesPtr = (uint8_t *) bytes;
     uint8_t *bytesEnd = bytesPtr + bytesCount;
 
 #define BYTES_PTR_INCR_AND_CHECK(size) do {\
-  bytesPtr += (size);\
-  if (bytesPtr > bytesEnd) return NULL;\
+bytesPtr += (size);\
+if (bytesPtr > bytesEnd) return NULL; /* overkill */ \
 } while (0)
 
+    size_t chkSize = sizeof (uint16_t); // checksum
+    size_t szSize  = sizeof (uint32_t); // size
+    size_t verSize = sizeof (uint16_t); // version
+    size_t tsSize  = sizeof (uint64_t); // timestamp
 
-    size_t verSize = sizeof (uint16_t);
-    size_t szSize  = sizeof (uint32_t);
+    // Demand at least <checksum16><size32> in `bytes`
+    if (bytesCount < (chkSize + szSize)) return NULL;
 
-    // Decode
+    // Checksum
+    uint16_t checksum = UInt16GetBE(bytesPtr);
+    bytesPtr += chkSize;
+
+    // Confirm checksum, otherwise done
+    if (checksum != checksumFletcher16 (&bytes[chkSize], (bytesCount - chkSize))) return NULL;
+
+    // Size
+    uint32_t size = UInt32GetBE(bytesPtr);
+    bytesPtr += szSize;
+
+    if (size != bytesCount) return NULL;
+
+    // Version
     uint16_t version = UInt16GetBE (bytesPtr);
     BYTES_PTR_INCR_AND_CHECK(verSize);
 
+    // Require the current verion, otherwise done.  Will force account create using
+    // `cryptoAccountCreate()` and a re-serialization
     if (ACCOUNT_SERIALIZE_DEFAULT_VERSION != version) return NULL;
 
-    switch (version) {
-        case 1: {
-            size_t tsSize  = sizeof (uint64_t);
+    // Timestamp
+    uint64_t timestamp = UInt64GetBE (bytesPtr);
+    BYTES_PTR_INCR_AND_CHECK (tsSize);
 
-            // Timestamp
-            uint64_t timestamp = UInt64GetBE (bytesPtr);
-            BYTES_PTR_INCR_AND_CHECK (tsSize);
+    // BTC
+    size_t mpkSize = UInt32GetBE(bytesPtr);
+    BYTES_PTR_INCR_AND_CHECK (szSize);
 
-            // BTC
-            size_t mpkSize = UInt32GetBE(bytesPtr);
-            BYTES_PTR_INCR_AND_CHECK (szSize);
-            (void) mpkSize; // TODO: Use mpkSize
+    // There is a slight chance that this fails IF AND ONLY IF the serialized format
+    // of a MasterPublicKey either changes or is key dependent.  That is, we parse the MPK
+    // from `bytes` but if THIS PARSE needs more than the original parse we might run
+    // off the end of the provided `bytes`.  Must be REALLY UNLIKELY.
+    //
+    // TODO: Add `bytesCount` to BRBIP32ParseMasterPubKey()
+    BRMasterPubKey mpk = BRBIP32ParseMasterPubKey ((const char *) bytesPtr);
+    if (mpkSize != BRBIP32SerializeMasterPubKey (NULL, 0, mpk)) return NULL;
 
-            BRMasterPubKey mpk = BRBIP32ParseMasterPubKey ((const char *) bytesPtr);
-            BYTES_PTR_INCR_AND_CHECK (BRBIP32SerializeMasterPubKey (NULL, 0, mpk));
+    // ETH
+    size_t ethSize = UInt32GetBE (bytesPtr);
+    BYTES_PTR_INCR_AND_CHECK (szSize);
+    assert (65 == ethSize);
 
-            // ETH
-            size_t ethSize = UInt32GetBE (bytesPtr);
-            BYTES_PTR_INCR_AND_CHECK (szSize);
-            assert (65 == ethSize);
+    BRKey ethPublicKey;
+    BRKeySetPubKey(&ethPublicKey, bytesPtr, 65);
+    BYTES_PTR_INCR_AND_CHECK (65);
 
-            BRKey ethPublicKey;
-            BRKeySetPubKey(&ethPublicKey, bytesPtr, 65);
-            BYTES_PTR_INCR_AND_CHECK (65);
-
-            return cryptoAccountCreateInternal (mpk, ethPublicKey, timestamp);
-        }
-
-        default:
-            assert (0);
-            break;
-    }
+    return cryptoAccountCreateInternal (mpk, ethPublicKey, timestamp);
 #undef BYTES_PTR_INCR_AND_CHECK
 }
 
@@ -173,7 +201,7 @@ cryptoAccountRelease (BRCryptoAccount account) {
 
 /**
  * Serialize the account as per ACCOUNT_SERIALIZE_DEFAULT_VERSION.  The serialization format is:
- *  <version><BTC size><BTC master public key><ETH size><ETH public key>
+ *  <checksum16><size32><version><BTC size><BTC master public key><ETH size><ETH public key>
  *
  *
  * @param account The account
@@ -185,9 +213,10 @@ extern uint8_t *
 cryptoAccountSerialize (BRCryptoAccount account, size_t *bytesCount) {
     assert (NULL != bytesCount);
 
-    size_t verSize = sizeof (uint16_t);
-    size_t tsSize  = sizeof (uint64_t); // timestamp size
-    size_t szSize  = sizeof (uint32_t); // size size
+    size_t chkSize = sizeof (uint16_t); // checksum
+    size_t szSize  = sizeof (uint32_t); // size
+    size_t verSize = sizeof (uint16_t); // version
+    size_t tsSize  = sizeof (uint64_t); // timestamp
 
     // Version
     uint16_t version = ACCOUNT_SERIALIZE_DEFAULT_VERSION;
@@ -200,11 +229,19 @@ cryptoAccountSerialize (BRCryptoAccount account, size_t *bytesCount) {
     ethPublicKey.compressed = 0;
     size_t ethSize = BRKeyPubKey (&ethPublicKey, NULL, 0);
 
-    *bytesCount = verSize + tsSize + (szSize + mpkSize) + (szSize + ethSize);
+    // Overall size - summing all factors.
+    *bytesCount = chkSize + szSize + verSize + tsSize + (szSize + mpkSize) + (szSize + ethSize);
     uint8_t *bytes = calloc (1, *bytesCount);
     uint8_t *bytesPtr = bytes;
 
     // Encode
+
+    // Skip the checksum; will comeback to it
+    bytesPtr += chkSize;
+
+    // Size
+    UInt32SetBE (bytesPtr, (uint32_t) *bytesCount);
+    bytesPtr += szSize;
 
     // Version
     UInt16SetBE (bytesPtr, version);
@@ -228,7 +265,11 @@ cryptoAccountSerialize (BRCryptoAccount account, size_t *bytesCount) {
     BRKeyPubKey (&ethPublicKey, bytesPtr, ethSize);
     bytesPtr += ethSize;
 
-    // ...
+    (void) bytesPtr;  // Avoid static analysis warning
+
+    // checksum
+    uint16_t checksum = checksumFletcher16 (&bytes[chkSize], (*bytesCount - chkSize));
+    UInt16SetBE (bytes, checksum);
 
     return bytes;
 }
@@ -251,4 +292,20 @@ cryptoAccountAddressAsETH (BRCryptoAccount account) {
 private_extern BRMasterPubKey
 cryptoAccountAsBTC (BRCryptoAccount account) {
     return account->btc;
+}
+
+// https://en.wikipedia.org/wiki/Fletcher%27s_checksum
+static uint16_t
+checksumFletcher16(const uint8_t *data, size_t count )
+{
+    uint16_t sum1 = 0;
+    uint16_t sum2 = 0;
+    int index;
+
+    for( index = 0; index < count; ++index )
+    {
+        sum1 = (sum1 + data[index]) % 255;
+        sum2 = (sum2 + sum1) % 255;
+    }
+    return (sum2 << 8) | sum1;
 }

--- a/crypto/BRCryptoAccount.h
+++ b/crypto/BRCryptoAccount.h
@@ -37,25 +37,46 @@ extern "C" {
 
     typedef struct BRCryptoAccountRecord *BRCryptoAccount;
 
+    /**
+     * Given a phrase (A BIP-39 PaperKey) dervied the corresponding 'seed'.  This is used
+     * exclusive to sign transactions (BTC ones for sure).
+     *
+     * @param phrase A BIP-32 Paper Key
+     *
+     * @return A UInt512 seed
+     */
     extern UInt512
     cryptoAccountDeriveSeed (const char *phrase);
+
+
+    extern char *
+    cryptoAccountGeneratePaperKey (const char **wordList);
 
     extern BRCryptoAccount
     cryptoAccountCreate (const char *paperKey, uint64_t timestamp);
 
+    /**
+     * Recreate an Account from a serialization
+     *
+     * @param bytes serialized bytes
+     * @param bytesCount serialized bytes count
+     *
+     * @return The Account, or NULL.  If the serialization is invalid then the account *must be
+     * recreated* from the `phrase` (aka 'Paper Key').  A serialization will be invald when the
+     * serialization format changes which will *always occur* when a new blockchain is added.  For
+     * example, when XRP is added the XRP public key must be serialized; the old serialization w/o
+     * the XRP public key will be invalid and the `phrase` is *required* in order to produce the
+     * XRP public key.
+     */
     extern BRCryptoAccount
-    cryptoAccountCreateFromSeed (UInt512 seed, uint64_t timestamp);
+    cryptoAccountCreateFromSerialization (const uint8_t *bytes, size_t bytesCount);
 
-    extern BRCryptoAccount
-    cryptoAccountCreateFromSeedBytes (const uint8_t *bytes, uint64_t timestamp);
+    extern uint8_t *
+    cryptoAccountSerialize (BRCryptoAccount account, size_t *bytesCount);
 
     extern uint64_t
     cryptoAccountGetTimestamp (BRCryptoAccount account);
 
-    extern void
-    cryptoAccountSetTimestamp (BRCryptoAccount account,
-                               uint64_t timestamp);
-    
     DECLARE_CRYPTO_GIVE_TAKE (BRCryptoAccount, cryptoAccount);
 
 #ifdef __cplusplus

--- a/crypto/BRCryptoAccount.h
+++ b/crypto/BRCryptoAccount.h
@@ -52,6 +52,16 @@ extern "C" {
     extern char *
     cryptoAccountGeneratePaperKey (const char **wordList);
 
+    /**
+     * Validate the number of words in the word list.
+     *
+     * @param wordsCount number of words
+     *
+     * @return CRYPTO_TRUE if valid; false otherwise.
+     */
+    extern BRCryptoBoolean
+    cryptoAccountValidateWordsList (int wordsCount);
+
     extern BRCryptoAccount
     cryptoAccountCreate (const char *paperKey, uint64_t timestamp);
 


### PR DESCRIPTION
Add account serialization.  Once an account is created, based on a `phrase` (aka 12-word BIP-39 'paper key') it can be serialized and then recreated from the serialization.  Doing so avoids using the sensitive 'paper key' whenever the account needs to be created.

We anticipate that that serialization will change; specifically anytime a new blockchain is added.  In such a case the new blockchain's public key needs to be serialized.  For example, when adding XRP (Ripple) the XRP public key must be serialized.  On a change recreating the account from the serialization will fail and the 'paper key' must be used to recreate the account.