### PR TITLE
CORE-448: Use BRKey determined compressed flag in Crypto Key interfaces

### DIFF
--- a/Swift/BRCrypto/common/BRCryptoKey.swift
+++ b/Swift/BRCrypto/common/BRCryptoKey.swift
@@ -40,7 +40,7 @@ public final class Key {
 
             BRKeySetPrivKey (&key, strPtr)
 
-            return Key (core: key, needPublicKey: true, compressedPublicKey: false)
+            return Key (core: key, needPublicKey: true)
         }
     }
 
@@ -56,7 +56,7 @@ public final class Key {
 
 
             return (1 == BRKeySetPubKey (&key, dataAddr, dataCount)
-                ? Key (core: key, needPublicKey: false, compressedPublicKey: false)
+                ? Key (core: key, needPublicKey: false)
                 : nil)
         }
     }
@@ -72,7 +72,7 @@ public final class Key {
 
             BRKeyPigeonPairingKey (&privateKey, &pairingKey, nonceAddr, nonce.count)
 
-            return Key (core: pairingKey, needPublicKey: true, compressedPublicKey: false)
+            return Key (core: pairingKey, needPublicKey: true)
         }
     }
 
@@ -100,7 +100,7 @@ public final class Key {
         //        guard pkData.withUnsafeMutableBytes({ BRKeyPrivKey(&key, $0.baseAddress?.assumingMemoryBound(to: Int8.self), pkLen) }) == pkLen else { return nil }
         //        key.clean()
 
-        return Key (core: key, needPublicKey: true, compressedPublicKey: false)
+        return Key (core: key, needPublicKey: true)
     }
 
     static public func createForBIP32BitID (phrase: String, index: Int, uri:String, words: [String]? = wordList) -> Key? {
@@ -118,7 +118,7 @@ public final class Key {
         BRBIP32BitIDKey (&key, &seed, MemoryLayout<UInt512>.size, UInt32(index), uri)
         defer { BRKeyClean (&key) }
 
-        return Key (core: key, needPublicKey: true, compressedPublicKey: false)
+        return Key (core: key, needPublicKey: true)
     }
 
     // The Core representation
@@ -171,12 +171,10 @@ public final class Key {
     ///
     /// - Parameter core: The Core representaion
     ///
-    internal init (core: BRKey, needPublicKey: Bool, compressedPublicKey: Bool) {
+    internal init (core: BRKey, needPublicKey: Bool) {
         self.core = core
 
         if needPublicKey {
-            // Uncompressed; Ensure that the public key is provided
-            BRKeySetCompressed (&self.core, (compressedPublicKey ? 1 : 0))
             BRKeyPubKey (&self.core, nil, 0)
         }
     }
@@ -194,7 +192,7 @@ public final class Key {
         defer { secret = UInt256() }
 
         BRKeySetSecret (&core, &secret, 1)
-        self.init (core: core, needPublicKey: true, compressedPublicKey: false)
+        self.init (core: core, needPublicKey: true)
     }
 
     ///

--- a/Swift/BRCrypto/common/BRCryptoKey.swift
+++ b/Swift/BRCrypto/common/BRCryptoKey.swift
@@ -30,7 +30,7 @@ public final class Key {
     }
 
     static public func createFromSerialization (asPrivate data: Data) -> Key? {
-        let str = String (data: data, encoding: .utf8)!
+        guard let str = String (data: data, encoding: .utf8) else { return nil }
 
         return str.withCString { (strPtr: UnsafePointer<Int8>) -> Key? in
             guard 1 == BRPrivKeyIsValid (strPtr) else { return nil }

--- a/Swift/BRCrypto/common/BRCryptoKey.swift
+++ b/Swift/BRCrypto/common/BRCryptoKey.swift
@@ -132,37 +132,17 @@ public final class Key {
 
     // Serialization - Public Key
 
-    public enum PublicEncoding {
-        case derCompressed
-        case derUncompressed
-    }
-
-    public func serialize (asPublic: PublicEncoding) -> Data {
-        switch asPublic {
-        case .derCompressed:
-            return serializePublicKeyDER (key: self.core, compressed: true)
-
-        case .derUncompressed:
-            return serializePublicKeyDER (key: self.core, compressed: false)
-        }
+    public func serializeAsPublic (compressed override: Bool? = nil) -> Data {
+        let compressed = override ?? (self.core.compressed == 1)
+        return serializePublicKeyDER (key: self.core, compressed: compressed)
     }
 
     // Serialization - Private Key
 
-    public enum PrivateEncoding {
-        case wifCompressed
-        case wifUncompressed
-    }
-
-    public func serialize (asPrivate: PrivateEncoding) -> Data? {
+    public func serializeAsPrivate (compressed override: Bool? = nil) -> Data? {
         guard hasSecret else { return nil }
-        switch asPrivate {
-        case .wifCompressed:
-            return serializePrivateKeyWIF (key: core, compressed: true)
-
-        case .wifUncompressed:
-            return serializePrivateKeyWIF (key: core, compressed: false)
-        }
+        let compressed = override ?? (self.core.compressed == 1)
+        return serializePrivateKeyWIF (key: core, compressed: compressed)
     }
 
     ///

--- a/Swift/BRCrypto/common/BRCryptoSigner.swift
+++ b/Swift/BRCrypto/common/BRCryptoSigner.swift
@@ -108,7 +108,7 @@ public enum CoreSigner: Signer {
                     var key = BRKey.self.init()
                     let signatureAddr  = signatureBytes.baseAddress?.assumingMemoryBound(to: UInt8.self)
                     let success: Bool = 1 == BRKeyRecoverPubKey (&key, digestUInt256, signatureAddr, signatureCount)
-                    return success ? Key (core: key, needPublicKey: false, compressedPublicKey: false) : nil
+                    return success ? Key (core: key, needPublicKey: false) : nil
                 }
             }
         }

--- a/Swift/BRCryptoTests/BRCryptoCommonTests.swift
+++ b/Swift/BRCryptoTests/BRCryptoCommonTests.swift
@@ -28,11 +28,12 @@ class BRCryptoCommonTests: XCTestCase {
         d = "5Kb8kLf9zgWQnogidDA76MzPL6TsZZY36hWXMssSzNydYXYB9KF".data(using: .utf8)!
         k = Key.createFromSerialization(asPrivate: d)
         XCTAssertNotNil(k)
-        XCTAssertEqual (d, k.serialize(asPrivate: Key.PrivateEncoding.wifUncompressed))
-        XCTAssertNotEqual (d, k.serialize(asPrivate: Key.PrivateEncoding.wifCompressed))
+        XCTAssertEqual (d, k.serializeAsPrivate ())
+        XCTAssertEqual (d, k.serializeAsPrivate (compressed: false))
+        XCTAssertNotEqual (d, k.serializeAsPrivate (compressed: true))
 
         // serialize public key - uncompressed
-        d = k.serialize(asPublic: Key.PublicEncoding.derUncompressed)
+        d = k.serializeAsPublic (compressed: false)
         XCTAssertNotNil(d)
 
         // create a 'public key' and check for match with private key's public key
@@ -41,7 +42,7 @@ class BRCryptoCommonTests: XCTestCase {
         XCTAssertTrue (k.publicKeyMatch(kpub))
 
         // serialize public key - compressed
-        d = k.serialize(asPublic: Key.PublicEncoding.derCompressed)
+        d = k.serializeAsPublic (compressed: true)
         XCTAssertNotNil(d)
 
         // TODO: Fix 'public key from compressed'
@@ -56,11 +57,12 @@ class BRCryptoCommonTests: XCTestCase {
         d = "KyvGbxRUoofdw3TNydWn2Z78dBHSy2odn1d3wXWN2o3SAtccFNJL".data(using: .utf8)!
         k = Key.createFromSerialization(asPrivate: d)
         XCTAssertNotNil(k)
-        XCTAssertEqual (d, k.serialize(asPrivate: Key.PrivateEncoding.wifCompressed))
-        XCTAssertNotEqual (d, k.serialize(asPrivate: Key.PrivateEncoding.wifUncompressed))
+        XCTAssertEqual (d, k.serializeAsPrivate ())
+        XCTAssertEqual (d, k.serializeAsPrivate (compressed: true))
+        XCTAssertNotEqual (d, k.serializeAsPrivate (compressed: false))
 
         // serialize public key - uncompressed
-        d = k.serialize(asPublic: Key.PublicEncoding.derUncompressed)
+        d = k.serializeAsPublic (compressed: false)
         XCTAssertNotNil(d)
 
         // create a 'public key' and check for match with private key's public key
@@ -69,7 +71,7 @@ class BRCryptoCommonTests: XCTestCase {
         XCTAssertTrue (k.publicKeyMatch(kpub))
 
         // serialize public key - compressed
-        d = k.serialize(asPublic: Key.PublicEncoding.derCompressed)
+        d = k.serializeAsPublic (compressed: true)
         XCTAssertNotNil(d)
 
         // TODO: Fix 'public key from compressed'


### PR DESCRIPTION
In Crypto Key Swift interfaces:
- remove compressed parameter from factory methods, let `BRKey` derivation method determine the value
- make compressed parameter optional in serialization interfaces, use `BRKey` internal value if an override value is not specified
