### PR TITLE
Fix eth testnet network name

### DIFF
--- a/Swift/BRCrypto/common/BRBlockChainDB.swift
+++ b/Swift/BRCrypto/common/BRBlockChainDB.swift
@@ -266,7 +266,7 @@ public class BlockChainDB {
              feeEstimates: [(amount: "30", tier: "10m", confirmations: "")]),
             (id: "bitcoin-cash-testnet",  name: "Bitcoin Cash Test", network: "testnet", isMainnet: false, currency: "bch", blockHeight: 1200000,
              feeEstimates: [(amount: "30", tier: "10m", confirmations: "")]),
-            (id: "ethereum-testnet",      name: "Ethereum Testnet",  network: "testnet", isMainnet: false, currency: "eth", blockHeight: 1000000,
+            (id: "ethereum-testnet",      name: "Ethereum Testnet",  network: "ropsten", isMainnet: false, currency: "eth", blockHeight: 1000000,
              feeEstimates: [(amount: "2000000000", tier: "1m", confirmations: "")]),
             (id: "ethereum-rinkeby",      name: "Ethereum Rinkeby",  network: "rinkeby", isMainnet: false, currency: "eth", blockHeight: 2000000,
              feeEstimates: [(amount: "2000000000", tier: "1m", confirmations: "")]),


### PR DESCRIPTION
A blockchain's network string is used to generate ethquery urls. Currently, the urls are: `/ethq/testnet/query`, but they should be `/ethq/ropsten/query`. 