### PR TITLE
CORE-412: Initialize WalletManagers w/ the Network Block Height

### DIFF
--- a/bitcoin/BRWalletManager.h
+++ b/bitcoin/BRWalletManager.h
@@ -235,7 +235,8 @@ BRWalletManagerNew (BRWalletManagerClient client,
                     const BRChainParams *params,
                     uint32_t earliestKeyTime,
                     BRSyncMode mode,
-                    const char *storagePath);
+                    const char *storagePath,
+                    uint64_t blockHeight);
 
 extern void
 BRWalletManagerFree (BRWalletManager manager);

--- a/bitcoin/test.c
+++ b/bitcoin/test.c
@@ -3121,7 +3121,7 @@ extern int BRRunTestWalletManagerSync (const char *paperKey,
 
     BRSyncMode mode = SYNC_MODE_P2P_ONLY;
 
-    BRWalletManager manager = BRWalletManagerNew (client, mpk, params, epoch, mode, storagePath);
+    BRWalletManager manager = BRWalletManagerNew (client, mpk, params, epoch, mode, storagePath, 0);
 
     BRPeerManager *pm = BRWalletManagerGetPeerManager(manager);
 

--- a/crypto/BRCryptoWalletManager.c
+++ b/crypto/BRCryptoWalletManager.c
@@ -131,7 +131,8 @@ cryptoWalletManagerCreate (BRCryptoCWMListener listener,
                                              cryptoNetworkAsBTC (network),
                                              (uint32_t) cryptoAccountGetTimestamp(account),
                                              mode,
-                                             cwmPath);
+                                             cwmPath,
+                                             cryptoNetworkGetHeight(network));
 
             break;
         }
@@ -145,7 +146,8 @@ cryptoWalletManagerCreate (BRCryptoCWMListener listener,
                                     (BREthereumTimestamp) cryptoAccountGetTimestamp(account),
                                     (BREthereumMode) mode,
                                     client,
-                                    cwmPath);
+                                    cwmPath,
+                                    cryptoNetworkGetHeight(network));
 
             // During the creation of both the BTC and ETH wallet managers, the primary wallet will
             // be created and will have wallet events generated.  There will be a race on `cwm->wallet` but

--- a/ethereum/bcs/BREthereumBCS.h
+++ b/ethereum/bcs/BREthereumBCS.h
@@ -53,7 +53,6 @@ typedef void
                                     uint64_t headBlockNumber,
                                     uint64_t headBlockTimestamp);
 
-
 /**
  * The BCS account state has been updated.
  */

--- a/ethereum/ewm/BREthereumEWM.c
+++ b/ethereum/ewm/BREthereumEWM.c
@@ -343,7 +343,8 @@ ewmCreate (BREthereumNetwork network,
            BREthereumTimestamp accountTimestamp,
            BREthereumMode mode,
            BREthereumClient client,
-           const char *storagePath) {
+           const char *storagePath,
+           uint64_t blockHeight) {
     BREthereumEWM ewm = (BREthereumEWM) calloc (1, sizeof (struct BREthereumEWMRecord));
 
     ewm->state = LIGHT_NODE_CREATED;
@@ -351,7 +352,7 @@ ewmCreate (BREthereumNetwork network,
     ewm->network = network;
     ewm->account = account;
     ewm->bcs = NULL;
-    ewm->blockHeight = 0;
+    ewm->blockHeight = blockHeight;
 
     {
         char address [ADDRESS_ENCODED_CHARS];
@@ -363,7 +364,7 @@ ewmCreate (BREthereumNetwork network,
     ewm->brdSync.ridTransaction = -1;
     ewm->brdSync.ridLog = -1;
     ewm->brdSync.begBlockNumber = 0;
-    ewm->brdSync.endBlockNumber = 0;
+    ewm->brdSync.endBlockNumber = ewm->blockHeight;
     ewm->brdSync.completedTransaction = 0;
     ewm->brdSync.completedLog = 0;
 
@@ -585,13 +586,15 @@ ewmCreateWithPaperKey (BREthereumNetwork network,
                        BREthereumTimestamp accountTimestamp,
                        BREthereumMode mode,
                        BREthereumClient client,
-                       const char *storagePath) {
+                       const char *storagePath,
+                       uint64_t blockHeight) {
     return ewmCreate (network,
                       createAccount (paperKey),
                       accountTimestamp,
                       mode,
                       client,
-                      storagePath);
+                      storagePath,
+                      blockHeight);
 }
 
 extern BREthereumEWM
@@ -600,13 +603,15 @@ ewmCreateWithPublicKey (BREthereumNetwork network,
                         BREthereumTimestamp accountTimestamp,
                         BREthereumMode mode,
                         BREthereumClient client,
-                        const char *storagePath) {
+                        const char *storagePath,
+                        uint64_t blockHeight) {
     return ewmCreate (network,
                       createAccountWithPublicKey(publicKey),
                       accountTimestamp,
                       mode,
                       client,
-                      storagePath);
+                      storagePath,
+                      blockHeight);
 }
 
 extern void

--- a/ethereum/ewm/BREthereumEWM.h
+++ b/ethereum/ewm/BREthereumEWM.h
@@ -29,7 +29,8 @@ ewmCreate (BREthereumNetwork network,
            BREthereumTimestamp accountTimestamp,
            BREthereumMode mode,
            BREthereumClient client,
-           const char *storagePath);
+           const char *storagePath,
+           uint64_t blockHeight);
 
 extern BREthereumEWM
 ewmCreateWithPaperKey (BREthereumNetwork network,
@@ -37,7 +38,8 @@ ewmCreateWithPaperKey (BREthereumNetwork network,
                        BREthereumTimestamp accountTimestamp,
                        BREthereumMode mode,
                        BREthereumClient client,
-                       const char *storagePath);
+                       const char *storagePath,
+                       uint64_t blockHeight);
 
 extern BREthereumEWM
 ewmCreateWithPublicKey (BREthereumNetwork network,
@@ -45,7 +47,8 @@ ewmCreateWithPublicKey (BREthereumNetwork network,
                         BREthereumTimestamp accountTimestamp,
                         BREthereumMode mode,
                         BREthereumClient client,
-                        const char *storagePath);
+                        const char *storagePath,
+                        uint64_t blockHeight);
 
 extern void
 ewmDestroy (BREthereumEWM ewm);

--- a/ethereum/ewm/BREthereumEWMPrivate.h
+++ b/ethereum/ewm/BREthereumEWMPrivate.h
@@ -103,6 +103,9 @@ struct BREthereumEWMRecord {
      * The BlockHeight is the largest block number seen or computed.  [Note: the blockHeight may
      * be computed from a Log event as (log block number + log confirmations).  This is the block
      * number for the block at the head of the blockchain.
+     *
+     * This gets initialized from ewmCreate() based on the 'known' block height of the network or
+     * with zero if the network's block height is unknown.
      */
     uint64_t blockHeight;
 

--- a/ethereum/ewm/testEwm.c
+++ b/ethereum/ewm/testEwm.c
@@ -584,7 +584,8 @@ runEWM_CONNECT_test (const char *paperKey,
     BREthereumEWM ewm = ewmCreateWithPaperKey (ethereumMainnet, paperKey, ETHEREUM_TIMESTAMP_UNKNOWN,
                                                BRD_ONLY,
                                                client,
-                                               storagePath);
+                                               storagePath,
+                                               0);
     assert (NULL != ewm);
 
     BREthereumWallet wallet = ewmGetWallet(ewm);
@@ -649,7 +650,8 @@ void prepareTransaction (const char *paperKey,
     BREthereumEWM ewm = ewmCreateWithPaperKey (ethereumMainnet, paperKey, ETHEREUM_TIMESTAMP_UNKNOWN,
                                                P2P_ONLY,
                                                client,
-                                               storagePath);
+                                               storagePath,
+                                               0);
     // A wallet amount Ether
     BREthereumWallet wallet = ewmGetWallet(ewm);
     // END - One Time Code Block
@@ -709,7 +711,8 @@ testReallySend (const char *storagePath) {
     BREthereumEWM ewm = ewmCreateWithPaperKey (ethereumMainnet, paperKey, ETHEREUM_TIMESTAMP_UNKNOWN,
                                                P2P_ONLY,
                                                client,
-                                               storagePath);
+                                               storagePath,
+                                               0);
     BREthereumAccount account = ewmGetAccount(ewm);
     
     // A wallet amount Ether
@@ -782,7 +785,8 @@ runEWM_TOKEN_test (const char *paperKey,
     BREthereumEWM ewm = ewmCreateWithPaperKey (ethereumMainnet, paperKey, ETHEREUM_TIMESTAMP_UNKNOWN,
                                                P2P_ONLY,
                                                client,
-                                               storagePath);
+                                               storagePath,
+                                               0);
     BREthereumWallet wid = ewmGetWalletHoldingToken(ewm, token);
     
     BREthereumAmount amount = ewmCreateTokenAmountString(ewm, token,
@@ -817,14 +821,16 @@ runEWM_PUBLIC_KEY_test (BREthereumNetwork network,
     BREthereumEWM ewm1 = ewmCreateWithPaperKey (ethereumMainnet, paperKey, ETHEREUM_TIMESTAMP_UNKNOWN,
                                                 P2P_ONLY,
                                                 client,
-                                                storagePath);
+                                                storagePath,
+                                                0);
     BRKey publicKey = ewmGetAccountPrimaryAddressPublicKey (ewm1);
     char *addr1 = ewmGetAccountPrimaryAddress (ewm1);
     
     BREthereumEWM ewm2 = ewmCreateWithPublicKey (ethereumMainnet, publicKey, ETHEREUM_TIMESTAMP_UNKNOWN,
                                                  P2P_ONLY,
                                                  client,
-                                                 storagePath);
+                                                 storagePath,
+                                                 0);
     char *addr2 = ewmGetAccountPrimaryAddress (ewm2);
     
     
@@ -853,7 +859,7 @@ runSyncTest (BREthereumNetwork network,
     
     alarmClockCreateIfNecessary (1);
 
-    ewm = ewmCreate (ethereumMainnet, account, accountTimestamp, mode, client, storagePath);
+    ewm = ewmCreate (ethereumMainnet, account, accountTimestamp, mode, client, storagePath, 0);
 
     
     char *address = ewmGetAccountPrimaryAddress(ewm);


### PR DESCRIPTION
This allows a sync to start immediately rather than, in API modes, after one full period.