### PR TITLE
CORE-450: Use ethq/ropsten/query in JSON RPC requests.

### DIFF
--- a/Java/Crypto/src/main/java/com/breadwallet/crypto/blockchaindb/apis/brd/BrdApiClient.java
+++ b/Java/Crypto/src/main/java/com/breadwallet/crypto/blockchaindb/apis/brd/BrdApiClient.java
@@ -62,21 +62,21 @@ public class BrdApiClient {
 
     /* package */
     void sendJsonRequest(String networkName, JSONObject json, CompletionHandler<String, QueryError> handler) {
-        makeAndSendRequest(Arrays.asList("ethq", networkName, "proxy"), ImmutableMultimap.of(), json, "POST",
+        makeAndSendRequest(Arrays.asList("ethq", getNetworkName(networkName), "proxy"), ImmutableMultimap.of(), json, "POST",
                 new EmbeddedStringHandler(handler));
     }
 
     /* package */
     void sendQueryRequest(String networkName, Multimap<String, String> params, JSONObject json,
                           CompletionHandler<String, QueryError> handler) {
-        makeAndSendRequest(Arrays.asList("ethq", networkName, "query"), params, json, "POST",
+        makeAndSendRequest(Arrays.asList("ethq", getNetworkName(networkName), "query"), params, json, "POST",
                 new EmbeddedStringHandler(handler));
     }
 
     /* package */
     <T> void sendQueryForArrayRequest(String networkName, Multimap<String, String> params, JSONObject json,
                                       ArrayResponseParser<T> parser, CompletionHandler<T, QueryError> handler) {
-        makeAndSendRequest(Arrays.asList("ethq", networkName, "query"), params, json, "POST",
+        makeAndSendRequest(Arrays.asList("ethq", getNetworkName(networkName), "query"), params, json, "POST",
                 new EmbeddedArrayHandler<T>(parser, handler));
     }
 
@@ -84,6 +84,11 @@ public class BrdApiClient {
     <T> void sendTokenRequest(ArrayResponseParser<T> parser, CompletionHandler<T, QueryError> handler) {
         makeAndSendRequest(Collections.singletonList("currencies"), ImmutableMultimap.of("type", "erc20"), null, "GET",
                 new RootArrayHandler<T>(parser, handler));
+    }
+
+    private String getNetworkName(String networkName) {
+        networkName = networkName.toLowerCase();
+        return networkName.equals("testnet") ? "ropsten" : networkName;
     }
 
     private <T> void makeAndSendRequest(List<String> pathSegments,

--- a/Swift/BRCrypto/common/BRBlockChainDB.swift
+++ b/Swift/BRCrypto/common/BRBlockChainDB.swift
@@ -1565,10 +1565,15 @@ public class BlockChainDB {
         }
     }
 
+    private func apiGetNetworkName (_ name: String) -> String {
+        let name = name.lowercased()
+        return name == "testnet" ? "ropsten" : name
+    }
+    
     internal func apiMakeRequestJSON (network: String,
                                       data: JSON.Dict,
                                       completion: @escaping (Result<JSON, QueryError>) -> Void) {
-        let path = "/ethq/\(network.lowercased())/proxy"
+        let path = "/ethq/\(apiGetNetworkName(network))/proxy"
         makeRequest (apiDataTaskFunc, apiBaseURL,
                      path: path,
                      query: nil,
@@ -1582,7 +1587,7 @@ public class BlockChainDB {
                                        query: Zip2Sequence<[String],[String]>?,
                                        data: JSON.Dict,
                                        completion: @escaping (Result<JSON, QueryError>) -> Void) {
-        let path = "/ethq/\(network.lowercased())/query"
+        let path = "/ethq/\(apiGetNetworkName(network))/query"
         makeRequest (apiDataTaskFunc, apiBaseURL,
                      path: path,
                      query: query,


### PR DESCRIPTION
Needs Java update - are API ethq/testnet/proxy requests working?  It should be ethq/ropsten/proxy where 'ropsten' is an alternate name for 'testnet'.  We use 'testnet' throughout; the API needs 'ropsten' - thus I only changed the HTTP query path.