### PR TITLE
CORE-480: Start the EWM event handler on `ewmStart()` not on `ewmConnect()`.

### DIFF
--- a/crypto/BRCryptoWalletManagerClient.c
+++ b/crypto/BRCryptoWalletManagerClient.c
@@ -787,38 +787,14 @@ cwmWalletManagerEventAsETH (BREthereumClientContext context,
     if (NULL == cwm->u.eth) cwm->u.eth = ewm;
 
     int needEvent = 1;
-    BRCryptoWalletManagerEvent cwmEvent;
+    BRCryptoWalletManagerEvent cwmEvent = { CRYPTO_WALLET_MANAGER_EVENT_CREATED };  // avoid warning
 
     switch (event) {
         case EWM_EVENT_CREATED: {
-            // Demand no 'wallet'
-            BREthereumWallet wid = ewmGetWallet (ewm);
-            assert (NULL == cryptoWalletManagerFindWalletAsETH (cwm, wid));
-
-            // Find the wallet's currency.
-            BRCryptoCurrency currency = cryptoNetworkGetCurrency (cwm->network);
-            assert (NULL != currency);
-
-            // Find the default unit; it too must exist.
-            BRCryptoUnit    unit = cryptoNetworkGetUnitAsDefault (cwm->network, currency);
-            assert (NULL != unit);
-
-            // Find the fee Unit
-            BRCryptoCurrency feeCurrency = cryptoNetworkGetCurrency (cwm->network);
-            assert (NULL != feeCurrency);
-
-            BRCryptoUnit     feeUnit     = cryptoNetworkGetUnitAsDefault (cwm->network, feeCurrency);
-            assert (NULL != feeUnit);
-
-            // Create the appropriate wallet based on currency
-            BRCryptoWallet wallet = cryptoWalletCreateAsETH (unit, feeUnit, cwm->u.eth, wid); // taken
-
-            // Set the primary wallet
-            assert (NULL == cwm->wallet);
-            cwm->wallet = cryptoWalletTake (wallet);
-
-            // Update CWM with the new wallet.
-            cryptoWalletManagerAddWallet (cwm, wallet);
+            // Demand a 'wallet'
+            BRCryptoWallet wallet = cryptoWalletManagerFindWalletAsETH (cwm, ewmGetWallet (ewm));
+            assert (NULL != wallet);
+            cryptoWalletGive (wallet);
 
             // Clear need for event as we propagate them here
             needEvent = 0;
@@ -833,7 +809,7 @@ cwmWalletManagerEventAsETH (BREthereumClientContext context,
             // Generate a CRYPTO wallet event for CREATED...
             cwm->listener.walletEventCallback (cwm->listener.context,
                                                cryptoWalletManagerTake (cwm),
-                                               cryptoWalletTake (wallet),
+                                               cryptoWalletTake (cwm->wallet),
                                                (BRCryptoWalletEvent) {
                                                    CRYPTO_WALLET_EVENT_CREATED
                                                });
@@ -843,16 +819,9 @@ cwmWalletManagerEventAsETH (BREthereumClientContext context,
                                                       cryptoWalletManagerTake (cwm),
                                                       (BRCryptoWalletManagerEvent) {
                                                           CRYPTO_WALLET_MANAGER_EVENT_WALLET_ADDED,
-                                                          { .wallet = { cryptoWalletTake (wallet) }}
+                                                          { .wallet = { cryptoWalletTake (cwm->wallet) }}
                                                       });
 
-            cryptoWalletGive (wallet);
-
-            cryptoUnitGive (feeUnit);
-            cryptoCurrencyGive (feeCurrency);
-
-            cryptoUnitGive (unit);
-            cryptoCurrencyGive (currency);
             break;
         }
 

--- a/ethereum/event/BREvent.c
+++ b/ethereum/event/BREvent.c
@@ -300,7 +300,7 @@ eventHandlerStop (BREventHandler handler) {
         // A mini-race here?
         handler->thread = PTHREAD_NULL;
 
-        // Empty the queue completely.
+        // TODO: Empty the queue completely?  Or not?
         eventHandlerClear (handler);
     }
     pthread_mutex_unlock(&handler->lockOnStartStop);

--- a/ethereum/ewm/BREthereumEWM.c
+++ b/ethereum/ewm/BREthereumEWM.c
@@ -480,7 +480,8 @@ ewmCreate (BREthereumNetwork network,
     // Queue the CREATED event so that it is the first event delievered to the BREthereumClient
     ewmSignalEWMEvent (ewm, EWM_EVENT_CREATED, SUCCESS, NULL);
 
-    // Create a default ETH wallet; other wallets will be created 'on demand'
+    // Create a default ETH wallet; other wallets will be created 'on demand'.  This will signal
+    // a WALLET_EVENT_CREATED event.
     ewm->walletHoldingEther = walletCreate(ewm->account,
                                            ewm->network);
     ewmInsertWallet(ewm, ewm->walletHoldingEther);
@@ -632,7 +633,16 @@ ewmCreateWithPublicKey (BREthereumNetwork network,
 extern void
 ewmDestroy (BREthereumEWM ewm) {
     pthread_mutex_lock(&ewm->lock);
+
+    // Disconnect BCS - Note ewm->lock is recursive so there is no deadlock here.
     ewmDisconnect(ewm);
+
+    // TODO: Before DISCONNECT... so disconnect events are not handled (but still queued?)
+    ewmStop (ewm);
+
+    //
+    // Begin destroy
+    //
 
     bcsDestroy(ewm->bcs);
 
@@ -651,6 +661,27 @@ ewmDestroy (BREthereumEWM ewm) {
 
     memset (ewm, 0, sizeof(*ewm));
     free (ewm);
+}
+
+/// MARK: - Start/Stop
+
+extern void
+ewmStart (BREthereumEWM ewm) {
+    // Start the alarm clock.
+    alarmClockStart(alarmClock);
+
+    // Start the EWM thread
+    eventHandlerStart(ewm->handler);
+}
+
+extern void
+ewmStop (BREthereumEWM ewm) {
+    // Stop the alarm clock
+    alarmClockStop (alarmClock);
+
+    // Stop the EWM thread
+    eventHandlerStop(ewm->handler);
+
 }
 
 /// MARK: - Connect / Disconnect
@@ -675,9 +706,6 @@ ewmConnect(BREthereumEWM ewm) {
         // with `ewmPeriodicDispatcher`.
         ewm->state = LIGHT_NODE_CONNECTED;
 
-        // Start the alarm clock, if needed.
-        alarmClockStart(alarmClock);
-
         switch (ewm->mode) {
             case BRD_ONLY:
                 break;
@@ -688,13 +716,10 @@ ewmConnect(BREthereumEWM ewm) {
                 break;
         }
 
-        eventHandlerStart(ewm->handler);
-
         result = ETHEREUM_BOOLEAN_TRUE;
     }
 
     ewmUnlock (ewm);
-
     return result;
 }
 
@@ -714,9 +739,6 @@ ewmDisconnect (BREthereumEWM ewm) {
         // Set ewm->state thereby stopping handlers (in a race with bcs/event calls).
         ewm->state = LIGHT_NODE_DISCONNECTED;
 
-        // What order for these stop functions?  See comment in `bcsStop()`.
-        alarmClockStop (alarmClock);
-
         switch (ewm->mode) {
             case BRD_ONLY:
                 break;
@@ -727,16 +749,10 @@ ewmDisconnect (BREthereumEWM ewm) {
                 break;
         }
 
-        // Unlock here - required for eventHandlerStop() to run and succeed on pthread_join(). This
-        // could be moved to immediately after `ewm->state = ...` as the lock *only* protects
-        // that EWM field.
-        ewmUnlock(ewm);
-        eventHandlerStop(ewm->handler);
-
         result = ETHEREUM_BOOLEAN_TRUE;
     }
-    else ewmUnlock(ewm);
 
+    ewmUnlock(ewm);
     return result;
 }
 
@@ -759,6 +775,7 @@ ewmIsConnected (BREthereumEWM ewm) {
                 break;
         }
     }
+
     ewmUnlock (ewm);
     return result;
 }

--- a/ethereum/ewm/BREthereumEWM.c
+++ b/ethereum/ewm/BREthereumEWM.c
@@ -634,10 +634,7 @@ extern void
 ewmDestroy (BREthereumEWM ewm) {
     pthread_mutex_lock(&ewm->lock);
 
-    // Disconnect BCS - Note ewm->lock is recursive so there is no deadlock here.
-    ewmDisconnect(ewm);
-
-    // TODO: Before DISCONNECT... so disconnect events are not handled (but still queued?)
+    // Stop, including disconnect.
     ewmStop (ewm);
 
     //
@@ -667,6 +664,8 @@ ewmDestroy (BREthereumEWM ewm) {
 
 extern void
 ewmStart (BREthereumEWM ewm) {
+    // TODO: Check on a current state before starting.
+
     // Start the alarm clock.
     alarmClockStart(alarmClock);
 
@@ -676,12 +675,17 @@ ewmStart (BREthereumEWM ewm) {
 
 extern void
 ewmStop (BREthereumEWM ewm) {
+    // TODO: Check on a current state before stopping.
+    
+    // Disconnect
+    ewmDisconnect(ewm);
+    // TODO: Are their disconnect events that we need to process before stopping the handler?
+
     // Stop the alarm clock
     alarmClockStop (alarmClock);
 
     // Stop the EWM thread
     eventHandlerStop(ewm->handler);
-
 }
 
 /// MARK: - Connect / Disconnect

--- a/ethereum/ewm/BREthereumEWM.h
+++ b/ethereum/ewm/BREthereumEWM.h
@@ -53,6 +53,24 @@ ewmCreateWithPublicKey (BREthereumNetwork network,
 extern void
 ewmDestroy (BREthereumEWM ewm);
 
+/// MARK: Start Stop
+
+/**
+ * Starts the EWM event queue.  Must be called after ewmCreate() and ewmStop()
+ *
+ * @param ewm
+ */
+extern void
+ewmStart (BREthereumEWM ewm);
+
+/**
+ * Stops the EWM event queue (but does not purge existing, queued events).
+ *
+ * @param ewm 
+ */
+extern void
+ewmStop (BREthereumEWM ewm);
+
 extern BREthereumNetwork
 ewmGetNetwork (BREthereumEWM ewm);
 


### PR DESCRIPTION
CWM will call ewmCreate(...), set up `cwm` and `cwm->wallet`, and then call `ewmStart()` to generate EWM events.  It might be that CWM doesn't need to generate its own CWM events (in cwmCreate()) as the EWM events, once flowing, will generate CWM events(?).