### PR TITLE
CORE-340: Create BRCryptoNetworkFee

### DIFF
--- a/Java/CoreCrypto/src/androidTest/java/com/breadwallet/corecrypto/NetworkAIT.java
+++ b/Java/CoreCrypto/src/androidTest/java/com/breadwallet/corecrypto/NetworkAIT.java
@@ -6,8 +6,10 @@ import com.google.common.primitives.UnsignedLong;
 import org.junit.Test;
 
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
 
 import static org.junit.Assert.assertEquals;
@@ -28,7 +30,11 @@ public class NetworkAIT {
         Map<Currency, NetworkAssociation> associations = new HashMap();
         associations.put(btc, association);
 
-        Network network = Network.create("bitcoin-mainnet", "Bitcoin", true, btc, UnsignedLong.valueOf(100000), associations);
+        NetworkFee fee = NetworkFee.create(UnsignedLong.valueOf(30 * 1000), Amount.create(1000, satoshi_btc).get(), satoshi_btc);
+
+        List<NetworkFee> fees = Collections.singletonList(fee);
+
+        Network network = Network.create("bitcoin-mainnet", "Bitcoin", true, btc, UnsignedLong.valueOf(100000), associations, fees);
 
         assertEquals(network.getUids(), "bitcoin-mainnet");
         assertEquals(network.getName(), "Bitcoin");
@@ -77,7 +83,9 @@ public class NetworkAIT {
         Map<Currency, NetworkAssociation> associations = new HashMap();
         associations.put(eth, association);
 
-        Network network = Network.create("ethereum-mainnet", "Ethereum", true, eth, UnsignedLong.valueOf(100000), associations);
+        List<NetworkFee> fees = Collections.emptyList();
+
+        Network network = Network.create("ethereum-mainnet", "Ethereum", true, eth, UnsignedLong.valueOf(100000), associations, fees);
 
         assertTrue(network.hasCurrency(eth));
         assertFalse(network.hasCurrency(btc));

--- a/Java/CoreCrypto/src/main/java/com/breadwallet/corecrypto/Network.java
+++ b/Java/CoreCrypto/src/main/java/com/breadwallet/corecrypto/Network.java
@@ -28,7 +28,8 @@ final class Network implements com.breadwallet.crypto.Network {
 
     /* package */
     static Network create(String uids, String name, boolean isMainnet, Currency currency, UnsignedLong height,
-                          Map<Currency, NetworkAssociation> associations) {
+                          Map<Currency, NetworkAssociation> associations,
+                          List<NetworkFee> fees) {
         CoreBRCryptoNetwork core;
 
         String code = currency.getCode();
@@ -66,6 +67,10 @@ final class Network implements com.breadwallet.crypto.Network {
             }
         }
 
+        for (NetworkFee fee: fees) {
+            core.addFee(fee.getCoreBRCryptoNetworkFee());
+        }
+
         return new Network(core);
     }
 
@@ -90,6 +95,7 @@ final class Network implements com.breadwallet.crypto.Network {
     private final Boolean isMainnet;
     private final Currency currency;
     private final Set<Currency> currencies;
+    private final List<NetworkFee> fees;
 
     private Network(CoreBRCryptoNetwork core) {
         this.core = core;
@@ -99,10 +105,17 @@ final class Network implements com.breadwallet.crypto.Network {
         name = core.getName();
         isMainnet = core.isMainnet();
         currency = Currency.create(core.getCurrency());
+
         currencies = new HashSet<>();
         UnsignedLong count = core.getCurrencyCount();
         for (UnsignedLong i = UnsignedLong.ZERO; i.compareTo(count) < 0; i = i.plus(UnsignedLong.ONE)) {
             currencies.add(Currency.create(core.getCurrency(i)));
+        }
+
+        fees = new ArrayList<>();
+        count = core.getFeeCount();
+        for (UnsignedLong i = UnsignedLong.ZERO; i.compareTo(count) < 0; i = i.plus(UnsignedLong.ONE)) {
+            fees.add(NetworkFee.create(core.getFee(i)));
         }
     }
 
@@ -134,6 +147,11 @@ final class Network implements com.breadwallet.crypto.Network {
     @Override
     public Set<Currency> getCurrencies() {
         return new HashSet<>(currencies);
+    }
+
+    @Override
+    public List<? extends NetworkFee> getFees() {
+        return fees;
     }
 
     @Override

--- a/Java/CoreCrypto/src/main/java/com/breadwallet/corecrypto/NetworkFee.java
+++ b/Java/CoreCrypto/src/main/java/com/breadwallet/corecrypto/NetworkFee.java
@@ -1,0 +1,59 @@
+package com.breadwallet.corecrypto;
+
+import com.breadwallet.corenative.crypto.CoreBRCryptoNetworkFee;
+import com.google.common.primitives.UnsignedLong;
+
+import java.util.Objects;
+
+public class NetworkFee implements com.breadwallet.crypto.NetworkFee {
+
+    /* package */
+    static NetworkFee create(UnsignedLong timeIntervalInMilliseconds,
+                             Amount pricePerCostFactor,
+                             Unit pricePerCostFactorUnit) {
+        return new NetworkFee(CoreBRCryptoNetworkFee.create(
+                timeIntervalInMilliseconds,
+                pricePerCostFactor.getCoreBRCryptoAmount(),
+                pricePerCostFactorUnit.getCoreBRCryptoUnit()));
+    }
+
+    /* package */
+    static NetworkFee create(CoreBRCryptoNetworkFee core) {
+        return new NetworkFee(core);
+    }
+
+    private final CoreBRCryptoNetworkFee core;
+
+    private NetworkFee(CoreBRCryptoNetworkFee core) {
+        this.core = core;
+    }
+
+    @Override
+    public UnsignedLong getConfirmationTimeInMilliseconds() {
+        return core.getConfirmationTimeInMilliseconds();
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        NetworkFee fee = (NetworkFee) o;
+        return core.isIdentical(fee.core);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(core);
+    }
+
+    /* package */
+    CoreBRCryptoNetworkFee getCoreBRCryptoNetworkFee() {
+        return core;
+    }
+}

--- a/Java/CoreCrypto/src/main/java/com/breadwallet/corecrypto/WalletManager.java
+++ b/Java/CoreCrypto/src/main/java/com/breadwallet/corecrypto/WalletManager.java
@@ -4,6 +4,7 @@ import com.breadwallet.corenative.crypto.BRCryptoCWMClient;
 import com.breadwallet.corenative.crypto.BRCryptoCWMListener;
 import com.breadwallet.corenative.crypto.CoreBRCryptoWallet;
 import com.breadwallet.corenative.crypto.CoreBRCryptoWalletManager;
+import com.breadwallet.crypto.NetworkFee;
 import com.breadwallet.crypto.WalletManagerMode;
 import com.breadwallet.crypto.WalletManagerState;
 import com.google.common.base.Optional;
@@ -149,6 +150,12 @@ final class WalletManager implements com.breadwallet.crypto.WalletManager {
     @Override
     public Unit getDefaultUnit() {
         return networkDefaultUnit;
+    }
+
+    @Override
+    public Optional<NetworkFee> getDefaultNetworkFee() {
+        // TODO(fix): Implement this
+        return Optional.absent();
     }
 
     @Override

--- a/Java/CoreNative/src/main/java/com/breadwallet/corenative/CryptoLibrary.java
+++ b/Java/CoreNative/src/main/java/com/breadwallet/corenative/CryptoLibrary.java
@@ -17,6 +17,7 @@ import com.breadwallet.corenative.crypto.BRCryptoCurrency;
 import com.breadwallet.corenative.crypto.BRCryptoFeeBasis;
 import com.breadwallet.corenative.crypto.BRCryptoHash;
 import com.breadwallet.corenative.crypto.BRCryptoNetwork;
+import com.breadwallet.corenative.crypto.BRCryptoNetworkFee;
 import com.breadwallet.corenative.crypto.BRCryptoTransfer;
 import com.breadwallet.corenative.crypto.BRCryptoTransferState;
 import com.breadwallet.corenative.crypto.BRCryptoUnit;
@@ -106,8 +107,13 @@ public interface CryptoLibrary extends Library {
     int cryptoNetworkHasCurrency(BRCryptoNetwork network, BRCryptoCurrency currency);
     SizeT cryptoNetworkGetUnitCount(BRCryptoNetwork network, BRCryptoCurrency currency);
     BRCryptoUnit cryptoNetworkGetUnitAt(BRCryptoNetwork network, BRCryptoCurrency currency, SizeT index);
+    SizeT cryptoNetworkGetNetworkFeeCount(BRCryptoNetwork network);
+    BRCryptoNetworkFee cryptoNetworkGetNetworkFeeAt(BRCryptoNetwork network, SizeT index);
     BRCryptoNetwork cryptoNetworkTake(BRCryptoNetwork obj);
     void cryptoNetworkGive(BRCryptoNetwork obj);
+    long cryptoNetworkFeeGetConfirmationTimeInMilliseconds(BRCryptoNetworkFee fee);
+    int cryptoNetworkFeeEqual(BRCryptoNetworkFee nf1, BRCryptoNetworkFee nf2);
+    void cryptoNetworkFeeGive(BRCryptoNetworkFee obj);
 
     // crypto/BRCryptoPrivate.h
     BRCryptoAddress cryptoAddressCreateFromStringAsBTC(String address);
@@ -123,6 +129,8 @@ public interface CryptoLibrary extends Library {
     void cryptoNetworkAddCurrencyUnit(BRCryptoNetwork network, BRCryptoCurrency currency, BRCryptoUnit unit);
     BRCryptoUnit cryptoUnitCreateAsBase(BRCryptoCurrency currency, String uids, String name, String symbol);
     BRCryptoUnit cryptoUnitCreate(BRCryptoCurrency currency, String uids, String name, String symbol, BRCryptoUnit base, byte decimals);
+    BRCryptoNetworkFee cryptoNetworkFeeCreate(long timeInternalInMilliseconds, BRCryptoAmount pricePerCostFactor, BRCryptoUnit pricePerCostFactorUnit);
+    void cryptoNetworkAddNetworkFee(BRCryptoNetwork network, BRCryptoNetworkFee fee);
 
     // crypto/BRCryptoTransfer.h
     BRCryptoAddress cryptoTransferGetSourceAddress(BRCryptoTransfer transfer);

--- a/Java/CoreNative/src/main/java/com/breadwallet/corenative/crypto/BRCryptoNetwork.java
+++ b/Java/CoreNative/src/main/java/com/breadwallet/corenative/crypto/BRCryptoNetwork.java
@@ -56,6 +56,17 @@ public class BRCryptoNetwork extends PointerType implements CoreBRCryptoNetwork 
     }
 
     @Override
+    public UnsignedLong getFeeCount() {
+        return UnsignedLong.fromLongBits(CryptoLibrary.INSTANCE.cryptoNetworkGetNetworkFeeCount(this).longValue());
+    }
+
+    @Override
+    public CoreBRCryptoNetworkFee getFee(UnsignedLong index) {
+        return new OwnedBRCryptoNetworkFee(CryptoLibrary.INSTANCE.cryptoNetworkGetNetworkFeeAt(this,
+                new SizeT(index.longValue())));
+    }
+
+    @Override
     public String getUids() {
         return CryptoLibrary.INSTANCE.cryptoNetworkGetUids(this).getString(0, "UTF-8");
     }
@@ -78,6 +89,11 @@ public class BRCryptoNetwork extends PointerType implements CoreBRCryptoNetwork 
     @Override
     public int getType() {
         return CryptoLibrary.INSTANCE.cryptoNetworkGetType(this);
+    }
+
+    @Override
+    public void addFee(CoreBRCryptoNetworkFee fee) {
+        CryptoLibrary.INSTANCE.cryptoNetworkAddNetworkFee(this, fee.asBRCryptoNetworkFee());
     }
 
     @Override

--- a/Java/CoreNative/src/main/java/com/breadwallet/corenative/crypto/BRCryptoNetworkFee.java
+++ b/Java/CoreNative/src/main/java/com/breadwallet/corenative/crypto/BRCryptoNetworkFee.java
@@ -1,0 +1,32 @@
+package com.breadwallet.corenative.crypto;
+
+import com.breadwallet.corenative.CryptoLibrary;
+import com.google.common.primitives.UnsignedLong;
+import com.sun.jna.Pointer;
+import com.sun.jna.PointerType;
+
+public class BRCryptoNetworkFee extends PointerType implements CoreBRCryptoNetworkFee {
+
+    public BRCryptoNetworkFee(Pointer address) {
+        super(address);
+    }
+
+    public BRCryptoNetworkFee() {
+        super();
+    }
+
+    @Override
+    public UnsignedLong getConfirmationTimeInMilliseconds() {
+        return UnsignedLong.valueOf(CryptoLibrary.INSTANCE.cryptoNetworkFeeGetConfirmationTimeInMilliseconds(this));
+    }
+
+    @Override
+    public boolean isIdentical(CoreBRCryptoNetworkFee other) {
+        return BRCryptoBoolean.CRYPTO_TRUE == CryptoLibrary.INSTANCE.cryptoNetworkFeeEqual(this, other.asBRCryptoNetworkFee());
+    }
+
+    @Override
+    public BRCryptoNetworkFee asBRCryptoNetworkFee() {
+        return this;
+    }
+}

--- a/Java/CoreNative/src/main/java/com/breadwallet/corenative/crypto/CoreBRCryptoNetwork.java
+++ b/Java/CoreNative/src/main/java/com/breadwallet/corenative/crypto/CoreBRCryptoNetwork.java
@@ -58,6 +58,10 @@ public interface CoreBRCryptoNetwork {
 
     CoreBRCryptoCurrency getCurrency(UnsignedLong index);
 
+    UnsignedLong getFeeCount();
+
+    CoreBRCryptoNetworkFee getFee(UnsignedLong i);
+
     String getUids();
 
     boolean isMainnet();
@@ -67,6 +71,8 @@ public interface CoreBRCryptoNetwork {
     String getName();
 
     int getType();
+
+    void addFee(CoreBRCryptoNetworkFee fee);
 
     void addCurrency(CoreBRCryptoCurrency currency, CoreBRCryptoUnit baseUnit, CoreBRCryptoUnit defaultUnit);
 

--- a/Java/CoreNative/src/main/java/com/breadwallet/corenative/crypto/CoreBRCryptoNetworkFee.java
+++ b/Java/CoreNative/src/main/java/com/breadwallet/corenative/crypto/CoreBRCryptoNetworkFee.java
@@ -1,0 +1,23 @@
+package com.breadwallet.corenative.crypto;
+
+import com.breadwallet.corenative.CryptoLibrary;
+import com.google.common.primitives.UnsignedLong;
+
+public interface CoreBRCryptoNetworkFee {
+
+    static CoreBRCryptoNetworkFee create(UnsignedLong timeIntervalInMilliseconds,
+                                         CoreBRCryptoAmount pricePerCostFactor,
+                                         CoreBRCryptoUnit pricePerCostFactorUnit) {
+        return new OwnedBRCryptoNetworkFee(
+                CryptoLibrary.INSTANCE.cryptoNetworkFeeCreate(
+                        timeIntervalInMilliseconds.longValue(),
+                        pricePerCostFactor.asBRCryptoAmount(),
+                        pricePerCostFactorUnit.asBRCryptoUnit()));
+    }
+
+    UnsignedLong getConfirmationTimeInMilliseconds();
+
+    boolean isIdentical(CoreBRCryptoNetworkFee fee);
+
+    BRCryptoNetworkFee asBRCryptoNetworkFee();
+}

--- a/Java/CoreNative/src/main/java/com/breadwallet/corenative/crypto/OwnedBRCryptoNetwork.java
+++ b/Java/CoreNative/src/main/java/com/breadwallet/corenative/crypto/OwnedBRCryptoNetwork.java
@@ -62,6 +62,16 @@ class OwnedBRCryptoNetwork implements CoreBRCryptoNetwork {
     }
 
     @Override
+    public UnsignedLong getFeeCount() {
+        return core.getFeeCount();
+    }
+
+    @Override
+    public CoreBRCryptoNetworkFee getFee(UnsignedLong i) {
+        return core.getFee(i);
+    }
+
+    @Override
     public String getUids() {
         return core.getUids();
     }
@@ -84,6 +94,11 @@ class OwnedBRCryptoNetwork implements CoreBRCryptoNetwork {
     @Override
     public int getType() {
         return core.getType();
+    }
+
+    @Override
+    public void addFee(CoreBRCryptoNetworkFee fee) {
+        core.addFee(fee);
     }
 
     @Override

--- a/Java/CoreNative/src/main/java/com/breadwallet/corenative/crypto/OwnedBRCryptoNetworkFee.java
+++ b/Java/CoreNative/src/main/java/com/breadwallet/corenative/crypto/OwnedBRCryptoNetworkFee.java
@@ -1,0 +1,37 @@
+package com.breadwallet.corenative.crypto;
+
+import com.breadwallet.corenative.CryptoLibrary;
+import com.google.common.primitives.UnsignedLong;
+
+class OwnedBRCryptoNetworkFee implements CoreBRCryptoNetworkFee {
+
+    private final BRCryptoNetworkFee core;
+
+    /* package */
+    OwnedBRCryptoNetworkFee(BRCryptoNetworkFee core) {
+        this.core = core;
+    }
+
+    @Override
+    protected void finalize() throws Throwable {
+        super.finalize();
+        if (null != core) {
+            CryptoLibrary.INSTANCE.cryptoNetworkFeeGive(core);
+        }
+    }
+
+    @Override
+    public UnsignedLong getConfirmationTimeInMilliseconds() {
+        return core.getConfirmationTimeInMilliseconds();
+    }
+
+    @Override
+    public boolean isIdentical(CoreBRCryptoNetworkFee fee) {
+        return core.isIdentical(fee);
+    }
+
+    @Override
+    public BRCryptoNetworkFee asBRCryptoNetworkFee() {
+        return core;
+    }
+}

--- a/Java/Crypto/src/main/java/com/breadwallet/crypto/Network.java
+++ b/Java/Crypto/src/main/java/com/breadwallet/crypto/Network.java
@@ -33,6 +33,8 @@ public interface Network {
 
     Set<? extends Currency> getCurrencies();
 
+    List<? extends NetworkFee> getFees();
+
     Optional<? extends Currency> getCurrencyByCode(String code);
 
     List<WalletManagerMode> getSupportedModes();

--- a/Java/Crypto/src/main/java/com/breadwallet/crypto/NetworkFee.java
+++ b/Java/Crypto/src/main/java/com/breadwallet/crypto/NetworkFee.java
@@ -1,0 +1,24 @@
+package com.breadwallet.crypto;
+
+import java.lang.Object;
+
+import com.google.common.primitives.UnsignedLong;
+
+/**
+ * A Network Fee represents the 'amount per cost factor' paid to mine a transfer. For BTC this
+ * amount is 'SAT/kB'; for ETH this amount is 'gasPrice'.  The actual fee for the transfer depends
+ * on properties of the transfer; for BTC, the cost factor is 'size in kB'; for ETH, the cost
+ * factor is 'gas'.
+ *
+ * A Network supports a variety of fees.  Essentially the higher the fee the more enticing the
+ * transfer is to a miner and thus the more quickly the transfer gets into the block chain.
+ *
+ * A NetworkFee implements {@link Object#equals(Object)} on the underlying Core representation.
+ * It is natural to compare NetworkFee based on timeIntervalInMilliseconds.
+ */
+public interface NetworkFee {
+
+    UnsignedLong getConfirmationTimeInMilliseconds();
+
+    boolean equals(Object fee);
+}

--- a/Java/Crypto/src/main/java/com/breadwallet/crypto/WalletManager.java
+++ b/Java/Crypto/src/main/java/com/breadwallet/crypto/WalletManager.java
@@ -9,6 +9,8 @@
  */
 package com.breadwallet.crypto;
 
+import com.google.common.base.Optional;
+
 import java.util.List;
 
 public interface WalletManager {
@@ -44,6 +46,8 @@ public interface WalletManager {
     Unit getBaseUnit();
 
     Unit getDefaultUnit();
+
+    Optional<NetworkFee> getDefaultNetworkFee();
 
     WalletManagerState getState();
 }

--- a/Java/Crypto/src/main/java/com/breadwallet/crypto/blockchaindb/models/bdb/Blockchain.java
+++ b/Java/Crypto/src/main/java/com/breadwallet/crypto/blockchaindb/models/bdb/Blockchain.java
@@ -115,4 +115,8 @@ public class Blockchain {
     public UnsignedLong getBlockHeight() {
         return blockHeight;
     }
+
+    public List<BlockchainFee> getFeeEstimates() {
+        return feeEstimates;
+    }
 }

--- a/Java/Crypto/src/main/java/com/breadwallet/crypto/blockchaindb/models/bdb/BlockchainFee.java
+++ b/Java/Crypto/src/main/java/com/breadwallet/crypto/blockchaindb/models/bdb/BlockchainFee.java
@@ -68,4 +68,16 @@ public class BlockchainFee {
         this.tier = tier;
         this.confirmations = confirmations;
     }
+
+    public String getAmount() {
+        return amount;
+    }
+
+    public String getTier() {
+        return tier;
+    }
+
+    public String getConfirmations() {
+        return confirmations;
+    }
 }

--- a/Swift/BRCrypto/BRCryptoNetwork.swift
+++ b/Swift/BRCrypto/BRCryptoNetwork.swift
@@ -293,6 +293,6 @@ public final class NetworkFee: Equatable {
 
     // Equatable using the Core representation
     public static func == (lhs: NetworkFee, rhs: NetworkFee) -> Bool {
-        return CRYPTO_TRUE == cryptoNetworkEqual (lhs.core, rhs.core)
+        return CRYPTO_TRUE == cryptoNetworkFeeEqual (lhs.core, rhs.core)
     }
 }

--- a/Swift/BRCrypto/BRCryptoNetwork.swift
+++ b/Swift/BRCrypto/BRCryptoNetwork.swift
@@ -34,6 +34,10 @@ public final class Network: CustomStringConvertible {
         set { cryptoNetworkSetHeight (core, newValue) }
     }
 
+    /// The network fees.  Expect the User to select their preferred fee, based on time-to-confirm,
+    /// and then have their preferred fee held in WalletManager.defaultNetworkFee.
+    public let fees: [NetworkFee];
+
     /// The native currency.
     public let currency: Currency
 
@@ -87,6 +91,9 @@ public final class Network: CustomStringConvertible {
         self.currencies = Set ((0..<cryptoNetworkGetCurrencyCount(core))
             .map { cryptoNetworkGetCurrencyAt (core, $0) }
             .map { Currency (core: $0, take: false)})
+        self.fees = Array ((0..<cryptoNetworkGetNetworkFeeCount(core))
+            .map { cryptoNetworkGetNetworkFeeAt (core, $0)}
+            .map { NetworkFee (core: $0, take: false) })
     }
 
     /// Create a Network
@@ -107,7 +114,8 @@ public final class Network: CustomStringConvertible {
                              isMainnet: Bool,
                              currency: Currency,
                              height: UInt64,
-                             associations: Dictionary<Currency, Association>) {
+                             associations: Dictionary<Currency, Association>,
+                             fees: [NetworkFee]) {
         var core: BRCryptoNetwork!
 
         switch currency.code.lowercased() {
@@ -154,6 +162,10 @@ public final class Network: CustomStringConvertible {
                                               currency.core,
                                               $0.core)
             }
+        }
+
+        fees.forEach {
+            cryptoNetworkAddNetworkFee (core, $0.core)
         }
 
         self.init (core: core, take: false)
@@ -232,3 +244,55 @@ public protocol NetworkListener: class {
 
 }
 
+///
+/// A Network Fee represents the 'amount per cost factor' paid to mine a transfer. For BTC this
+/// amount is 'SAT/kB'; for ETH this amount is 'gasPrice'.  The actual fee for the transfer depends
+/// on properties of the transfer; for BTC, the cost factor is 'size in kB'; for ETH, the cost
+/// factor is 'gas'.
+///
+/// A Network supports a variety of fees.  Essentially the higher the fee the more enticing the
+/// transfer is to a miner and thus the more quickly the transfer gets into the block chain.
+///
+/// A NetworkFee is Equatable on the underlying Core representation.  It is natural to compare
+/// NetworkFee based on timeIntervalInMilliseconds
+///
+public final class NetworkFee: Equatable {
+    // The Core representation
+    internal var core: BRCryptoNetworkFee
+
+    /// The estimated time internal for a transaction confirmation.
+    public let timeIntervalInMilliseconds: UInt64
+
+    /// The ammount, as a rate on 'cost factor', to pay in network fees for the desired
+    /// time internal to confirmation.  The 'cost factor' is blockchain specific - for BTC it is
+    /// 'transaction size in kB'; for ETH it is 'gas'.
+    internal let pricePerCostFactor: Amount
+
+    /// Initialize from the Core representation
+    internal init (core: BRCryptoNetworkFee, take: Bool) {
+        self.core = (take ? cryptoNetworkFeeTake(core) : core)
+        self.timeIntervalInMilliseconds = cryptoNetworkFeeGetConfirmationTimeInMilliseconds(core)
+        self.pricePerCostFactor = Amount (core: cryptoNetworkFeeGetPricePerCostFactor (core),
+                                          unit: Unit (core: cryptoNetworkFeeGetPricePerCostFactorUnit(core), take: false),
+                                          take: false)
+    }
+
+    /// Initialize based on the timeInternal and pricePerCostFactor.  Used by BlockchainDB when
+    /// parsing a NetworkFee from BlockchainDB.Model.BlockchainFee
+    internal convenience init (timeInternalInMilliseconds: UInt64,
+                               pricePerCostFactor: Amount) {
+        self.init (core: cryptoNetworkFeeCreate (timeInternalInMilliseconds,
+                                                 pricePerCostFactor.core,
+                                                 pricePerCostFactor.unit.core),
+                   take: false)
+    }
+
+    deinit {
+        cryptoNetworkFeeGive (core)
+    }
+
+    // Equatable using the Core representation
+    public static func == (lhs: NetworkFee, rhs: NetworkFee) -> Bool {
+        return CRYPTO_TRUE == cryptoNetworkEqual (lhs.core, rhs.core)
+    }
+}

--- a/Swift/BRCrypto/BRCryptoWallet.swift
+++ b/Swift/BRCrypto/BRCryptoWallet.swift
@@ -132,8 +132,8 @@ public final class Wallet: Equatable {
     /// - Returns: A new transfer
     ///
     public func createTransfer (target: Address,
-                         amount: Amount,
-                         feeBasis: TransferFeeBasis) -> Transfer? {
+                                amount: Amount,
+                                feeBasis: TransferFeeBasis) -> Transfer? {
         return cryptoWalletCreateTransfer (core, target.core, amount.core, feeBasis.core)
             .map { Transfer (core: $0,
                              wallet: self,

--- a/Swift/BRCrypto/BRCryptoWalletManager.swift
+++ b/Swift/BRCrypto/BRCryptoWalletManager.swift
@@ -109,6 +109,8 @@ public final class WalletManager: Equatable {
                           take: true))
     }
 
+    public var defaultNetworkFee: NetworkFee? = nil
+
     /// The default WalletFactory for creating wallets.
     //    var walletFactory: WalletFactory { get set }
 

--- a/Swift/BRCrypto/common/BRBlockChainDB.swift
+++ b/Swift/BRCrypto/common/BRBlockChainDB.swift
@@ -208,7 +208,7 @@ public class BlockChainDB {
 
         /// Blockchain
 
-        public typealias BlockchainFee = (amount: String, tier: String, confirmations: String)
+        public typealias BlockchainFee = (amount: String, tier: String, confirmations: String) // currency?
         public typealias Blockchain = (
             id: String,
             name: String,

--- a/Swift/BRCryptoTests/BRBlockChainDBTest.swift
+++ b/Swift/BRCryptoTests/BRBlockChainDBTest.swift
@@ -193,9 +193,10 @@ class BRBlockChainDBTest: XCTestCase {
                             includeRaw: true) {
                                 (res: Result<[BlockChainDB.Model.Transaction], BlockChainDB.QueryError>) in
                                 // A 'status' 400
-                                guard case .failure = res
+                                guard case let .success(transactions) = res
                                     else { XCTAssert(false); return }
 
+                                XCTAssert(transactions.isEmpty)
                                 self.expectation.fulfill()
         }
 

--- a/Swift/BRCryptoTests/BRCryptoAccountTests.swift
+++ b/Swift/BRCryptoTests/BRCryptoAccountTests.swift
@@ -50,7 +50,8 @@ class BRCryptoAccountTests: XCTestCase {
                                isMainnet: true,
                                currency: eth,
                                height: 100000,
-                               associations: [:])
+                               associations: [:],
+                               fees: [])
 
         let e1 = Address.create (string: "0xb0F225defEc7625C6B5E43126bdDE398bD90eF62", network: network)
         let e2 = Address.create (string: "0xd3CFBA03Fc13dc01F0C67B88CBEbE776D8F3DE8f", network: network)
@@ -78,7 +79,8 @@ class BRCryptoAccountTests: XCTestCase {
                                isMainnet: true,
                                currency: btc,
                                height: 100000,
-                               associations: [:])
+                               associations: [:],
+                               fees: [])
 
         let b1 = Address.create (string: "1CC3X2gu58d6wXUWMffpuzN9JAfTUWu4Kj", network: network)
 

--- a/Swift/BRCryptoTests/BRCryptoNetworkTests.swift
+++ b/Swift/BRCryptoTests/BRCryptoNetworkTests.swift
@@ -29,12 +29,16 @@ class BRCryptoNetworkTests: XCTestCase {
                                                 defaultUnit: BTC_BTC,
                                                 units: Set (arrayLiteral: BTC_SATOSHI, BTC_BTC))
 
+        let fee = NetworkFee (timeInternalInMilliseconds: 30 * 1000,
+                              pricePerCostFactor: Amount.create(integer: 1000, unit: BTC_SATOSHI))
+
         let network = Network (uids: "bitcoin-mainnet",
                                name: "bitcoin-name",
                                isMainnet: true,
                                currency: btc,
                                height: 100000,
-                               associations: [btc:associations])
+                               associations: [btc:associations],
+                               fees: [fee])
 
         XCTAssertEqual (network.uids, "bitcoin-mainnet")
         XCTAssertEqual (network.name, "bitcoin-name")
@@ -65,6 +69,8 @@ class BRCryptoNetworkTests: XCTestCase {
         XCTAssertFalse (network.hasUnitFor(currency: eth, unit: ETH_WEI) ?? false)
         XCTAssertFalse (network.hasUnitFor(currency: eth, unit: BTC_BTC) ?? false)
         XCTAssertFalse (network.hasUnitFor(currency: btc, unit: ETH_WEI) ?? false)
+
+        XCTAssertEqual(1, network.fees.count)
     }
 
     func testNetworkETH () {
@@ -84,7 +90,8 @@ class BRCryptoNetworkTests: XCTestCase {
                                isMainnet: true,
                                currency: eth,
                                height: 100000,
-                               associations: [eth:associations])
+                               associations: [eth:associations],
+                               fees: [])
 
         XCTAssertTrue  (network.hasCurrency(eth))
         XCTAssertFalse (network.hasCurrency(btc))

--- a/crypto/BRCryptoNetwork.c
+++ b/crypto/BRCryptoNetwork.c
@@ -76,7 +76,7 @@ cryptoNetworkFeeGetPricePerCostFactorUnit (BRCryptoNetworkFee networkFee) {
 }
 
 extern BRCryptoBoolean
-cryptoNetworkEqual (BRCryptoNetworkFee nf1, BRCryptoNetworkFee nf2) {
+cryptoNetworkFeeEqual (BRCryptoNetworkFee nf1, BRCryptoNetworkFee nf2) {
     return AS_CRYPTO_BOOLEAN (nf1 == nf2 ||
                               (nf1->confirmationTimeInMilliseconds == nf2->confirmationTimeInMilliseconds) &&
                               CRYPTO_COMPARE_EQ == cryptoAmountCompare (nf1->pricePerCostFactor, nf2->pricePerCostFactor));

--- a/crypto/BRCryptoNetwork.c
+++ b/crypto/BRCryptoNetwork.c
@@ -84,9 +84,11 @@ cryptoNetworkEqual (BRCryptoNetworkFee nf1, BRCryptoNetworkFee nf2) {
 
 static void
 cryptoNetworkFeeRelease (BRCryptoNetworkFee networkFee) {
-    printf ("Network Fpp: Release\n");
+    printf ("Network Fee: Release\n");
 
     cryptoAmountGive (networkFee->pricePerCostFactor);
+    cryptoUnitGive   (networkFee->pricePerCostFactorUnit);
+
     free (networkFee);
 }
 
@@ -450,7 +452,7 @@ cryptoNetworkAddCurrencyUnit (BRCryptoNetwork network,
 private_extern void
 cryptoNetworkAddNetworkFee (BRCryptoNetwork network,
                             BRCryptoNetworkFee fee) {
-    array_add (network->fees, fee);
+    array_add (network->fees, cryptoNetworkFeeTake (fee));
 }
 
 extern size_t

--- a/crypto/BRCryptoNetwork.h
+++ b/crypto/BRCryptoNetwork.h
@@ -26,14 +26,39 @@
 #ifndef BRCryptoNetwork_h
 #define BRCryptoNetwork_h
 
-#include "BRCryptoCurrency.h"
-#include "BRCryptoUnit.h"
+#include "BRCryptoAmount.h"
 
 #include "../support/BRArray.h"
 
 #ifdef __cplusplus
 extern "C" {
 #endif
+
+    /**
+     *
+     */
+    typedef struct BRCryptoNetworkFeeRecord *BRCryptoNetworkFee;
+
+    /**
+     * The estimated time to confirm a transfer for this network fee
+     *
+     * @param networkFee the network fee
+     *
+     * @return time in milliseconds
+     */
+    extern uint64_t
+    cryptoNetworkFeeGetConfirmationTimeInMilliseconds (BRCryptoNetworkFee networkFee);
+
+    extern BRCryptoAmount
+    cryptoNetworkFeeGetPricePerCostFactor (BRCryptoNetworkFee networkFee);
+
+    extern BRCryptoUnit
+    cryptoNetworkFeeGetPricePerCostFactorUnit (BRCryptoNetworkFee networkFee);
+
+    extern BRCryptoBoolean
+    cryptoNetworkEqual (BRCryptoNetworkFee nf1, BRCryptoNetworkFee nf2);
+
+    DECLARE_CRYPTO_GIVE_TAKE (BRCryptoNetworkFee, cryptoNetworkFee);
 
     /**
      * A Crypto Network represents a Blockchain.  The blockchains are determined from the
@@ -197,6 +222,13 @@ extern "C" {
     cryptoNetworkGetUnitAt (BRCryptoNetwork network,
                             BRCryptoCurrency currency,
                             size_t index);
+
+    extern size_t
+    cryptoNetworkGetNetworkFeeCount (BRCryptoNetwork network);
+
+    extern BRCryptoNetworkFee
+    cryptoNetworkGetNetworkFeeAt (BRCryptoNetwork network,
+                                  size_t index);
 
     DECLARE_CRYPTO_GIVE_TAKE (BRCryptoNetwork, cryptoNetwork);
 

--- a/crypto/BRCryptoNetwork.h
+++ b/crypto/BRCryptoNetwork.h
@@ -56,7 +56,7 @@ extern "C" {
     cryptoNetworkFeeGetPricePerCostFactorUnit (BRCryptoNetworkFee networkFee);
 
     extern BRCryptoBoolean
-    cryptoNetworkEqual (BRCryptoNetworkFee nf1, BRCryptoNetworkFee nf2);
+    cryptoNetworkFeeEqual (BRCryptoNetworkFee nf1, BRCryptoNetworkFee nf2);
 
     DECLARE_CRYPTO_GIVE_TAKE (BRCryptoNetworkFee, cryptoNetworkFee);
 

--- a/crypto/BRCryptoPrivate.h
+++ b/crypto/BRCryptoPrivate.h
@@ -218,6 +218,12 @@ extern "C" {
     cryptoTransferHasGEN (BRCryptoTransfer transfer,
                           BRGenericTransfer gen);
 
+    /// MARK: - Network Fee
+    private_extern BRCryptoNetworkFee
+    cryptoNetworkFeeCreate (uint64_t confirmationTimeInMilliseconds,
+                            BRCryptoAmount pricePerCostFactor,
+                            BRCryptoUnit   pricePerCostFactorUnit);
+    
     /// MARK: - Network
 
     private_extern void
@@ -242,6 +248,10 @@ extern "C" {
                                   BRCryptoCurrency currency,
                                   BRCryptoUnit unit);
 
+    private_extern void
+    cryptoNetworkAddNetworkFee (BRCryptoNetwork network,
+                                BRCryptoNetworkFee fee);
+    
     private_extern BREthereumNetwork
     cryptoNetworkAsETH (BRCryptoNetwork network);
 


### PR DESCRIPTION
Derive from BlockchainDB `fee_estimates`.  Keep an (unsorted) array in `Network`; allow for saving a default in `WalletManager`.

Does not yet propagate to `Wallet.createTransfer`.
