### PR TITLE
CORE-413: In Swift Core Crypto BlockchainDB, 'chunk' addresses in

### DIFF
--- a/Swift/BRCrypto/common/BRSupport.swift
+++ b/Swift/BRCrypto/common/BRSupport.swift
@@ -183,3 +183,13 @@ extension Array {
         }
     }
 }
+
+
+extension Array {
+    // https://www.hackingwithswift.com/example-code/language/how-to-split-an-array-into-chunks
+    func chunked(into size: Int) -> [[Element]] {
+        return stride(from: 0, to: count, by: size).map {
+            Array(self[$0 ..< Swift.min($0 + size, count)])
+        }
+    }
+}


### PR DESCRIPTION
The nature of a BTC sync is that each transaction may use new addresses.  When querying the BDB all these addresses must be provided in the HTTP request.  Apparently the number of address overflowed the HTTP request limit and later transactions request (when addresses had accumulated) had failed.  The IOS App missed finding known transactions.  So, split the request into at most ADDRESS_COUNT addresses (currently 50).