### PR TITLE
CORE-478: Extend BRCrypto{WalletManager, Wallet, Transfer} Tests.

### DIFF
--- a/Swift/BRCore.xcodeproj/xcshareddata/xcschemes/BRCrypto.xcscheme
+++ b/Swift/BRCore.xcodeproj/xcshareddata/xcschemes/BRCrypto.xcscheme
@@ -26,8 +26,8 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      enableAddressSanitizer = "YES"
       enableASanStackUseAfterReturn = "YES"
+      disableMainThreadChecker = "YES"
       codeCoverageEnabled = "YES"
       onlyGenerateCoverageForSpecifiedTargets = "YES"
       shouldUseLaunchSchemeArgsEnv = "YES">
@@ -96,16 +96,6 @@
          </BuildableReference>
       </MacroExpansion>
       <AdditionalOptions>
-         <AdditionalOption
-            key = "NSZombieEnabled"
-            value = "YES"
-            isEnabled = "YES">
-         </AdditionalOption>
-         <AdditionalOption
-            key = "MallocScribble"
-            value = ""
-            isEnabled = "YES">
-         </AdditionalOption>
       </AdditionalOptions>
    </TestAction>
    <LaunchAction

--- a/Swift/BRCrypto/BRCryptoNetwork.swift
+++ b/Swift/BRCrypto/BRCryptoNetwork.swift
@@ -217,7 +217,6 @@ public enum NetworkEvent {
 /// Listener for NetworkEvent
 ///
 public protocol NetworkListener: class {
-
     ///
     /// Handle a NetworkEvent
     ///
@@ -229,8 +228,10 @@ public protocol NetworkListener: class {
     func handleNetworkEvent (system: System,
                              network: Network,
                              event: NetworkEvent)
-
 }
+
+/// A Functional Interface for a Handler
+public typealias NetworkEventHandler = (System, Network, NetworkEvent) -> Void
 
 ///
 /// A Network Fee represents the 'amount per cost factor' paid to mine a transfer. For BTC this

--- a/Swift/BRCrypto/BRCryptoSystem.swift
+++ b/Swift/BRCrypto/BRCryptoSystem.swift
@@ -350,7 +350,7 @@ public final class System {
                         // the default currency
                         guard let currency = associations.keys.first (where: { $0.code == blockchainModel.currency.lowercased() }),
                             let feeUnit = associations[currency]?.baseUnit
-                            else { print ("SYS: CONFIGURE: Missed Currency (\(blockchainModel.currency)): defaultUnit"); return }
+                            else { print ("SYS: CONFIGURE: Missed Currency (\(blockchainModel.currency)) on '\(blockchainModel.network)': defaultUnit"); return }
 
                         let fees = blockchainModel.feeEstimates
                             // Well, quietly ignore a fee if we can't parse the amount.
@@ -362,7 +362,7 @@ public final class System {
                         }
 
                         guard !fees.isEmpty
-                            else { print ("SYS: CONFIGURE: Missed Fees (\(blockchainModel.name))"); return }
+                            else { print ("SYS: CONFIGURE: Missed Fees (\(blockchainModel.name)) on '\(blockchainModel.network)'"); return }
 
                         // define the network
                         let network = Network (uids: blockchainModel.id,
@@ -473,6 +473,9 @@ public protocol SystemListener : /* class, */ WalletManagerListener, WalletListe
     func handleSystemEvent (system: System,
                             event: SystemEvent)
 }
+
+/// A Functional Interface for a Handler
+public typealias SystemEventHandler = (System, SystemEvent) -> Void
 
 public final class SystemCallbackCoordinator {
     enum Handler {

--- a/Swift/BRCrypto/BRCryptoTransfer.swift
+++ b/Swift/BRCrypto/BRCryptoTransfer.swift
@@ -169,7 +169,7 @@ extension Transfer {
     }
 }
 
-public enum TransferDirection {
+public enum TransferDirection: Equatable {
     case sent
     case received
     case recovered

--- a/Swift/BRCrypto/BRCryptoTransfer.swift
+++ b/Swift/BRCrypto/BRCryptoTransfer.swift
@@ -350,6 +350,9 @@ public protocol TransferListener: class {
                               event: TransferEvent)
 }
 
+/// A Functional Interface for a Handler
+public typealias TransferEventHandler = (System, WalletManager, Wallet, Transfer, TransferEvent) -> Void
+
 ///
 /// A `TransferFectory` is a customization point for `Transfer` creation.
 ///

--- a/Swift/BRCrypto/BRCryptoWallet.swift
+++ b/Swift/BRCrypto/BRCryptoWallet.swift
@@ -296,7 +296,7 @@ extension Wallet {
 /// - created: The wallet was created (and remains in existence).
 /// - deleted: The wallet was deleted.
 ///
-public enum WalletState {
+public enum WalletState: Equatable {
     case created
     case deleted
 

--- a/Swift/BRCrypto/BRCryptoWallet.swift
+++ b/Swift/BRCrypto/BRCryptoWallet.swift
@@ -362,6 +362,9 @@ public protocol WalletListener: class {
                             wallet: Wallet,
                             event: WalletEvent)
 }
+/// A Functional Interface for a Handler
+public typealias WalletEventHandler = (System, WalletManager, Wallet, WalletEvent) -> Void
+
 
 ///
 /// A WalletFactory is a customization point for Wallet creation.

--- a/Swift/BRCrypto/BRCryptoWalletManager.swift
+++ b/Swift/BRCrypto/BRCryptoWalletManager.swift
@@ -252,7 +252,7 @@ extension WalletManager {
 ///
 /// The WalletManager state.
 ///
-public enum WalletManagerState {
+public enum WalletManagerState: Equatable {
     case created
     case disconnected
     case connected

--- a/Swift/BRCrypto/BRCryptoWalletManager.swift
+++ b/Swift/BRCrypto/BRCryptoWalletManager.swift
@@ -351,7 +351,9 @@ public protocol WalletManagerListener: class {
     func handleManagerEvent (system: System,
                              manager: WalletManager,
                              event: WalletManagerEvent)
-
 }
+
+/// A Functional Interface for a Handler
+public typealias WalletManagerEventHandler = (System, WalletManager, WalletManagerEvent) -> Void
 
 public protocol WalletManagerFactory { }

--- a/Swift/BRCrypto/common/BRSupport.swift
+++ b/Swift/BRCrypto/common/BRSupport.swift
@@ -212,22 +212,15 @@ public struct AccountSpecification {
         self.timestamp = dateFormatter.date(from: dict["timestamp"]!)!
     }
 
-    static public func loadFrom (configPath: String, withDefault: Bool = true) -> [AccountSpecification] {
+    static public func loadFrom (configPath: String, defaultSpecification: AccountSpecification? = nil) -> [AccountSpecification] {
         if FileManager.default.fileExists(atPath: configPath) {
             let configFile = URL(fileURLWithPath: configPath)
             let configData = try! Data.init(contentsOf: configFile)
             let json = try! JSONSerialization.jsonObject(with: configData, options: []) as! [[String:String]]
             return json.map { AccountSpecification (dict: $0) }
         }
-        else if withDefault {
-            return [
-                AccountSpecification (dict: [
-                    "identifier": "ginger",
-                    "paperKey":   "ginger settle marine tissue robot crane night number ramp coast roast critic",
-                    "timestamp":  "2018-01-01",
-                    "network":    "testnet",
-                    ])
-            ]
+        else if let defaultSpecification = defaultSpecification {
+            return [defaultSpecification]
         }
         else {
             return []

--- a/Swift/BRCryptoTests/BRCryptoBaseTests.swift
+++ b/Swift/BRCryptoTests/BRCryptoBaseTests.swift
@@ -10,7 +10,7 @@
 //
 
 import XCTest
-import BRCrypto
+@testable import BRCrypto
 
 class BRCryptoBaseTests: XCTestCase {
 
@@ -109,13 +109,207 @@ class BRCryptoBaseTests: XCTestCase {
 
         coreDirCreate()
         coreDirClear()
-   }
-
-    func testBase() {
         XCTAssert (nil != coreDataDir)
-    }
+
+        print ("TST: StoragePath: \(coreDataDir ?? "<none>")");
+   }
 
     override func tearDown() {
         // Put teardown code here. This method is called after the invocation of each test method in the class.
+    }
+}
+
+///
+/// Listeners
+///
+
+class TestWalletManagerListener: WalletManagerListener {
+    let handler: WalletManagerEventHandler
+
+    init (_ handler: @escaping WalletManagerEventHandler) {
+        self.handler = handler
+    }
+
+    func handleManagerEvent(system: System, manager: WalletManager, event: WalletManagerEvent) {
+        handler (system, manager, event)
+    }
+}
+
+class TestWalletListener: WalletListener {
+    let handler: WalletEventHandler
+
+    init (_ handler: @escaping WalletEventHandler) {
+        self.handler = handler
+    }
+
+    func handleWalletEvent(system: System, manager: WalletManager, wallet: Wallet, event: WalletEvent) {
+        handler (system, manager, wallet, event)
+    }
+}
+
+class TestTransferListener: TransferListener {
+    let handler: TransferEventHandler
+
+    init (_ handler: @escaping TransferEventHandler) {
+        self.handler = handler
+    }
+
+    func handleTransferEvent(system: System, manager: WalletManager, wallet: Wallet, transfer: Transfer, event: TransferEvent) {
+        handler (system, manager, wallet, transfer, event)
+    }
+}
+
+class TestNetworkListener: NetworkListener {
+    let handler: NetworkEventHandler
+
+    init (_ handler: @escaping NetworkEventHandler) {
+        self.handler = handler
+    }
+    func handleNetworkEvent(system: System, network: Network, event: NetworkEvent) {
+        handler (system, network, event)
+    }
+}
+
+class CryptoTestSystemListener: SystemListener {
+
+    private let currencyCodesNeeded: [String]
+    private let isMainnet: Bool
+
+    var networkExpectation = XCTestExpectation (description: "NetworkExpectation")
+    var managerExpectation = XCTestExpectation (description: "ManagerExpectation")
+    var walletExpectation  = XCTestExpectation (description: "ManagerExpectation")
+
+    var systemHandlers: [SystemEventHandler] = []
+
+    public init (currencyCodesNeeded: [String], isMainnet: Bool) {
+        self.currencyCodesNeeded = currencyCodesNeeded
+        self.isMainnet = isMainnet
+    }
+
+    func handleSystemEvent(system: System, event: SystemEvent) {
+        switch event {
+        case .networkAdded (let network):
+            if isMainnet == network.isMainnet &&
+                currencyCodesNeeded.contains (where: { nil != network.currencyBy (code: $0) }) {
+                let mode = system.supportsMode (network: network, WalletManagerMode.api_only)
+                    ? WalletManagerMode.api_only
+                    : system.defaultMode(network: network)
+                let scheme = system.defaultAddressScheme(network: network)
+
+                let _ = system.createWalletManager (network: network,
+                                                    mode: mode,
+                                                    addressScheme: scheme)
+            }
+            networkExpectation.fulfill()
+
+        case .managerAdded:
+            managerExpectation.fulfill()
+
+        default: break
+        }
+        systemHandlers.forEach { $0 (system, event) }
+    }
+
+    var managerHandlers: [WalletManagerEventHandler] = []
+
+    func handleManagerEvent(system: System, manager: WalletManager, event: WalletManagerEvent) {
+        if case .walletAdded = event { walletExpectation.fulfill() }
+        managerHandlers.forEach { $0 (system, manager, event) }
+    }
+
+    var walletHandlers: [WalletEventHandler] = []
+
+    func handleWalletEvent(system: System, manager: WalletManager, wallet: Wallet, event: WalletEvent) {
+        walletHandlers.forEach { $0 (system, manager, wallet, event) }
+    }
+
+    var transferHandlers: [TransferEventHandler] = []
+
+    func handleTransferEvent(system: System, manager: WalletManager, wallet: Wallet, transfer: Transfer, event: TransferEvent) {
+        transferHandlers.forEach { $0 (system, manager, wallet, transfer, event) }
+    }
+
+    var networkHandlers: [NetworkEventHandler] = []
+
+    func handleNetworkEvent(system: System, network: Network, event: NetworkEvent) {
+        networkHandlers.forEach { $0 (system, network, event) }
+    }
+}
+
+/*
+ fileprivate class BRCryptoBaseTestSystemListner: SystemListener {
+
+        case .networkAdded(let network):
+            if isMainnet == network.isMainnet &&
+                currencyCodesNeeded.contains (where: { nil != network.currencyBy (code: $0) }) {
+                let mode = system.supportsMode (network: network, WalletManagerMode.api_only)
+                    ? WalletManagerMode.api_only
+                    : system.defaultMode(network: network)
+                let scheme = system.defaultAddressScheme(network: network)
+
+                let _ = system.createWalletManager (network: network,
+                                                    mode: mode,
+                                                    addressScheme: scheme)
+            }
+
+
+            networkExpectation.fulfill()
+
+            // A network was created; create the corresponding wallet manager.  Note: an actual
+            // App might not be interested in having a wallet manager for every network -
+            // specifically, test networks are announced and having a wallet manager for a
+            // testnet won't happen in a deployed App.
+
+            let mode = system.supportsMode (network: network, WalletManagerMode.p2p_only)
+                ? WalletManagerMode.p2p_only
+                : system.defaultMode(network: network)
+            let scheme = system.defaultAddressScheme(network: network)
+
+
+            let _ = system.createWalletManager (network: network,
+                                                mode: mode,
+                                                addressScheme: scheme)
+}
+*/
+
+class BRCryptoSystemBaseTests: BRCryptoBaseTests {
+
+    var listener: CryptoTestSystemListener!
+    var query: BlockChainDB!
+    var system: System!
+
+    var currencyCodesNeeded = ["btc"]
+
+    func createDefaultListener() -> CryptoTestSystemListener {
+        return CryptoTestSystemListener (currencyCodesNeeded: currencyCodesNeeded, isMainnet: isMainnet)
+    }
+
+    func createDefaultQuery () -> BlockChainDB {
+        return BlockChainDB()
+    }
+
+    func prepareSystem (listener: CryptoTestSystemListener? = nil, query: BlockChainDB? = nil) {
+
+        self.listener = listener ?? createDefaultListener()
+        self.query    = query    ?? createDefaultQuery()
+
+        system = System (listener:  self.listener,
+                         account:   self.account,
+                         onMainnet: self.isMainnet,
+                         path:      self.coreDataDir,
+                         query:     self.query)
+
+        XCTAssertEqual (coreDataDir, system.path)
+        XCTAssertTrue  (self.query === system.query)
+        XCTAssertEqual (account.uids, system.account.uids)
+
+        system.configure() // Don't connect
+        wait (for: [self.listener.networkExpectation], timeout: 5)
+        wait (for: [self.listener.managerExpectation], timeout: 5)
+        wait (for: [self.listener.walletExpectation ], timeout: 5)
+    }
+
+    override func setUp() {
+        super.setUp()
     }
 }

--- a/Swift/BRCryptoTests/BRCryptoSystemTests.swift
+++ b/Swift/BRCryptoTests/BRCryptoSystemTests.swift
@@ -24,6 +24,7 @@ class BRCryptoSystemTests: BRCryptoSystemBaseTests {
     func testSystemBTC() {
         isMainnet = false
         currencyCodesNeeded = ["btc"]
+        prepareAccount()
         prepareSystem()
 
         XCTAssertTrue (system.networks.count >= 1)
@@ -51,21 +52,5 @@ class BRCryptoSystemTests: BRCryptoSystemBaseTests {
         XCTAssertTrue  (network.defaultUnitFor(currency: network.currency).map { $0 == wallet.unit } ?? false)
         XCTAssertEqual (wallet.balance, Amount.create(integer: 0, unit: manager.baseUnit))
         XCTAssertEqual (wallet.state, WalletState.created)
-
-        #if false
-        let transfer = wallet.createTransfer (target: targetAddress,
-                                              amount: Amount.create (integer: 1, unit: manager.baseUnit))
-
-        XCTAssertNil(transfer) // no balance => no transfer
-        #endif
-
-        #if false
-        XCTAssertTrue (transfer.wallet === wallet)
-        XCTAssertTrue (transfer.manager === manager)
-        XCTAssertTrue (transfer.system  === sys)
-
-        XCTAssertEqual (transfer.target, targetAddress)
-        XCTAssertEqual (transfer.source, wallet.source)
-        #endif
     }
 }

--- a/Swift/BRCryptoTests/BRCryptoTransferTests.swift
+++ b/Swift/BRCryptoTests/BRCryptoTransferTests.swift
@@ -11,40 +11,71 @@
 
 import XCTest
 @testable import BRCrypto
+import BRCryptoC
 
-class BRCryptoTransferTests: XCTestCase {
-
-    var system: System! = nil
-    var manager: WalletManager! = nil
-    var wallet: Wallet! = nil
-
+class BRCryptoTransferTests: BRCryptoSystemBaseTests {
     override func setUp() {
-/*
-        system = System (listener: <#T##SystemListener#>,
-                         account: <#T##Account#>,
-                         path: <#T##String#>,
-                         query: <#T##BlockChainDB#>)
-
-        manager = WalletManager (system: <#T##System#>,
-                                 listener: <#T##WalletManagerListener#>,
-                                 account: <#T##Account#>,
-                                 network: <#T##Network#>,
-                                 mode: <#T##WalletManagerMode#>,
-                                 storagePath: <#T##String#>)
-
-        wallet = Wallet (core: <#T##BRCryptoWallet#>,
-                         listener: <#T##WalletListener?#>,
-                         manager: <#T##WalletManager#>,
-                         unit: <#T##Unit#>)
-*/
+        super.setUp()
     }
 
     override func tearDown() {
     }
 
-//    func testTransferA() {
-//    }
+    func testTransferBTC() {
+        isMainnet = false
+        currencyCodesNeeded = ["btc"]
+        prepareSystem()
 
+        let network: Network! = system.networks.first { "btc" == $0.currency.code && isMainnet == $0.isMainnet }
+        XCTAssertNotNil (network)
+
+        let manager: WalletManager! = system.managers.first { $0.network == network }
+        XCTAssertNotNil (manager)
+    }
+
+    func testTransferETH () {
+        isMainnet = false
+        currencyCodesNeeded = ["eth"]
+        prepareSystem()
+
+        let network: Network! = system.networks.first { "eth" == $0.currency.code && isMainnet == $0.isMainnet }
+        XCTAssertNotNil (network)
+
+        let manager: WalletManager! = system.managers.first { $0.network == network }
+        XCTAssertNotNil (manager)
+    }
+
+    
+    func testTransferConfirmation () {
+        let btc = Currency (uids: "Bitcoin",  name: "Bitcoin",  code: "BTC", type: "native", issuer: nil)
+        let BTC_SATOSHI = BRCrypto.Unit (currency: btc, uids: "BTC-SAT",  name: "Satoshi", symbol: "SAT")
+
+        let confirmation = TransferConfirmation (blockNumber: 1,
+                                                 transactionIndex: 2,
+                                                 timestamp: 3,
+                                                 fee: nil)
+        XCTAssertEqual(1, confirmation.blockNumber)
+        XCTAssertEqual(2, confirmation.transactionIndex)
+        XCTAssertEqual(3, confirmation.timestamp)
+        XCTAssertNil(confirmation.fee)
+    }
+
+    func testTransferDirection () {
+        XCTAssertEqual(TransferDirection.sent,      TransferDirection (core: BRCryptoTransferDirection (rawValue: 0)))
+        XCTAssertEqual(TransferDirection.received,  TransferDirection (core: BRCryptoTransferDirection (rawValue: 1)))
+        XCTAssertEqual(TransferDirection.recovered, TransferDirection (core: BRCryptoTransferDirection (rawValue: 2)))
+    }
+
+    func testTransferHash () {
+    }
+
+    func testTransferFeeBasis () {
+    }
+
+    func testTransferState () {
+        // XCTAssertEqual (TransferState.created, TransferState(core: CRYPTO_TRANSFER_STATE_CREATED))
+        // ...
+    }
     func testTransfer () {
 /*
         let wid = BRWalletNew ()

--- a/Swift/BRCryptoTests/BRCryptoTransferTests.swift
+++ b/Swift/BRCryptoTests/BRCryptoTransferTests.swift
@@ -24,31 +24,149 @@ class BRCryptoTransferTests: BRCryptoSystemBaseTests {
     func testTransferBTC() {
         isMainnet = false
         currencyCodesNeeded = ["btc"]
-        prepareSystem()
+        prepareAccount (AccountSpecification (dict: [
+            "identifier": "ginger",
+            "paperKey":   "ginger settle marine tissue robot crane night number ramp coast roast critic",
+            "timestamp":  "2018-01-01",
+            "network":    (isMainnet ? "mainnet" : "testnet")
+            ]))
+        let listener = CryptoTestSystemListener (currencyCodesNeeded: currencyCodesNeeded, isMainnet: isMainnet)
+        prepareSystem(listener: listener)
 
         let network: Network! = system.networks.first { "btc" == $0.currency.code && isMainnet == $0.isMainnet }
         XCTAssertNotNil (network)
 
         let manager: WalletManager! = system.managers.first { $0.network == network }
         XCTAssertNotNil (manager)
+
+        let wallet = manager.primaryWallet
+        XCTAssertNotNil(wallet)
+
+        // Connect and wait for a number of transfers
+        var transferCount: Int = 10
+        let transferExpectation = XCTestExpectation (description: "Transfer")
+        listener.walletHandlers += [
+            { (system: System, manager: WalletManager, wallet: Wallet, event: WalletEvent) -> Void in
+                switch event {
+                case .transferAdded:
+                    transferCount -= 1
+                    if 0 == transferCount {
+                        transferExpectation.fulfill()
+                    }
+                default: break
+                }
+            }]
+        manager.connect()
+        wait (for: [transferExpectation ], timeout: 70)
+
+        XCTAssertFalse (wallet.transfers.isEmpty)
+        XCTAssertTrue  (wallet.transfers.count >= 10)
+        let t0 = wallet.transfers[0]
+        let t1  = wallet.transfers[1]
+
+        XCTAssertEqual (t0.wallet,  wallet)
+        XCTAssertEqual (t0.manager, manager)
+        XCTAssertNotNil (t0.confirmedFeeBasis)
+
+        XCTAssertNotNil (t0.confirmation)
+        // confirmations
+        // confirmationsAs
+        let t0c = t0.confirmation!
+
+        // Fails until TransferState(core: ...) fills in Fee - requires unit...CORE-421
+        XCTAssertNotNil (t0c.fee)
+
+        XCTAssertNotNil (t0.hash)
+        XCTAssertNotNil (wallet.transferBy(hash: t0.hash!))
+        XCTAssertNotNil (wallet.transferBy(hash: t1.hash!))
+        XCTAssertNotNil (wallet.transferBy(core: t0.core))
+        XCTAssertNotNil (wallet.transferBy(core: t1.core))
+
+        if case .included = t0.state {} else { XCTAssertTrue (false)}
+        // direction
+
+        manager.disconnect()
     }
 
     func testTransferETH () {
         isMainnet = false
         currencyCodesNeeded = ["eth"]
-        prepareSystem()
+        prepareAccount (AccountSpecification (dict: [
+            "identifier": "ginger",
+            "paperKey":   "ginger settle marine tissue robot crane night number ramp coast roast critic",
+            "timestamp":  "2018-01-01",
+            "network":    (isMainnet ? "mainnet" : "testnet")
+            ]))
+        let listener = CryptoTestSystemListener (currencyCodesNeeded: currencyCodesNeeded, isMainnet: isMainnet)
+        prepareSystem(listener: listener)
 
         let network: Network! = system.networks.first { "eth" == $0.currency.code && isMainnet == $0.isMainnet }
         XCTAssertNotNil (network)
 
         let manager: WalletManager! = system.managers.first { $0.network == network }
         XCTAssertNotNil (manager)
+
+        let wallet = manager.primaryWallet
+        XCTAssertNotNil(wallet)
+
+        // Connect and wait for a number of transfers
+        var transferCount: Int = 3
+        let transferExpectation = XCTestExpectation (description: "Transfer")
+        listener.walletHandlers += [
+            { (system: System, manager: WalletManager, wallet: Wallet, event: WalletEvent) -> Void in
+                switch event {
+                case .transferAdded:
+                    transferCount -= 1
+                    if 0 == transferCount {
+                        transferExpectation.fulfill()
+                    }
+                default: break
+                }
+            }]
+        manager.connect()
+        wait (for: [transferExpectation ], timeout: 70)
+
+        XCTAssertFalse (wallet.transfers.isEmpty)
+        XCTAssertTrue  (wallet.transfers.count >= 3)
+        let t0 = wallet.transfers[0]
+        let t1  = wallet.transfers[1]
+
+        XCTAssertTrue  (t0.identical(that: t0))
+        XCTAssertFalse (t0.identical(that: t1))
+        XCTAssertEqual (t0, t0)
+        XCTAssertNotEqual (t0, t1)
+
+        XCTAssertTrue  (t0.system === system)
+        XCTAssertEqual (t0.wallet,  wallet)
+        XCTAssertEqual (t0.manager, manager)
+        XCTAssertNotNil(t0.source)
+        XCTAssertNotNil(t0.target)
+        XCTAssertNotNil (t0.confirmedFeeBasis)
+
+        XCTAssertNotNil (t0.confirmation)
+        // confirmations
+        // confirmationsAs
+        let t0c = t0.confirmation!
+
+        // Fails until TransferState(core: ...) fills in Fee - requires unit...CORE-421
+        XCTAssertNotNil (t0c.fee)
+
+        XCTAssertNotNil (t0.hash)
+        XCTAssertNotNil (t1.hash)
+        XCTAssertEqual (t0.hash, t0.hash)
+        XCTAssertNotEqual(t0.hash, t1.hash)
+        let _: [TransferHash:Int] = [t0.hash!:0, t1.hash!:1]
+
+        if case .included = t0.state {} else { XCTAssertTrue (false)}
+        // direction
+
+        manager.disconnect()
     }
 
     
     func testTransferConfirmation () {
         let btc = Currency (uids: "Bitcoin",  name: "Bitcoin",  code: "BTC", type: "native", issuer: nil)
-        let BTC_SATOSHI = BRCrypto.Unit (currency: btc, uids: "BTC-SAT",  name: "Satoshi", symbol: "SAT")
+        //let BTC_SATOSHI = BRCrypto.Unit (currency: btc, uids: "BTC-SAT",  name: "Satoshi", symbol: "SAT")
 
         let confirmation = TransferConfirmation (blockNumber: 1,
                                                  transactionIndex: 2,
@@ -76,16 +194,5 @@ class BRCryptoTransferTests: BRCryptoSystemBaseTests {
         // XCTAssertEqual (TransferState.created, TransferState(core: CRYPTO_TRANSFER_STATE_CREATED))
         // ...
     }
-    func testTransfer () {
-/*
-        let wid = BRWalletNew ()
-        let tid = 
-        let coreTransfer = cryptoTransferCreateAsBTC (coreCurrency, wid, tid);
 
-        let transfer = Transfer (core: <#T##BRCryptoTransfer#>,
-                                 listener: <#T##TransferListener?#>,
-                                 wallet: <#T##Wallet#>,
-                                 unit: <#T##Unit#>)
-*/
-    }
 }

--- a/Swift/BRCryptoTests/BRCryptoWalletManagerTests.swift
+++ b/Swift/BRCryptoTests/BRCryptoWalletManagerTests.swift
@@ -12,37 +12,36 @@
 import XCTest
 @testable import BRCrypto
 
-#if false
-class Listener : BitcoinListener, EthereumListener {
-    func handleTokenEvent(manager: WalletManager, token: EthereumToken, event: EthereumTokenEvent) {
-
-    }
-
-    func handleManagerEvent(manager: WalletManager, event: WalletManagerEvent) {
-    }
-
-    func handleWalletEvent(manager: WalletManager, wallet: Wallet, event: WalletEvent) {
-    }
-
-    func handleTransferEvent(manager: WalletManager, wallet: Wallet, transfer: Transfer, event: TransferEvent) {
-    }
-}
-#endif
-
-class BRCryptoWalletManagerTests: XCTestCase {
-
-    #if false
-    var listener: Listener!
-    #endif
-
+class BRCryptoWalletManagerTests: BRCryptoSystemBaseTests {
+    
     override func setUp() {
+        super.setUp()
     }
 
     override func tearDown() {
     }
 
-    // Bitcoin
+    func testWalletManagerBTC() {
+        isMainnet = false
+        currencyCodesNeeded = ["btc"]
+        prepareSystem()
 
-    // Ethereum
+        let network: Network! = system.networks.first { "btc" == $0.currency.code && isMainnet == $0.isMainnet }
+        XCTAssertNotNil (network)
 
+        let manager: WalletManager! = system.managers.first { $0.network == network }
+        XCTAssertNotNil (manager)
+    }
+
+    func testWalletManagerETH () {
+        isMainnet = false
+        currencyCodesNeeded = ["eth"]
+        prepareSystem()
+
+        let network: Network! = system.networks.first { "eth" == $0.currency.code && isMainnet == $0.isMainnet }
+        XCTAssertNotNil (network)
+
+        let manager: WalletManager! = system.managers.first { $0.network == network }
+        XCTAssertNotNil (manager)
+    }
 }

--- a/Swift/BRCryptoTests/BRCryptoWalletManagerTests.swift
+++ b/Swift/BRCryptoTests/BRCryptoWalletManagerTests.swift
@@ -24,6 +24,7 @@ class BRCryptoWalletManagerTests: BRCryptoSystemBaseTests {
     func testWalletManagerBTC() {
         isMainnet = false
         currencyCodesNeeded = ["btc"]
+        prepareAccount()
         prepareSystem()
 
         let network: Network! = system.networks.first { "btc" == $0.currency.code && isMainnet == $0.isMainnet }
@@ -31,11 +32,40 @@ class BRCryptoWalletManagerTests: BRCryptoSystemBaseTests {
 
         let manager: WalletManager! = system.managers.first { $0.network == network }
         XCTAssertNotNil (manager)
+        XCTAssertTrue  (system  === manager.system)
+        XCTAssertTrue  (self.query === manager.query)
+        XCTAssertEqual (network, manager.network)
+
+        XCTAssertEqual (WalletManagerState.created, manager.state)
+        XCTAssertTrue  (manager.height > 0)
+        XCTAssertEqual (manager.primaryWallet.manager, manager)
+        XCTAssertEqual (1, manager.wallets.count)
+        XCTAssertTrue  (manager.wallets.contains(manager.primaryWallet))
+        XCTAssertTrue  (network.fees.contains(manager.defaultNetworkFee))
+
+        XCTAssertTrue  (system.supportedModes(network: network).contains(manager.mode))
+        XCTAssertEqual (system.defaultAddressScheme(network: network), manager.addressScheme)
+
+        let otherAddressScheme = system.supportedAddressSchemes(network: network).first { $0 != manager.addressScheme }!
+        manager.addressScheme = otherAddressScheme
+        XCTAssertEqual (otherAddressScheme, manager.addressScheme)
+        manager.addressScheme = system.defaultAddressScheme(network: network)
+        XCTAssertEqual (system.defaultAddressScheme(network: network), manager.addressScheme)
+
+        XCTAssertNotNil (manager.baseUnit)
+        XCTAssertNotNil (manager.defaultUnit)
+        XCTAssertFalse (manager.isActive)
+        XCTAssertEqual (manager, manager)
+        
+        XCTAssertEqual("btc", manager.description)
+
+        XCTAssertFalse (system.wallets.isEmpty)
     }
 
     func testWalletManagerETH () {
         isMainnet = false
         currencyCodesNeeded = ["eth"]
+        prepareAccount()
         prepareSystem()
 
         let network: Network! = system.networks.first { "eth" == $0.currency.code && isMainnet == $0.isMainnet }

--- a/Swift/BRCryptoTests/BRCryptoWalletTests.swift
+++ b/Swift/BRCryptoTests/BRCryptoWalletTests.swift
@@ -11,142 +11,25 @@
 
 import XCTest
 @testable import BRCrypto
-import BRCryptoC
-import BRCore
 
-fileprivate class TestListener: SystemListener {
-    var walletExpectation = XCTestExpectation (description: "walletExpectation")
-    var btcWallet: Wallet! = nil
-    var ethWallet: Wallet! = nil
-    var brdWallet: Wallet! = nil
-
-    func handleSystemEvent(system: System, event: SystemEvent) {
-        switch event {
-        default:
-            break
-        }
-    }
-
-    func handleNetworkEvent(system: System, network: Network, event: NetworkEvent) {
-        switch event {
-        case .created:
-            // A network was created; create the corresponding wallet manager.  Note: an actual
-            // App might not be interested in having a wallet manager for every network -
-            // specifically, test networks are announced and having a wallet manager for a
-            // testnet won't happen in a deployed App.
-
-            let mode = system.supportsMode (network: network, WalletManagerMode.p2p_only)
-                ? WalletManagerMode.p2p_only
-                : system.defaultMode(network: network)
-            let scheme = system.defaultAddressScheme(network: network)
-
-
-            let _ = system.createWalletManager (network: network,
-                                                mode: mode,
-                                                addressScheme: scheme)
-        }
-    }
-
-    func handleManagerEvent (system: System, manager: WalletManager, event: WalletManagerEvent) {
-        switch event {
-        case .created:
-            manager.connect()
-            // A WalletManager was created; create a wallet for each currency.
-            break
-        default:
-            break
-        }
-    }
-
-    func handleWalletEvent(system: System, manager: WalletManager, wallet: Wallet, event: WalletEvent) {
-        if case .created = event {
-            print ("Wallet: \(wallet.name)")
-            switch wallet.name.lowercased() {
-            case Currency.codeAsBTC:
-                btcWallet = wallet
-            case Currency.codeAsETH:
-                ethWallet = wallet
-            case "brd":
-                brdWallet = wallet
-            default:
-                return
-            }
-
-            if nil != btcWallet && nil != ethWallet && nil != brdWallet {
-                walletExpectation.fulfill()
-            }
-        }
-    }
-
-    func handleTransferEvent(system: System, manager: WalletManager, wallet: Wallet, transfer: Transfer, event: TransferEvent) {
-    }
-}
-
-///
-///
-///
-class BRCryptoWalletTests: BRCryptoBaseTests {
-    fileprivate var listener: TestListener! = nil
-    var system: System! = nil
+class BRCryptoWalletTests: BRCryptoSystemBaseTests {
 
     override func setUp() {
         super.setUp()
-        #if false
-        if (nil == listener) {
-            // Race condition
-            listener = TestListener()
-            system   = System (listener: listener,
-                               account: account,
-                               path: coreDataDir,
-                               query: BlockChainDB())
-            system.start (networksNeeded: ["bitcoin-mainnet", "ethereum-mainnet"])
-            wait (for: [listener.walletExpectation], timeout: 10)
-        }
-        #endif
     }
 
     override func tearDown() {
     }
 
-/*
-    func genericWalletTest (wallet: Wallet) {
+    func testWalletBTC() {
+        isMainnet = false
+        currencyCodesNeeded = ["btc"]
+        prepareSystem()
 
-        // guard let defaultUnit = wallet.manager.network.defaultUnitFor(currency: wallet.currency)
-        //     else { XCTAssertTrue(false); return }
+        let network: Network! = system.networks.first { "btc" == $0.currency.code && isMainnet == $0.isMainnet }
+        XCTAssertNotNil (network)
 
-        guard let baseUnit = wallet.manager.network.baseUnitFor (currency: wallet.currency)
-            else { XCTAssertTrue(false); return }
-
-        let feeUnit = wallet.manager.defaultUnit
-
-        XCTAssertEqual(wallet.balance, Amount.create( integer: 0, unit: baseUnit))
-
-        let feeBasis = wallet.defaultFeeBasis
-        let fee = wallet.estimateFee (amount: Amount.create(integer: 1, unit: baseUnit), feeBasis: nil)
-
-        switch cryptoFeeBasisGetType (feeBasis.core) {
-        case BLOCK_CHAIN_TYPE_BTC:
-            XCTAssertEqual (cryptoFeeBasisAsBTC(feeBasis.core), DEFAULT_FEE_PER_KB)
-            // Fee: XCTAssertEqual (fee, Amount.create(integer: 0, unit: feeUnit))
-        case BLOCK_CHAIN_TYPE_ETH:
-            let ethFeeBasis = cryptoFeeBasisAsETH (feeBasis.core)
-            XCTAssertEqual (ethFeeBasis.u.gas.limit.amountOfGas, wallet === listener.ethWallet ? 21000 : 92000)
-            // Fee: XCTAssertEqual (fee.asBTC, gasPrice.asETH * gasLimit)
-        default:
-            break
-        }
+        let manager: WalletManager! = system.managers.first { $0.network == network }
+        XCTAssertNotNil (manager)
     }
-*/
-    func testWallet() {
-        #if false
-        genericWalletTest(wallet: listener.btcWallet)
-        genericWalletTest(wallet: listener.ethWallet)
-        genericWalletTest(wallet: listener.brdWallet)
-        #endif
-    }
-
-//    func testPerformanceExample() {
-//        self.measure {
-//        }
-//    }
 }

--- a/Swift/BRCryptoTests/BRCryptoWalletTests.swift
+++ b/Swift/BRCryptoTests/BRCryptoWalletTests.swift
@@ -24,12 +24,156 @@ class BRCryptoWalletTests: BRCryptoSystemBaseTests {
     func testWalletBTC() {
         isMainnet = false
         currencyCodesNeeded = ["btc"]
-        prepareSystem()
+        prepareAccount (AccountSpecification (dict: [
+            "identifier": "ginger",
+            "paperKey":   "ginger settle marine tissue robot crane night number ramp coast roast critic",
+            "timestamp":  "2018-01-01",
+            "network":    (isMainnet ? "mainnet" : "testnet")
+            ]))
+        let listener = CryptoTestSystemListener (currencyCodesNeeded: currencyCodesNeeded, isMainnet: isMainnet)
+        prepareSystem(listener: listener)
 
         let network: Network! = system.networks.first { "btc" == $0.currency.code && isMainnet == $0.isMainnet }
         XCTAssertNotNil (network)
 
         let manager: WalletManager! = system.managers.first { $0.network == network }
         XCTAssertNotNil (manager)
+
+        let wallet = manager.primaryWallet
+        XCTAssertNotNil(wallet)
+
+        XCTAssertTrue  (system === wallet.system)
+        XCTAssertEqual (manager, wallet.manager)
+        XCTAssertEqual (network.currency, wallet.currency)
+        XCTAssertEqual (wallet.unit, manager.unit)
+        XCTAssertEqual (wallet.unit,       network.defaultUnitFor(currency: network.currency))
+        XCTAssertEqual (wallet.unitForFee, network.defaultUnitFor(currency: network.currency))
+        XCTAssertEqual (wallet.balance, Amount.create(integer: 0, unit: wallet.unit))
+        XCTAssertEqual (wallet.state, WalletState.created)
+        XCTAssertEqual (wallet.target, wallet.targetForScheme(manager.addressScheme))
+        XCTAssertEqual (wallet, wallet)
+
+        let feeBasisPricePerCostFactor = Amount.create (integer: 5000, unit: network.baseUnitFor(currency: network.currency)!)
+        let feeBasisCostFactor = 1.0
+        let feeBasis: TransferFeeBasis! =
+            wallet.createTransferFeeBasis (pricePerCostFactor: feeBasisPricePerCostFactor,
+                                           costFactor: feeBasisCostFactor)
+        XCTAssertNotNil(feeBasis)
+        XCTAssertEqual (feeBasis.currency, wallet.unitForFee.currency)
+        XCTAssertEqual (feeBasis.pricePerCostFactor, feeBasisPricePerCostFactor)
+        XCTAssertEqual (feeBasis.costFactor, feeBasisCostFactor)
+
+        // No existing transfers
+        XCTAssertTrue (wallet.transfers.isEmpty)
+
+        // With no existing transfers, cannot create a transfer (no BTC UTXOs)
+        let transferBaseUnit = network.baseUnitFor(currency: network.currency)!
+        let transferTargetAddress = wallet.target
+        let transferAmount = Amount.create (integer: 40000, unit: transferBaseUnit)
+        var transfer: Transfer! = wallet.createTransfer (target: transferTargetAddress,
+                                                         amount: transferAmount,
+                                                         estimatedFeeBasis: feeBasis)
+        XCTAssertNil(transfer)
+
+        // Connect and wait for a number of transfers
+        var transferCount: Int = 10
+        let transferExpectation = XCTestExpectation (description: "Transfer")
+        listener.walletHandlers += [
+            { (system: System, manager: WalletManager, wallet: Wallet, event: WalletEvent) -> Void in
+                switch event {
+                case .transferAdded:
+                    transferCount -= 1
+                    if 0 == transferCount {
+                        transferExpectation.fulfill()
+                    }
+                default: break
+                }
+            }]
+        manager.connect()
+        wait (for: [transferExpectation ], timeout: 70)
+
+        // Try again
+        transfer = wallet.createTransfer (target: transferTargetAddress,
+                                          amount: transferAmount,
+                                          estimatedFeeBasis: feeBasis)
+        XCTAssertNotNil(transfer)
+        XCTAssertEqual (transfer.wallet,  wallet)
+        XCTAssertEqual (transfer.manager, manager)
+        XCTAssertNotNil(transfer.estimatedFeeBasis)
+        // the transfer's estimatedFeeBasis is the original feeBasis but w/ a correct cost factor
+        XCTAssertNotEqual (transfer.estimatedFeeBasis!.fee, feeBasis.fee)
+        XCTAssertNotEqual (transfer.fee, feeBasis.fee)
+        XCTAssertEqual (transfer.target, transferTargetAddress)
+        XCTAssertEqual (transfer.unit, wallet.unit)
+        XCTAssertEqual (transfer.amount, transferAmount)
+        XCTAssertEqual (transfer.amountDirected, transferAmount)
+
+        XCTAssertNil   (transfer.confirmedFeeBasis)
+        XCTAssertNil   (transfer.confirmation)
+        XCTAssertNil   (transfer.confirmations)
+        XCTAssertNil   (transfer.confirmationsAt(blockHeight: 10))
+
+        XCTAssertNil   (transfer.hash)
+        if case .created = transfer.state {} else { XCTAssertTrue (false ) }
+        XCTAssertEqual (transfer.direction, TransferDirection.recovered)
+
+        // Estiamte the fee
+        let feeEstimateExpectation = XCTestExpectation (description: "FeeEstimate")
+        var feeEstimateResult: Result<TransferFeeBasis, Wallet.FeeEstimationError>!
+        wallet.estimateFee (target: transferTargetAddress,
+                            amount: transferAmount,
+                            fee: network.minimumFee) { (res: Result<TransferFeeBasis, Wallet.FeeEstimationError>) in
+                                feeEstimateResult = res
+                                feeEstimateExpectation.fulfill()
+        }
+        wait (for: [feeEstimateExpectation], timeout: 10)
+        XCTAssertNotNil (feeEstimateResult)
+        if case .success = feeEstimateResult! {} else { XCTAssertTrue(false) }
+
+        manager.disconnect()
+    }
+
+    func testWalletETH() {
+        isMainnet = false
+        currencyCodesNeeded = ["eth"]
+        prepareAccount (AccountSpecification (dict: [
+            "identifier": "ginger",
+            "paperKey":   "ginger settle marine tissue robot crane night number ramp coast roast critic",
+            "timestamp":  "2018-01-01",
+            "network":    (isMainnet ? "mainnet" : "testnet")
+            ]))
+        let listener = CryptoTestSystemListener (currencyCodesNeeded: currencyCodesNeeded, isMainnet: isMainnet)
+
+        // Connect and wait for a number of transfers
+        var walletCount: Int = 2
+        let walletExpectation = XCTestExpectation (description: "Wallet")
+        listener.managerHandlers += [
+            { (system: System, manager: WalletManager, event: WalletManagerEvent) -> Void in
+                switch event {
+                case .walletAdded:
+                    walletCount -= 1
+                    if 0 == walletCount {
+                        walletExpectation.fulfill()
+                    }
+                default: break
+                }
+            }]
+
+        prepareSystem(listener: listener)
+
+        let network: Network! = system.networks.first { "eth" == $0.currency.code && isMainnet == $0.isMainnet }
+        XCTAssertNotNil (network)
+
+        let manager: WalletManager! = system.managers.first { $0.network == network }
+        XCTAssertNotNil (manager)
+
+        wait (for: [walletExpectation ], timeout: 10)
+        XCTAssertFalse (manager.wallets.isEmpty)
+        XCTAssertTrue  (manager.wallets.count >= 2)
+        let w0 = manager.wallets[0]
+        let w1 = manager.wallets[1]
+
+        XCTAssertEqual (w0, w0)
+        XCTAssertNotEqual (w0, w1)
     }
 }

--- a/crypto/BRCryptoTransfer.c
+++ b/crypto/BRCryptoTransfer.c
@@ -242,20 +242,20 @@ cryptoTransferGetAmountAsSign (BRCryptoTransfer transfer, BRCryptoBoolean isNega
             switch (cryptoTransferGetDirection(transfer)) {
                 case CRYPTO_TRANSFER_RECOVERED:
                     amount = cryptoAmountCreate (currency,
-                                               isNegative,
-                                               createUInt256(send));
+                                                 isNegative,
+                                                 createUInt256(send));
                     break;
 
                 case CRYPTO_TRANSFER_SENT:
                     amount = cryptoAmountCreate (currency,
-                                               isNegative,
-                                               createUInt256(send - fee - recv));
+                                                 isNegative,
+                                                 createUInt256(send - fee - recv));
                     break;
 
                 case CRYPTO_TRANSFER_RECEIVED:
                     amount = cryptoAmountCreate (currency,
-                                               isNegative,
-                                               createUInt256(recv));
+                                                 isNegative,
+                                                 createUInt256(recv));
                     break;
                     
                 default: assert(0);


### PR DESCRIPTION
This does not completely cover the WalletManager, Wallet and Transfer interface - but, aside from 'submit', it is pretty good.  Would expect to add more tests as some existing bugs are fixed.

This is all in Swift; certain things must be; some others could be in C, at some point.

This does include a merge from CORE-480 (EWM Event Handlers) and we'd expect CORE-480 to be reworked in a future merge to 'crypto'