### PR TITLE
CORE-311: Remove unnecessary transfer add that triggered assert

### DIFF
--- a/crypto/BRCryptoWallet.c
+++ b/crypto/BRCryptoWallet.c
@@ -364,7 +364,7 @@ cryptoWalletGetAddress (BRCryptoWallet wallet,
             BREthereumAddress ethAddress = accountGetPrimaryAddress (ewmGetAccount(ewm));
             return cryptoAddressCreateAsETH (ethAddress);
         }
-            
+
         case BLOCK_CHAIN_TYPE_GEN: {
             assert (CRYPTO_ADDRESS_SCHEME_GEN_DEFAULT == addressScheme);
             BRGenericWalletManager gwm = wallet->u.gen.gwm;
@@ -556,9 +556,6 @@ cryptoWalletCreateTransfer (BRCryptoWallet  wallet,
     cryptoUnitGive (unitForFee);
     cryptoUnitGive (unit);
 
-    // Required?  Or just 'better safe than sorry'
-    if (NULL != transfer) cryptoWalletAddTransfer (wallet, transfer);
-
     return transfer;
 }
 
@@ -665,7 +662,7 @@ cryptoWalletCreateFeeBasis (BRCryptoWallet wallet,
         }
 
         case BLOCK_CHAIN_TYPE_GEN: {
-            BRGenericFeeBasis feeBasis = NULL; 
+            BRGenericFeeBasis feeBasis = NULL;
             return cryptoFeeBasisCreateAsGEN (wallet->unitForFee, wallet->u.gen.gwm, feeBasis);
         }
     }


### PR DESCRIPTION
Adding transfer directly in createTransfer routine caused ETH assert on NULL == transfer in BRCryptoWalletManagerClient's TRANSFER_EVENT_CREATED handler.

I believe the pattern we've established is that transfers are added in their event handler so restoring that pattern with this commit.

In my testing, transfer status events (created, submitted, included) are all propagated correctly.