### PR TITLE
CORE-414: Confirm Account Creation From a Public Key

### DIFF
--- a/ripple/BRRippleAccount.h
+++ b/ripple/BRRippleAccount.h
@@ -46,9 +46,9 @@ rippleAccountCreateWithKey(BRKey key);
 /**
  * Create a Ripple account object from a (prior) serialization of the account
  *
- * @param bytes
- * @param bytesCount
- * @return account
+ * @param bytes        raw bytes created from a previous serialization of the account
+ * @param bytesCount   number of raw bytes
+ * @return account     created account
  */
 extern BRRippleAccount
 rippleAccountCreateWithSerialization (uint8_t *bytes, size_t bytesCount);
@@ -102,7 +102,17 @@ rippleAccountSignTransaction(BRRippleAccount account, BRRippleTransaction transa
 extern BRRippleAddress
 rippleAccountGetAddress(BRRippleAccount account);
 
-// Serialize `account`; return `bytes` and set `bytesCount`
+/*
+ * Serialize the account and return a pointer to bytes
+ *
+ * The serialized account will simply be the uncompressed public key in this form
+ * <0x04><64 bytes of public key>
+ *
+ * @param account        handle of a valid account object
+ * @param bytesCount     pointer to where the size is stored
+ *
+ * @return bytes         pointer to raw bytes of serialized account
+ */
 extern uint8_t *
 rippleAccountGetSerialization (BRRippleAccount account, size_t *bytesCount);
 

--- a/support/BRKey.h
+++ b/support/BRKey.h
@@ -83,6 +83,9 @@ int BRKeySetPrivKey(BRKey *key, const char *privKey);
 // assigns DER encoded pubKey to key and returns true on success
 int BRKeySetPubKey(BRKey *key, const uint8_t *pubKey, size_t pkLen);
 
+// assigned DER encode pubkey to key and optionally compress results
+int BRKeySetPubKeyEx(BRKey *key, const uint8_t *pubKey, size_t pkLen, int compress);
+
 // writes the WIF private key to privKey and returns the number of bytes writen, or pkLen needed if privKey is NULL
 // returns 0 on failure
 size_t BRKeyPrivKey(const BRKey *key, char *privKey, size_t pkLen);


### PR DESCRIPTION
The public key was in compressed form, so there was some
work to do in order to return an uncompressed version

Added a test case to serialize an account, then create from
serialized bytes.

(cherry picked from commit 390b5f6790335e24912dea3a7a5f506c828f06e6)