### PR TITLE
CORE-451: Add CryptoKey in Java

### DIFF
--- a/Java/CoreCrypto/src/androidTest/java/com/breadwallet/corecrypto/KeyAIT.java
+++ b/Java/CoreCrypto/src/androidTest/java/com/breadwallet/corecrypto/KeyAIT.java
@@ -1,0 +1,56 @@
+package com.breadwallet.corecrypto;
+
+import com.google.common.base.Optional;
+
+import org.junit.Test;
+
+import java.nio.charset.StandardCharsets;
+
+import static org.junit.Assert.*;
+
+public class KeyAIT {
+
+    @Test
+    public void testKey() {
+        byte[] s;
+        byte[] t;
+        Optional<Key> k;
+        Optional<Key> l;
+
+        //
+        // Uncompressed
+        //
+
+        s = "5Kb8kLf9zgWQnogidDA76MzPL6TsZZY36hWXMssSzNydYXYB9KF".getBytes(StandardCharsets.UTF_8);
+        k = Key.createFromPrivateKeyString(s);
+        assertTrue(k.isPresent());
+        assertTrue(k.get().hasSecret());
+        assertArrayEquals(s, k.get().encodeAsPrivate());
+
+        //
+        // Compressed
+        //
+
+        s = "KyvGbxRUoofdw3TNydWn2Z78dBHSy2odn1d3wXWN2o3SAtccFNJL".getBytes(StandardCharsets.UTF_8);
+        k = Key.createFromPrivateKeyString(s);
+        assertTrue(k.isPresent());
+        assertTrue(k.get().hasSecret());
+        assertArrayEquals(s, k.get().encodeAsPrivate());
+
+        t = k.get().encodeAsPublic();
+        l = Key.createFromPublicKeyString(t);
+        assertTrue(l.isPresent());
+        assertFalse(l.get().hasSecret());
+        assertArrayEquals(t, l.get().encodeAsPublic());
+
+        assertTrue (l.get().publicKeyMatch(k.get()));
+
+        //
+        // Bad Key
+        //
+
+        s = "XyvGbxRUoofdw3TNydWn2Z78dBHSy2odn1d3wXWN2o3SAtccFNJL".getBytes(StandardCharsets.UTF_8);
+        k = Key.createFromPrivateKeyString(s);
+        assertFalse(k.isPresent());
+    }
+}

--- a/Java/CoreCrypto/src/main/java/com/breadwallet/corecrypto/CryptoApiProvider.java
+++ b/Java/CoreCrypto/src/main/java/com/breadwallet/corecrypto/CryptoApiProvider.java
@@ -76,6 +76,37 @@ public final class CryptoApiProvider implements CryptoApi.Provider {
         }
     };
 
+    private static final CryptoApi.PrimitivesProvider primitivesProvider = new CryptoApi.PrimitivesProvider() {
+        @Override
+        public Optional<com.breadwallet.crypto.Key> createFromPhrase(byte[] phraseUtf8, List<String> words) {
+            return Key.createFromPhrase(phraseUtf8, words).transform(a -> a);
+        }
+
+        @Override
+        public Optional<com.breadwallet.crypto.Key> createFromPrivateKeyString(byte[] keyStringUtf8) {
+            return Key.createFromPrivateKeyString(keyStringUtf8).transform(a -> a);
+        }
+
+        @Override
+        public Optional<com.breadwallet.crypto.Key> createFromPublicKeyString(byte[] keyStringUtf8) {
+            return Key.createFromPublicKeyString(keyStringUtf8).transform(a -> a);
+        }
+
+        public Optional<com.breadwallet.crypto.Key> createForPigeon(com.breadwallet.crypto.Key key, byte[] nonce) {
+            return Key.createForPigeon(key, nonce).transform(a -> a);
+        }
+
+        @Override
+        public Optional<com.breadwallet.crypto.Key> createForBIP32ApiAuth(byte[] phraseUtf8, List<String> words) {
+            return Key.createForBIP32ApiAuth(phraseUtf8, words).transform(a -> a);
+        }
+
+        @Override
+        public Optional<com.breadwallet.crypto.Key> createForBIP32BitID(byte[] phraseUtf8, int index, String uri, List<String> words) {
+            return Key.createForBIP32BitID(phraseUtf8, index, uri, words).transform(a -> a);
+        }
+    };
+
     private CryptoApiProvider() {
 
     }
@@ -93,5 +124,10 @@ public final class CryptoApiProvider implements CryptoApi.Provider {
     @Override
     public CryptoApi.SystemProvider systemProvider() {
         return systemProvider;
+    }
+
+    @Override
+    public CryptoApi.PrimitivesProvider primitivesProvider() {
+        return primitivesProvider;
     }
 }

--- a/Java/CoreCrypto/src/main/java/com/breadwallet/corecrypto/Key.java
+++ b/Java/CoreCrypto/src/main/java/com/breadwallet/corecrypto/Key.java
@@ -55,6 +55,7 @@ final class Key implements com.breadwallet.crypto.Key {
 
     private Key(BRCryptoKey core) {
         this.core = core;
+        this.core.providePublicKey(0, 0);
     }
 
     @Override
@@ -79,13 +80,11 @@ final class Key implements com.breadwallet.crypto.Key {
 
     @Override
     public boolean privateKeyMatch(com.breadwallet.crypto.Key other) {
-        Key cryptoKey = from(other);
-        return core.privateKeyMatch(cryptoKey.core);
+        return core.privateKeyMatch(from(other).core);
     }
 
     @Override
     public boolean publicKeyMatch(com.breadwallet.crypto.Key other) {
-        Key cryptoKey = from(other);
-        return core.publicKeyMatch(cryptoKey.core);
+        return core.publicKeyMatch(from(other).core);
     }
 }

--- a/Java/CoreCrypto/src/main/java/com/breadwallet/corecrypto/Key.java
+++ b/Java/CoreCrypto/src/main/java/com/breadwallet/corecrypto/Key.java
@@ -59,11 +59,6 @@ final class Key implements com.breadwallet.crypto.Key {
     }
 
     @Override
-    public boolean hasSecret() {
-        return core.hasSecret();
-    }
-
-    @Override
     public byte[] encodeAsPrivate() {
         return core.encodeAsPrivate();
     }
@@ -71,6 +66,11 @@ final class Key implements com.breadwallet.crypto.Key {
     @Override
     public byte[] encodeAsPublic() {
         return core.encodeAsPublic();
+    }
+
+    @Override
+    public boolean hasSecret() {
+        return core.hasSecret();
     }
 
     @Override

--- a/Java/CoreCrypto/src/main/java/com/breadwallet/corecrypto/Key.java
+++ b/Java/CoreCrypto/src/main/java/com/breadwallet/corecrypto/Key.java
@@ -1,0 +1,91 @@
+package com.breadwallet.corecrypto;
+
+import com.breadwallet.corenative.crypto.BRCryptoKey;
+import com.google.common.base.Optional;
+
+import java.util.List;
+
+/* package */
+final class Key implements com.breadwallet.crypto.Key {
+
+    /* package */
+    static Optional<Key> createFromPhrase(byte[] phraseUtf8, List<String> words) {
+        return BRCryptoKey.createFromPhrase(phraseUtf8, words).transform(Key::new);
+    }
+
+    /* package */
+    static Optional<Key> createFromPrivateKeyString(byte[] privateData) {
+        return BRCryptoKey.createFromPrivateKeyString(privateData).transform(Key::new);
+    }
+
+    /* package */
+    static Optional<Key> createFromPublicKeyString(byte[] publicData) {
+        return BRCryptoKey.createFromPublicKeyString(publicData).transform(Key::new);
+    }
+
+    /* package */
+    static Optional<Key> createForPigeon(com.breadwallet.crypto.Key key, byte[] nonce) {
+        return BRCryptoKey.createForPigeon(from(key).core, nonce).transform(Key::new);
+    }
+
+    /* package */
+    static Optional<Key> createForBIP32ApiAuth(byte[] phraseUtf8, List<String> words) {
+        return BRCryptoKey.createForBIP32ApiAuth(phraseUtf8, words).transform(Key::new);
+    }
+
+    /* package */
+    static Optional<Key> createForBIP32BitID(byte[] phraseUtf8, int index, String uri, List<String> words) {
+        return BRCryptoKey.createForBIP32BitID(phraseUtf8, index, uri, words).transform(Key::new);
+    }
+
+    /* package */
+    static Key create(BRCryptoKey core) {
+        return new Key(core);
+    }
+
+    /* package */
+    static Key from(com.breadwallet.crypto.Key key) {
+        if (key instanceof Key) {
+            return (Key) key;
+        }
+        throw new IllegalArgumentException("Unsupported key instance");
+    }
+
+    private final BRCryptoKey core;
+
+    private Key(BRCryptoKey core) {
+        this.core = core;
+    }
+
+    @Override
+    public boolean hasSecret() {
+        return core.hasSecret();
+    }
+
+    @Override
+    public byte[] encodeAsPrivate() {
+        return core.encodeAsPrivate();
+    }
+
+    @Override
+    public byte[] encodeAsPublic() {
+        return core.encodeAsPublic();
+    }
+
+    @Override
+    public byte[] getSecret() {
+        return core.getSecret();
+    }
+
+    @Override
+    public boolean privateKeyMatch(com.breadwallet.crypto.Key other) {
+        Key cryptoKey = from(other);
+        return core.privateKeyMatch(cryptoKey.core);
+    }
+
+    @Override
+    public boolean publicKeyMatch(com.breadwallet.crypto.Key other) {
+        Key cryptoKey = from(other);
+        return core.publicKeyMatch(cryptoKey.core);
+    }
+}

--- a/Java/CoreNative/CMakeLists.txt
+++ b/Java/CoreNative/CMakeLists.txt
@@ -296,6 +296,8 @@ target_sources (crypto
                 src/main/cpp/core/crypto/BRCryptoFeeBasis.h
                 src/main/cpp/core/crypto/BRCryptoHash.c
                 src/main/cpp/core/crypto/BRCryptoHash.h
+                src/main/cpp/core/crypto/BRCryptoKey.c
+                src/main/cpp/core/crypto/BRCryptoKey.h
                 src/main/cpp/core/crypto/BRCryptoNetwork.c
                 src/main/cpp/core/crypto/BRCryptoNetwork.h
                 src/main/cpp/core/crypto/BRCryptoPrivate.h

--- a/Java/CoreNative/src/main/java/com/breadwallet/corenative/CryptoLibrary.java
+++ b/Java/CoreNative/src/main/java/com/breadwallet/corenative/CryptoLibrary.java
@@ -16,6 +16,7 @@ import com.breadwallet.corenative.crypto.BRCryptoCWMClientCallbackState;
 import com.breadwallet.corenative.crypto.BRCryptoCurrency;
 import com.breadwallet.corenative.crypto.BRCryptoFeeBasis;
 import com.breadwallet.corenative.crypto.BRCryptoHash;
+import com.breadwallet.corenative.crypto.BRCryptoKey;
 import com.breadwallet.corenative.crypto.BRCryptoNetwork;
 import com.breadwallet.corenative.crypto.BRCryptoNetworkFee;
 import com.breadwallet.corenative.crypto.BRCryptoTransfer;
@@ -94,6 +95,21 @@ public interface CryptoLibrary extends Library {
     BRCryptoAmount cryptoFeeBasisGetFee (BRCryptoFeeBasis feeBasis);
     BRCryptoFeeBasis cryptoFeeBasisTake(BRCryptoFeeBasis obj);
     void cryptoFeeBasisGive(BRCryptoFeeBasis obj);
+
+    // crypto/BRCryptoKey.h
+    BRCryptoKey.OwnedBRCryptoKey cryptoKeyCreateFromPhraseWithWords(ByteBuffer phraseBuffer, StringArray wordsArray);
+    BRCryptoKey.OwnedBRCryptoKey cryptoKeyCreateFromStringPrivate(ByteBuffer stringBuffer);
+    BRCryptoKey.OwnedBRCryptoKey cryptoKeyCreateFromStringPublic(ByteBuffer stringBuffer);
+    BRCryptoKey.OwnedBRCryptoKey cryptoKeyCreateForPigeon(BRCryptoKey key, byte[] nonce, SizeT nonceCount);
+    BRCryptoKey.OwnedBRCryptoKey cryptoKeyCreateForBIP32ApiAuth(ByteBuffer phraseBuffer, StringArray wordsArray);
+    BRCryptoKey.OwnedBRCryptoKey cryptoKeyCreateForBIP32BitID(ByteBuffer phraseBuffer, int index, String uri, StringArray wordsArray);
+    int cryptoKeyHasSecret(BRCryptoKey key);
+    int cryptoKeyPublicMatch(BRCryptoKey key, BRCryptoKey other);
+    int cryptoKeySecretMatch(BRCryptoKey key, BRCryptoKey other);
+    Pointer cryptoKeyEncodePrivate(BRCryptoKey key);
+    Pointer cryptoKeyEncodePublic(BRCryptoKey key);
+    UInt256.ByValue cryptoKeyGetSecret(BRCryptoKey key);
+    void cryptoKeyGive(BRCryptoKey key);
 
     // crypto/BRCryptoHash.h
     int cryptoHashEqual(BRCryptoHash h1, BRCryptoHash h2);

--- a/Java/CoreNative/src/main/java/com/breadwallet/corenative/CryptoLibrary.java
+++ b/Java/CoreNative/src/main/java/com/breadwallet/corenative/CryptoLibrary.java
@@ -103,6 +103,7 @@ public interface CryptoLibrary extends Library {
     BRCryptoKey.OwnedBRCryptoKey cryptoKeyCreateForPigeon(BRCryptoKey key, byte[] nonce, SizeT nonceCount);
     BRCryptoKey.OwnedBRCryptoKey cryptoKeyCreateForBIP32ApiAuth(ByteBuffer phraseBuffer, StringArray wordsArray);
     BRCryptoKey.OwnedBRCryptoKey cryptoKeyCreateForBIP32BitID(ByteBuffer phraseBuffer, int index, String uri, StringArray wordsArray);
+    void cryptoKeyProvidePublicKey(BRCryptoKey key, int useCompressed, int compressed);
     int cryptoKeyHasSecret(BRCryptoKey key);
     int cryptoKeyPublicMatch(BRCryptoKey key, BRCryptoKey other);
     int cryptoKeySecretMatch(BRCryptoKey key, BRCryptoKey other);

--- a/Java/CoreNative/src/main/java/com/breadwallet/corenative/crypto/BRCryptoKey.java
+++ b/Java/CoreNative/src/main/java/com/breadwallet/corenative/crypto/BRCryptoKey.java
@@ -1,0 +1,185 @@
+package com.breadwallet.corenative.crypto;
+
+import com.breadwallet.corenative.CryptoLibrary;
+import com.breadwallet.corenative.utility.SizeT;
+import com.google.common.base.Optional;
+import com.sun.jna.FromNativeContext;
+import com.sun.jna.Memory;
+import com.sun.jna.Native;
+import com.sun.jna.NativeMapped;
+import com.sun.jna.Pointer;
+import com.sun.jna.PointerType;
+import com.sun.jna.StringArray;
+
+import java.nio.ByteBuffer;
+import java.util.Arrays;
+import java.util.List;
+
+public class BRCryptoKey extends PointerType {
+
+    public BRCryptoKey(Pointer address) {
+        super(address);
+    }
+
+    public BRCryptoKey() {
+        super();
+    }
+
+    public static Optional<BRCryptoKey> createFromPhrase(byte[] phraseUtf8, List<String> words) {
+        StringArray wordsArray = new StringArray(words.toArray(new String[0]), "UTF-8");
+
+        // ensure string is null terminated
+        phraseUtf8 = Arrays.copyOf(phraseUtf8, phraseUtf8.length + 1);
+        try {
+            Memory phraseMemory = new Memory(phraseUtf8.length);
+            try {
+                phraseMemory.write(0, phraseUtf8, 0, phraseUtf8.length);
+                ByteBuffer phraseBuffer = phraseMemory.getByteBuffer(0, phraseUtf8.length);
+
+                return Optional.fromNullable(CryptoLibrary.INSTANCE.cryptoKeyCreateFromPhraseWithWords(phraseBuffer, wordsArray));
+            } finally {
+                phraseMemory.clear();
+            }
+        } finally {
+            // clear out our copy; caller responsible for original array
+            Arrays.fill(phraseUtf8, (byte) 0);
+        }
+    }
+
+    public static Optional<BRCryptoKey> createFromPrivateKeyString(byte[] keyString) {
+        // ensure string is null terminated
+        keyString = Arrays.copyOf(keyString, keyString.length + 1);
+        try {
+            Memory keyMemory = new Memory(keyString.length);
+            try {
+                keyMemory.write(0, keyString, 0, keyString.length);
+                ByteBuffer keyBuffer = keyMemory.getByteBuffer(0, keyString.length);
+
+                return Optional.fromNullable(CryptoLibrary.INSTANCE.cryptoKeyCreateFromStringPrivate(keyBuffer));
+            } finally {
+                keyMemory.clear();
+            }
+        } finally {
+            // clear out our copy; caller responsible for original array
+            Arrays.fill(keyString, (byte) 0);
+        }
+    }
+
+    public static Optional<BRCryptoKey> createFromPublicKeyString(byte[] keyString) {
+        // ensure string is null terminated
+        keyString = Arrays.copyOf(keyString, keyString.length + 1);
+        try {
+            Memory keyMemory = new Memory(keyString.length);
+            try {
+                keyMemory.write(0, keyString, 0, keyString.length);
+                ByteBuffer keyBuffer = keyMemory.getByteBuffer(0, keyString.length);
+
+                return Optional.fromNullable(CryptoLibrary.INSTANCE.cryptoKeyCreateFromStringPublic(keyBuffer));
+            } finally {
+                keyMemory.clear();
+            }
+        } finally {
+            // clear out our copy; caller responsible for original array
+            Arrays.fill(keyString, (byte) 0);
+        }
+    }
+
+    public static Optional<BRCryptoKey> createForPigeon(BRCryptoKey key, byte[] nonce) {
+        return Optional.fromNullable(CryptoLibrary.INSTANCE.cryptoKeyCreateForPigeon(key, nonce, new SizeT(nonce.length)));
+    }
+
+    public static Optional<BRCryptoKey> createForBIP32ApiAuth(byte[] phraseUtf8, List<String> words) {
+        StringArray wordsArray = new StringArray(words.toArray(new String[0]), "UTF-8");
+
+        // ensure string is null terminated
+        phraseUtf8 = Arrays.copyOf(phraseUtf8, phraseUtf8.length + 1);
+        try {
+            Memory phraseMemory = new Memory(phraseUtf8.length);
+            try {
+                phraseMemory.write(0, phraseUtf8, 0, phraseUtf8.length);
+                ByteBuffer phraseBuffer = phraseMemory.getByteBuffer(0, phraseUtf8.length);
+
+                return Optional.fromNullable(CryptoLibrary.INSTANCE.cryptoKeyCreateForBIP32ApiAuth(phraseBuffer, wordsArray));
+            } finally {
+                phraseMemory.clear();
+            }
+        } finally {
+            // clear out our copy; caller responsible for original array
+            Arrays.fill(phraseUtf8, (byte) 0);
+        }
+    }
+
+    public static Optional<BRCryptoKey> createForBIP32BitID(byte[] phraseUtf8, int index, String uri, List<String> words) {
+        StringArray wordsArray = new StringArray(words.toArray(new String[0]), "UTF-8");
+
+        // ensure string is null terminated
+        phraseUtf8 = Arrays.copyOf(phraseUtf8, phraseUtf8.length + 1);
+        try {
+            Memory phraseMemory = new Memory(phraseUtf8.length);
+            try {
+                phraseMemory.write(0, phraseUtf8, 0, phraseUtf8.length);
+                ByteBuffer phraseBuffer = phraseMemory.getByteBuffer(0, phraseUtf8.length);
+
+                return Optional.fromNullable(CryptoLibrary.INSTANCE.cryptoKeyCreateForBIP32BitID(phraseBuffer, index, uri, wordsArray));
+                
+            } finally {
+                phraseMemory.clear();
+            }
+        } finally {
+            // clear out our copy; caller responsible for original array
+            Arrays.fill(phraseUtf8, (byte) 0);
+        }
+    }
+
+    public boolean hasSecret() {
+        return BRCryptoBoolean.CRYPTO_TRUE == CryptoLibrary.INSTANCE.cryptoKeyHasSecret(this);
+    }
+
+    public byte[] encodeAsPrivate() {
+        Pointer ptr = CryptoLibrary.INSTANCE.cryptoKeyEncodePrivate(this);
+        try {
+            return ptr.getByteArray(0, (int) ptr.indexOf(0, (byte) 0));
+        } finally {
+            Native.free(Pointer.nativeValue(ptr));
+        }
+    }
+
+    public byte[] encodeAsPublic() {
+        Pointer ptr = CryptoLibrary.INSTANCE.cryptoKeyEncodePublic(this);
+        try {
+            return ptr.getByteArray(0, (int) ptr.indexOf(0, (byte) 0));
+        } finally {
+            Native.free(Pointer.nativeValue(ptr));
+        }
+    }
+
+    public byte[] getSecret() {
+        return CryptoLibrary.INSTANCE.cryptoKeyGetSecret(this).u8;
+    }
+
+    public boolean privateKeyMatch(BRCryptoKey other) {
+        return BRCryptoBoolean.CRYPTO_TRUE == CryptoLibrary.INSTANCE.cryptoKeySecretMatch(this, other);
+    }
+
+    public boolean publicKeyMatch(BRCryptoKey other) {
+        return BRCryptoBoolean.CRYPTO_TRUE == CryptoLibrary.INSTANCE.cryptoKeyPublicMatch(this, other);
+    }
+
+    public static class OwnedBRCryptoKey extends BRCryptoKey {
+
+        public OwnedBRCryptoKey(Pointer address) {
+            super(address);
+        }
+
+        public OwnedBRCryptoKey() {
+            super();
+        }
+
+        @Override
+        protected void finalize() {
+            if (null != getPointer()) {
+                CryptoLibrary.INSTANCE.cryptoKeyGive(this);
+            }
+        }
+    }
+}

--- a/Java/CoreNative/src/main/java/com/breadwallet/corenative/crypto/BRCryptoKey.java
+++ b/Java/CoreNative/src/main/java/com/breadwallet/corenative/crypto/BRCryptoKey.java
@@ -121,7 +121,7 @@ public class BRCryptoKey extends PointerType {
                 ByteBuffer phraseBuffer = phraseMemory.getByteBuffer(0, phraseUtf8.length);
 
                 return Optional.fromNullable(CryptoLibrary.INSTANCE.cryptoKeyCreateForBIP32BitID(phraseBuffer, index, uri, wordsArray));
-                
+
             } finally {
                 phraseMemory.clear();
             }
@@ -129,10 +129,6 @@ public class BRCryptoKey extends PointerType {
             // clear out our copy; caller responsible for original array
             Arrays.fill(phraseUtf8, (byte) 0);
         }
-    }
-
-    public boolean hasSecret() {
-        return BRCryptoBoolean.CRYPTO_TRUE == CryptoLibrary.INSTANCE.cryptoKeyHasSecret(this);
     }
 
     public byte[] encodeAsPrivate() {
@@ -151,6 +147,10 @@ public class BRCryptoKey extends PointerType {
         } finally {
             Native.free(Pointer.nativeValue(ptr));
         }
+    }
+
+    public boolean hasSecret() {
+        return BRCryptoBoolean.CRYPTO_TRUE == CryptoLibrary.INSTANCE.cryptoKeyHasSecret(this);
     }
 
     public byte[] getSecret() {

--- a/Java/CoreNative/src/main/java/com/breadwallet/corenative/crypto/BRCryptoKey.java
+++ b/Java/CoreNative/src/main/java/com/breadwallet/corenative/crypto/BRCryptoKey.java
@@ -165,6 +165,10 @@ public class BRCryptoKey extends PointerType {
         return BRCryptoBoolean.CRYPTO_TRUE == CryptoLibrary.INSTANCE.cryptoKeyPublicMatch(this, other);
     }
 
+    public void providePublicKey(int useCompressed, int compressed) {
+        CryptoLibrary.INSTANCE.cryptoKeyProvidePublicKey(this, useCompressed, compressed);
+    }
+
     public static class OwnedBRCryptoKey extends BRCryptoKey {
 
         public OwnedBRCryptoKey(Pointer address) {

--- a/Java/Crypto/src/main/java/com/breadwallet/crypto/CryptoApi.java
+++ b/Java/Crypto/src/main/java/com/breadwallet/crypto/CryptoApi.java
@@ -36,6 +36,15 @@ public final class CryptoApi {
         System create(ExecutorService listenerExecutor, SystemListener listener, Account account, boolean isMainnet, String path, BlockchainDb query);
     }
 
+    public interface PrimitivesProvider {
+        Optional<Key> createFromPhrase(byte[] phraseUtf8, List<String> words);
+        Optional<Key> createFromPrivateKeyString(byte[] keyStringUtf8);
+        Optional<Key> createFromPublicKeyString(byte[] keyStringUtf8);
+        Optional<Key> createForPigeon(Key key, byte[] nonce);
+        Optional<Key> createForBIP32ApiAuth(byte[] phraseUtf8, List<String> words);
+        Optional<Key> createForBIP32BitID(byte[] phraseUtf8, int index, String uri, List<String> words);
+    }
+
     public interface Provider {
 
         AccountProvider accountProvider();
@@ -43,6 +52,8 @@ public final class CryptoApi {
         AmountProvider amountProvider();
 
         SystemProvider systemProvider();
+
+        PrimitivesProvider primitivesProvider();
     }
 
     private static Provider provider;

--- a/Java/Crypto/src/main/java/com/breadwallet/crypto/Key.java
+++ b/Java/Crypto/src/main/java/com/breadwallet/crypto/Key.java
@@ -1,0 +1,44 @@
+package com.breadwallet.crypto;
+
+import com.google.common.base.Optional;
+
+import java.util.List;
+
+public interface Key {
+
+    static Optional<Key> createFromPhrase(byte[] phraseUtf8, List<String> words) {
+        return CryptoApi.getProvider().primitivesProvider().createFromPhrase(phraseUtf8, words);
+    }
+
+    static Optional<Key> createFromPrivateKeyString(byte[] privatekeyUtf8) {
+        return CryptoApi.getProvider().primitivesProvider().createFromPrivateKeyString(privatekeyUtf8);
+    }
+
+    static Optional<Key> createFromPublicKeyString(byte[] publicKeyUtf8) {
+        return CryptoApi.getProvider().primitivesProvider().createFromPublicKeyString(publicKeyUtf8);
+    }
+
+    static Optional<Key> createForPigeon(Key key, byte[] nonce) {
+        return CryptoApi.getProvider().primitivesProvider().createForPigeon(key, nonce);
+    }
+
+    static Optional<Key> createForBIP32ApiAuth(byte[] phraseUtf8, List<String> words) {
+        return CryptoApi.getProvider().primitivesProvider().createForBIP32ApiAuth(phraseUtf8, words);
+    }
+
+    static Optional<Key> createForBIP32BitID(byte[] phraseUtf8, int index, String uri, List<String> words) {
+        return CryptoApi.getProvider().primitivesProvider().createForBIP32BitID(phraseUtf8, index, uri, words);
+    }
+
+    boolean hasSecret();
+
+    byte[] encodeAsPrivate();
+
+    byte[] encodeAsPublic();
+
+    byte[] getSecret();
+
+    boolean privateKeyMatch(Key other);
+
+    boolean publicKeyMatch(Key other);
+}


### PR DESCRIPTION
Bonus, this establishes a pattern where we don't need the CoreBRCryptoXyz and corresponding OwnedBRCryptoXyz classes.

I will create a ticket to (at some point) convert everything to this new pattern.