### PR TITLE
CORE-414 Confirm Ripple Account Creation from a Public Key

### DIFF
--- a/ripple/BRRippleAccount.h
+++ b/ripple/BRRippleAccount.h
@@ -37,7 +37,7 @@ rippleAccountCreateWithSeed(UInt512 seed);
 /**
  * Create a Ripple account object
  *
- * @param  key      BRKey with valid private key
+ * @param  key      BRKey with valid compressed public key
  * @return account
  */
 extern BRRippleAccount /* caller must free - rippleAccountFree */
@@ -46,11 +46,11 @@ rippleAccountCreateWithKey(BRKey key);
 /**
  * Create a Ripple account object from a (prior) serialization of the account
  *
- * @param bytes
- * @param bytesCount
- * @return account
+ * @param bytes        raw bytes returned from rippleAccountGetSerialization
+ * @param bytesCount   number of raw bytes
+ * @return account     valid account object
  */
-extern BRRippleAccount
+extern BRRippleAccount /* caller must free - rippleAccountFree */
 rippleAccountCreateWithSerialization (uint8_t *bytes, size_t bytesCount);
 
 /**
@@ -103,7 +103,7 @@ extern BRRippleAddress
 rippleAccountGetAddress(BRRippleAccount account);
 
 // Serialize `account`; return `bytes` and set `bytesCount`
-extern uint8_t *
+extern uint8_t * /* caller must free - using "free" function */
 rippleAccountGetSerialization (BRRippleAccount account, size_t *bytesCount);
 
 /*

--- a/ripple/testRipple.c
+++ b/ripple/testRipple.c
@@ -190,19 +190,20 @@ testCreateRippleAccountWithKey (void /* ... */) {
     BRBIP39DeriveKey(seed.u8, paper_key, NULL); // no passphrase
 
     // Create the private key from the seed
-    BRKey privateKey;
+    BRKey key;
     // The BIP32 privateKey for m/44'/60'/0'/0/index
-    BRBIP32PrivKeyPath(&privateKey, &seed, sizeof(UInt512), 5,
+    BRBIP32PrivKeyPath(&key, &seed, sizeof(UInt512), 5,
                        44 | BIP32_HARD,          // purpose  : BIP-44
                        144 | BIP32_HARD,        // coin_type: Ripple
                        0 | BIP32_HARD,          // account  : <n/a>
                        0,                        // change   : not change
                        0);                   // index    :
 
-    privateKey.compressed = 0;
+    key.compressed = 1;
+    BRKeyPubKey(&key, &key.pubKey, 33);
 
     // If we pass the expected_accountid_string to this function it will validate for us
-    BRRippleAccount account = rippleAccountCreateWithKey(privateKey);
+    BRRippleAccount account = rippleAccountCreateWithKey(key);
     assert(account);
 
     // Get the 20 bytes that were created for the account

--- a/ripple/testRipple.c
+++ b/ripple/testRipple.c
@@ -215,7 +215,7 @@ testCreateRippleAccountWithKey (void /* ... */) {
     BRRippleAccount account2 = rippleAccountCreateWithKey(publicKey);
     char rippleAddress2[36];
     rippleAccountGetAddressString(account2, rippleAddress2, 36);
-    assert(0 == strcmp(rippleAddress, expected_accountid_string));
+    assert(0 == strcmp(rippleAddress2, expected_accountid_string));
 
     rippleAccountFree(account);
     rippleAccountFree(account2);
@@ -255,7 +255,7 @@ testCreateRippleAccountWithSerializedAccount (void /* ... */) {
     assert(account2);
     char rippleAddress2[36];
     rippleAccountGetAddressString(account2, rippleAddress2, 36);
-    assert(0 == strcmp(rippleAddress, expected_ripple_address));
+    assert(0 == strcmp(rippleAddress2, expected_ripple_address));
     
     rippleAccountFree(account);
     rippleAccountFree(account2);


### PR DESCRIPTION
Create an account with both serialized account bytes and with a public key.
Add unit tests to confirm.
All existing unit tests passed.