### PR TITLE
CORE-417: Add createUInt256Double()

### DIFF
--- a/crypto/BRCryptoAmount.c
+++ b/crypto/BRCryptoAmount.c
@@ -84,15 +84,15 @@ cryptoAmountCreateUInt256 (UInt256 v,
 extern BRCryptoAmount
 cryptoAmountCreateDouble (double value,
                           BRCryptoUnit unit) {
-    uint8_t decimals = cryptoUnitGetBaseDecimalOffset (unit);
-    long double v = fabs(value) * powl (10.0, decimals);
+    int overflow;
+    UInt256 valueAsUInt256 = createUInt256Double (value, cryptoUnitGetBaseDecimalOffset (unit), &overflow);
 
-    if (v > INT64_MAX) return NULL;
-
-    return cryptoAmountCreateInternal (cryptoUnitGetCurrency(unit),
-                                       (value < 0.0 ? CRYPTO_TRUE : CRYPTO_FALSE),
-                                       createUInt256((uint64_t) v),
-                                       0);
+    return (overflow
+            ? NULL
+            : cryptoAmountCreateInternal (cryptoUnitGetCurrency(unit),
+                                          (value < 0.0 ? CRYPTO_TRUE : CRYPTO_FALSE),
+                                          valueAsUInt256,
+                                          0));
 }
 
 extern BRCryptoAmount

--- a/crypto/testCrypto.c
+++ b/crypto/testCrypto.c
@@ -5,8 +5,74 @@
 //  Created by Ed Gamble on 3/28/19.
 //  Copyright © 2019 breadwallet. All rights reserved.
 //
+#include <assert.h>
+#include <math.h>
+
+#include "BRCryptoPrivate.h"
+#include "BRCryptoAmount.h"
+
+static void
+runCryptoAmountTests (void) {
+    BRCryptoBoolean overflow;
+
+    BRCryptoCurrency currency =
+        cryptoCurrencyCreate ("Cuids",
+                              "Cname",
+                              "Ccode",
+                              "Ctype",
+                              NULL);
+
+    BRCryptoUnit unitBase =
+        cryptoUnitCreateAsBase (currency,
+                                "UuidsBase",
+                                "UnameBase",
+                                "UsymbBase");
+
+    BRCryptoUnit unitDef =
+        cryptoUnitCreate (currency,
+                          "UuidsDef",
+                          "UnameDef",
+                          "UsymbDef",
+                          unitBase,
+                          18);
+
+    double value = 25.25434525155732538797258871;
+
+    BRCryptoAmount amountInBase = cryptoAmountCreateDouble (value, unitBase);
+    assert (NULL != amountInBase);
+
+    double valueFromBase = cryptoAmountGetDouble (amountInBase, unitBase, &overflow);
+    assert (CRYPTO_FALSE == overflow);
+    assert (valueFromBase == 25.0);  // In base truncated fraction
+    cryptoAmountGive(amountInBase);
+
+    BRCryptoAmount amountInDef  = cryptoAmountCreateDouble (value, unitDef);
+    assert (NULL != amountInDef);
+
+    double valueFromDef = cryptoAmountGetDouble (amountInDef, unitDef, &overflow);
+    assert (CRYPTO_FALSE == overflow);
+    assert (fabs (valueFromDef - value) / value < 1e-10);
+    cryptoAmountGive(amountInDef);
+
+    value = 1e50;
+    amountInBase = cryptoAmountCreateDouble (value, unitBase);
+    assert (NULL != amountInBase);
+    valueFromBase = cryptoAmountGetDouble (amountInBase, unitBase, &overflow);
+    assert (CRYPTO_FALSE == overflow);
+    assert (fabs (valueFromBase - value) / value < 1e-10);
+    cryptoAmountGive(amountInBase);
+
+    value = 1e100;
+    amountInBase = cryptoAmountCreateDouble (value, unitBase);
+    assert (NULL == amountInBase);
+
+    cryptoUnitGive(unitDef);
+    cryptoUnitGive(unitBase);
+    cryptoCurrencyGive(currency);
+}
 
 extern void
 runCryptoTests (void) {
+    runCryptoAmountTests ();
     return;
 }

--- a/ethereum/util/BRUtilMath.c
+++ b/ethereum/util/BRUtilMath.c
@@ -23,6 +23,22 @@ createUInt256 (uint64_t value) {
 }
 
 extern UInt256
+createUInt256Double (double value, int decimals, int *overflow) {
+    assert (NULL != overflow);
+
+    UInt256 result = UINT256_ZERO;
+    long double y = fabs(value) * powl (10.0, decimals);
+
+    y = roundl(y);  // (extraneous) Axe any fraction; can't participate in a UInt
+
+    for (size_t index = 0; index < 4; index++)
+        result.u64[index] = UINT64_MAX * modfl(y/UINT64_MAX, &y);
+    *overflow = (y != 0);
+
+    return *overflow ? UINT256_ZERO : result;
+}
+
+extern UInt256
 createUInt256Power (uint8_t digits, int *overflow) {
     if (digits < 20) {    // 10^19 fits in uint64_t
         uint64_t value = 1;

--- a/ethereum/util/BRUtilMath.h
+++ b/ethereum/util/BRUtilMath.h
@@ -36,6 +36,9 @@ typedef enum {
 extern UInt256
 createUInt256 (uint64_t value);
 
+extern UInt256
+createUInt256Double (double value, int decimals, int *overflow);
+
 /**
  * Create as `(expt 10 power)` where power < 20 is required.
  */

--- a/ethereum/util/testUtil.c
+++ b/ethereum/util/testUtil.c
@@ -9,6 +9,7 @@
 #include <stdio.h>
 #include <string.h>
 #include <assert.h>
+#include <math.h>
 #include "BRUtil.h"
 
 //
@@ -157,7 +158,7 @@ runMathMulTests () {
 static void
 runMathMulDoubleTests () {
     BRCoreParseStatus status;
-    int over, neg; double rem;
+    int over, neg; double rem, v;
     UInt256 ai, ao, r;
 
     ai = createUInt256Parse("1000000000000000", 10, &status);  // Input
@@ -205,7 +206,11 @@ runMathMulDoubleTests () {
     assert (over == 0 && eqUInt256(r, ao));
     assert (0 == strcmp ("2", coerceString(r, 10)));
 
-    // overflow...
+    double x = 25.25434525155732538797258871;
+    r = createUInt256Double(x, 18, &over);
+    assert (!over && !eqUInt256(r, UINT256_ZERO));
+    v  = coerceDouble(r, &over);
+    assert(!over && fabs(v*1e-18 - x) / x < 1e-10);
 }
 
 static void


### PR DESCRIPTION
Reimplement `cryptoAmountCreateDouble` to accept an arbitrary double - instead of a double that needed to be less than INT64_MAX (sigh).