### PR TITLE
CORE-421: Move Amount.unit into BRCryptoAmount

### DIFF
--- a/Java/CoreCrypto/src/androidTest/java/com/breadwallet/corecrypto/AmountAIT.java
+++ b/Java/CoreCrypto/src/androidTest/java/com/breadwallet/corecrypto/AmountAIT.java
@@ -41,6 +41,9 @@ public class AmountAIT {
 
         assertEquals("-B1.50", btc4.toStringAsUnit(btc_btc, null).get());
         assertEquals("-SAT150,000,000", btc4.toStringAsUnit(satoshi_btc, null).get());
+
+        assertEquals (btc1.doubleAmount(btc_btc).get(),     btc1.convert(satoshi_btc).get().doubleAmount(btc_btc).get());
+        assertEquals (btc1.doubleAmount(satoshi_btc).get(), btc1.convert(btc_btc).get().doubleAmount(satoshi_btc).get());
     }
 
     @Test

--- a/Java/CoreCrypto/src/main/java/com/breadwallet/corecrypto/System.java
+++ b/Java/CoreCrypto/src/main/java/com/breadwallet/corecrypto/System.java
@@ -1075,7 +1075,7 @@ final class System implements com.breadwallet.crypto.System {
                 Optional<Wallet> optWallet = walletManager.getWallet(coreWallet);
                 if (optWallet.isPresent()) {
                     Wallet wallet = optWallet.get();
-                    Amount amount = Amount.create(coreAmount, wallet.getUnit());
+                    Amount amount = Amount.create(coreAmount);
                     Log.d(TAG, String.format("WalletBalanceUpdated: %s", amount));
                     system.announceWalletEvent(walletManager, wallet, new WalletBalanceUpdatedEvent(amount));
 

--- a/Java/CoreCrypto/src/main/java/com/breadwallet/corecrypto/Transfer.java
+++ b/Java/CoreCrypto/src/main/java/com/breadwallet/corecrypto/Transfer.java
@@ -55,8 +55,8 @@ final class Transfer implements com.breadwallet.crypto.Transfer {
 
         this.sourceSupplier = Suppliers.memoize(() -> core.getSourceAddress().transform(Address::create));
         this.targetSupplier = Suppliers.memoize(() -> core.getTargetAddress().transform(Address::create));
-        this.amountSupplier = Suppliers.memoize(() -> Amount.create(core.getAmount(), unit));
-        this.directedSupplier = Suppliers.memoize(() -> Amount.create(core.getAmountDirected(), unit));
+        this.amountSupplier = Suppliers.memoize(() -> Amount.create(core.getAmount()));
+        this.directedSupplier = Suppliers.memoize(() -> Amount.create(core.getAmountDirected()));
         this.directionSupplier = Suppliers.memoize(() -> Utilities.transferDirectionFromCrypto(core.getDirection()));
         this.hashSupplier = Suppliers.memoize(() -> core.getHash().transform(TransferHash::create));
     }

--- a/Java/CoreCrypto/src/main/java/com/breadwallet/corecrypto/TransferFeeBasis.java
+++ b/Java/CoreCrypto/src/main/java/com/breadwallet/corecrypto/TransferFeeBasis.java
@@ -32,10 +32,10 @@ class TransferFeeBasis implements com.breadwallet.crypto.TransferFeeBasis {
 
         this.unit= Unit.create(core.getPricePerCostFactorUnit());
         this.costFactorSupplier = Suppliers.memoize(core::getCostFactor);
-        this.pricePerCostFactorSupplier = Suppliers.memoize(() -> Amount.create(core.getPricePerCostFactor(), unit));
+        this.pricePerCostFactorSupplier = Suppliers.memoize(() -> Amount.create(core.getPricePerCostFactor()));
 
         // TODO(fix): Unchecked get here
-        this.feeSupplier = Suppliers.memoize(() -> Amount.create(core.getFee().get(), unit));
+        this.feeSupplier = Suppliers.memoize(() -> Amount.create(core.getFee().get()));
     }
 
     @Override

--- a/Java/CoreCrypto/src/main/java/com/breadwallet/corecrypto/Utilities.java
+++ b/Java/CoreCrypto/src/main/java/com/breadwallet/corecrypto/Utilities.java
@@ -14,6 +14,7 @@ import com.breadwallet.corenative.crypto.BRCryptoTransferState;
 import com.breadwallet.corenative.crypto.BRCryptoTransferStateType;
 import com.breadwallet.corenative.crypto.BRCryptoWalletManagerState;
 import com.breadwallet.corenative.crypto.BRCryptoWalletState;
+import com.breadwallet.corenative.crypto.CoreBRCryptoAmount;
 import com.breadwallet.corenative.support.BRSyncMode;
 import com.breadwallet.crypto.AddressScheme;
 import com.breadwallet.crypto.TransferConfirmation;
@@ -123,12 +124,11 @@ final class Utilities {
                 }
                 return TransferState.FAILED(message.substring(0, end));
             case BRCryptoTransferStateType.CRYPTO_TRANSFER_STATE_INCLUDED:
-                // TODO(fix): Fill in the fee
                 return TransferState.INCLUDED(new TransferConfirmation(
                         UnsignedLong.fromLongBits(state.u.included.blockNumber),
                         UnsignedLong.fromLongBits(state.u.included.transactionIndex),
                         UnsignedLong.fromLongBits(state.u.included.timestamp),
-                        Optional.absent()
+                        Optional.fromNullable(state.u.included.fee).transform(Amount::takeAndCreate)
                 ));
             default: throw new IllegalArgumentException("Unsupported state");
         }

--- a/Java/CoreCrypto/src/main/java/com/breadwallet/corecrypto/Wallet.java
+++ b/Java/CoreCrypto/src/main/java/com/breadwallet/corecrypto/Wallet.java
@@ -109,7 +109,7 @@ final class Wallet implements com.breadwallet.crypto.Wallet {
 
     @Override
     public Amount getBalance() {
-        return Amount.create(core.getBalance(), unit);
+        return Amount.create(core.getBalance());
     }
 
     @Override

--- a/Java/CoreNative/src/main/java/com/breadwallet/corenative/CryptoLibrary.java
+++ b/Java/CoreNative/src/main/java/com/breadwallet/corenative/CryptoLibrary.java
@@ -64,6 +64,7 @@ public interface CryptoLibrary extends Library {
     BRCryptoAmount cryptoAmountCreateInteger(long value, BRCryptoUnit unit);
     BRCryptoAmount cryptoAmountCreateString(String value, int isNegative, BRCryptoUnit unit);
     BRCryptoCurrency cryptoAmountGetCurrency(BRCryptoAmount amount);
+    BRCryptoUnit cryptoAmountGetUnit(BRCryptoAmount brCryptoAmount);
     int cryptoAmountHasCurrency(BRCryptoAmount amount, BRCryptoCurrency currency);
     int cryptoAmountIsNegative(BRCryptoAmount amount);
     int cryptoAmountIsCompatible(BRCryptoAmount a1, BRCryptoAmount a2);
@@ -71,9 +72,11 @@ public interface CryptoLibrary extends Library {
     BRCryptoAmount cryptoAmountAdd(BRCryptoAmount a1, BRCryptoAmount a2);
     BRCryptoAmount cryptoAmountSub(BRCryptoAmount a1, BRCryptoAmount a2);
     BRCryptoAmount cryptoAmountNegate(BRCryptoAmount amount);
+    BRCryptoAmount cryptoAmountConvertToUnit(BRCryptoAmount amount, BRCryptoUnit unit);
     double cryptoAmountGetDouble(BRCryptoAmount amount, BRCryptoUnit unit, IntByReference overflow);
     long cryptoAmountGetIntegerRaw(BRCryptoAmount amount, IntByReference overflow);
     UInt256.ByValue cryptoAmountGetValue(BRCryptoAmount amount);
+    BRCryptoAmount cryptoAmountTake(BRCryptoAmount obj);
     void cryptoAmountGive(BRCryptoAmount obj);
 
     // crypto/BRCryptoCurrency.h

--- a/Java/CoreNative/src/main/java/com/breadwallet/corenative/crypto/BRCryptoAmount.java
+++ b/Java/CoreNative/src/main/java/com/breadwallet/corenative/crypto/BRCryptoAmount.java
@@ -34,6 +34,11 @@ public class BRCryptoAmount extends PointerType implements CoreBRCryptoAmount {
     }
 
     @Override
+    public CoreBRCryptoUnit getUnit() {
+        return new OwnedBRCryptoUnit(CryptoLibrary.INSTANCE.cryptoAmountGetUnit(this));
+    }
+
+    @Override
     public Optional<Double> getDouble(CoreBRCryptoUnit unit) {
         BRCryptoUnit unitCore = unit.asBRCryptoUnit();
         IntByReference overflowRef = new IntByReference(BRCryptoBoolean.CRYPTO_FALSE);
@@ -56,6 +61,11 @@ public class BRCryptoAmount extends PointerType implements CoreBRCryptoAmount {
     @Override
     public CoreBRCryptoAmount negate() {
         return new OwnedBRCryptoAmount(CryptoLibrary.INSTANCE.cryptoAmountNegate(this));
+    }
+
+    @Override
+    public Optional<CoreBRCryptoAmount> convert(CoreBRCryptoUnit toUnit) {
+        return Optional.fromNullable(CryptoLibrary.INSTANCE.cryptoAmountConvertToUnit(this, toUnit.asBRCryptoUnit())).transform(OwnedBRCryptoAmount::new);
     }
 
     @Override

--- a/Java/CoreNative/src/main/java/com/breadwallet/corenative/crypto/CoreBRCryptoAmount.java
+++ b/Java/CoreNative/src/main/java/com/breadwallet/corenative/crypto/CoreBRCryptoAmount.java
@@ -36,7 +36,13 @@ public interface CoreBRCryptoAmount {
         return new OwnedBRCryptoAmount(amount);
     }
 
+    static CoreBRCryptoAmount takeAndCreateOwned(BRCryptoAmount amount) {
+        return new OwnedBRCryptoAmount(CryptoLibrary.INSTANCE.cryptoAmountTake(amount));
+    }
+
     CoreBRCryptoCurrency getCurrency();
+
+    CoreBRCryptoUnit getUnit();
 
     Optional<Double> getDouble(CoreBRCryptoUnit unit);
 
@@ -45,6 +51,8 @@ public interface CoreBRCryptoAmount {
     Optional<CoreBRCryptoAmount> sub(CoreBRCryptoAmount amount);
 
     CoreBRCryptoAmount negate();
+
+    Optional<CoreBRCryptoAmount> convert(CoreBRCryptoUnit toUnit);
 
     boolean isNegative();
 

--- a/Java/CoreNative/src/main/java/com/breadwallet/corenative/crypto/OwnedBRCryptoAmount.java
+++ b/Java/CoreNative/src/main/java/com/breadwallet/corenative/crypto/OwnedBRCryptoAmount.java
@@ -38,6 +38,11 @@ class OwnedBRCryptoAmount implements CoreBRCryptoAmount {
     }
 
     @Override
+    public CoreBRCryptoUnit getUnit() {
+        return core.getUnit();
+    }
+
+    @Override
     public Optional<Double> getDouble(CoreBRCryptoUnit unit) {
         return core.getDouble(unit);
     }
@@ -55,6 +60,11 @@ class OwnedBRCryptoAmount implements CoreBRCryptoAmount {
     @Override
     public CoreBRCryptoAmount negate() {
         return core.negate();
+    }
+
+    @Override
+    public Optional<CoreBRCryptoAmount> convert(CoreBRCryptoUnit toUnit) {
+        return core.convert(toUnit);
     }
 
     @Override

--- a/Java/Crypto/src/main/java/com/breadwallet/crypto/Amount.java
+++ b/Java/Crypto/src/main/java/com/breadwallet/crypto/Amount.java
@@ -43,6 +43,8 @@ public interface Amount extends Comparable<Amount> {
 
     Amount negate();
 
+    Optional<? extends Amount> convert(Unit toUnit);
+
     Optional<String> toStringAsUnit(Unit asUnit);
 
     Optional<String> toStringAsUnit(Unit asUnit, NumberFormat numberFormatter);

--- a/Swift/BRCrypto/BRCryptoAmount.swift
+++ b/Swift/BRCrypto/BRCryptoAmount.swift
@@ -23,7 +23,9 @@ public final class Amount {
     /// The (default) unit.  Without this there is no reasonable implementation of
     /// CustomeStringConvertable.  This property is only used in the `description` function
     /// and to ascertain the Amount's currency typically for consistency in add/sub functions.
-    public let unit: Unit
+    public var unit: Unit {
+        return Unit (core: cryptoAmountGetUnit (core), take: false)
+    }
 
     /// The currency
     public var currency: Currency {
@@ -89,35 +91,36 @@ public final class Amount {
     public func add (_ that: Amount) -> Amount? {
         precondition (isCompatible (with: that))
         return cryptoAmountAdd (self.core, that.core)
-            .map { Amount (core: $0, unit: self.unit, take: false) }
+            .map { Amount (core: $0, take: false) }
     }
 
     public func sub (_ that: Amount) -> Amount? {
         precondition (isCompatible (with: that))
         return cryptoAmountSub (self.core, that.core)
-            .map { Amount (core: $0, unit: self.unit, take: false) }
+            .map { Amount (core: $0, take: false) }
+    }
+
+    public func convert (to unit: Unit) -> Amount? {
+        return cryptoAmountConvertToUnit (self.core, unit.core)
+                .map { Amount (core: $0, take: false) }
     }
 
     public var negate: Amount {
-        return Amount (core: cryptoAmountNegate (core), unit: unit, take: false)
+        return Amount (core: cryptoAmountNegate (core), take: false)
     }
 
     internal init (core: BRCryptoAmount,
-                   unit: Unit,
                    take: Bool) {
         self.core = take ? cryptoAmountTake(core) : core
-        self.unit = unit
     }
 
     public static func create (double: Double, unit: Unit) -> Amount {
         return Amount (core: cryptoAmountCreateDouble (double, unit.core),
-                       unit: unit,
                        take: false)
     }
 
     public static func create (integer: Int64, unit: Unit) -> Amount {
         return Amount (core: cryptoAmountCreateInteger (integer, unit.core),
-                       unit: unit,
                        take: false)
     }
 
@@ -147,7 +150,7 @@ public final class Amount {
     ///
     public static func create (string: String, negative: Bool = false, unit: Unit) -> Amount? {
         return cryptoAmountCreateString (string, (negative ? CRYPTO_TRUE : CRYPTO_FALSE), unit.core)
-            .map { Amount (core: $0, unit: unit, take: false) }
+            .map { Amount (core: $0, take: false) }
     }
 
     ///

--- a/Swift/BRCrypto/BRCryptoNetwork.swift
+++ b/Swift/BRCrypto/BRCryptoNetwork.swift
@@ -261,7 +261,6 @@ public final class NetworkFee: Equatable {
         self.core = (take ? cryptoNetworkFeeTake(core) : core)
         self.timeIntervalInMilliseconds = cryptoNetworkFeeGetConfirmationTimeInMilliseconds(core)
         self.pricePerCostFactor = Amount (core: cryptoNetworkFeeGetPricePerCostFactor (core),
-                                          unit: Unit (core: cryptoNetworkFeeGetPricePerCostFactorUnit(core), take: false),
                                           take: false)
     }
 

--- a/Swift/BRCrypto/BRCryptoSystem.swift
+++ b/Swift/BRCrypto/BRCryptoSystem.swift
@@ -660,7 +660,6 @@ extension System {
 
                 case CRYPTO_WALLET_EVENT_BALANCE_UPDATED:
                     let amount = Amount (core: event.u.balanceUpdated.amount,
-                                         unit: wallet.unit,
                                          take: false)
                     system.listener?.handleWalletEvent (system: manager.system,
                                                         manager: manager,

--- a/Swift/BRCrypto/BRCryptoTransfer.swift
+++ b/Swift/BRCrypto/BRCryptoTransfer.swift
@@ -121,8 +121,8 @@ public final class Transfer: Equatable {
             .map { TransferFeeBasis (core: $0, take: false) }
 
         // Other properties
-        self.amount         = Amount (core: cryptoTransferGetAmount (core),        unit: wallet.unit, take: false)
-        self.amountDirected = Amount (core: cryptoTransferGetAmountDirected(core), unit: wallet.unit, take: false)
+        self.amount         = Amount (core: cryptoTransferGetAmount (core),        take: false)
+        self.amountDirected = Amount (core: cryptoTransferGetAmountDirected(core), take: false)
     }
 
 
@@ -222,14 +222,12 @@ public class TransferFeeBasis {
         let unit = Unit (core: cryptoFeeBasisGetPricePerCostFactorUnit(core), take: false)
 
         self.unit = unit
-        self.pricePerCostFactor = Amount (core: cryptoFeeBasisGetPricePerCostFactor(core),
-                                          unit: unit,
-                                          take: false)
+        self.pricePerCostFactor = Amount (core: cryptoFeeBasisGetPricePerCostFactor(core), take: false)
         self.costFactor  = cryptoFeeBasisGetCostFactor (core)
 
         // The Core fee calculation might overflow.
         guard let fee = cryptoFeeBasisGetFee (core)
-            .map ({ Amount (core: $0, unit: unit, take: false) })
+            .map ({ Amount (core: $0, take: false) })
             else { print ("Missed Fee"); preconditionFailure () }
 
         self.fee = fee
@@ -298,7 +296,7 @@ public enum TransferState {
             confirmation: TransferConfirmation (blockNumber: core.u.included.blockNumber,
                                                 transactionIndex: core.u.included.transactionIndex,
                                                 timestamp: core.u.included.timestamp,
-                                                fee: nil))
+                                                fee: core.u.included.fee.map { Amount (core: $0, take: true) }))
         case CRYPTO_TRANSFER_STATE_ERRORRED:  self = .failed(reason: asUTF8String(cryptoTransferStateGetErrorMessage (core)))
         case CRYPTO_TRANSFER_STATE_DELETED:   self = .deleted
         default: /* ignore this */ self = .pending; precondition(false)

--- a/Swift/BRCrypto/BRCryptoWallet.swift
+++ b/Swift/BRCrypto/BRCryptoWallet.swift
@@ -46,7 +46,7 @@ public final class Wallet: Equatable {
 
     /// The current balance for currency
     public var balance: Amount {
-        return Amount (core: cryptoWalletGetBalance (core), unit: unit, take: false)
+        return Amount (core: cryptoWalletGetBalance (core), take: false)
     }
 
     /// The current state.

--- a/Swift/BRCryptoTests/BRCryptoAmountTests.swift
+++ b/Swift/BRCryptoTests/BRCryptoAmountTests.swift
@@ -119,6 +119,9 @@ class BRCryptoAmountTests: XCTestCase {
         XCTAssert ("-B1.50"          == btc4.string (as: BTC_BTC))
         XCTAssert ("-SAT150,000,000" == btc4.string (as: BTC_SATOSHI))
 
+        XCTAssertEqual (btc1.double(as: BTC_BTC),     btc1.convert(to: BTC_SATOSHI)?.double(as: BTC_BTC))
+        XCTAssertEqual (btc1.double(as: BTC_SATOSHI), btc1.convert(to: BTC_BTC)?.double(as: BTC_SATOSHI))
+
         let formatter = NumberFormatter()
         formatter.minimumFractionDigits = 2
         formatter.generatesDecimalNumbers = true
@@ -267,7 +270,8 @@ class BRCryptoAmountTests: XCTestCase {
         let btc3 = Amount.create(double: 1e20, unit: BTC_SATOSHI)
         XCTAssertNotNil (btc3.double(as: BTC_MONGO))
 
-        let _ = Amount (core: btc1.core, unit: BTC_SATOSHI, take: true)
+        let btc4 = Amount (core: btc1.core, take: true)
+        XCTAssertTrue (btc4.core == btc1.core)
     }
 
     func testCurrencyPair () {

--- a/crypto/BRCryptoAmount.c
+++ b/crypto/BRCryptoAmount.c
@@ -36,7 +36,7 @@ static void
 cryptoAmountRelease (BRCryptoAmount amount);
 
 struct BRCryptoAmountRecord {
-    BRCryptoCurrency currency;
+    BRCryptoUnit unit;
     BRCryptoBoolean isNegative;
     UInt256 value;
     BRCryptoRef ref;
@@ -45,13 +45,13 @@ struct BRCryptoAmountRecord {
 IMPLEMENT_CRYPTO_GIVE_TAKE (BRCryptoAmount, cryptoAmount);
 
 private_extern BRCryptoAmount
-cryptoAmountCreateInternal (BRCryptoCurrency currency,
+cryptoAmountCreateInternal (BRCryptoUnit unit,
                             BRCryptoBoolean isNegative,
                             UInt256 value,
-                            int takeCurrency) {
+                            int takeUnit) {
     BRCryptoAmount amount = malloc (sizeof (struct BRCryptoAmountRecord));
 
-    amount->currency = takeCurrency ? cryptoCurrencyTake (currency) : currency;
+    amount->unit = takeUnit ? cryptoUnitTake (unit) : unit;
     amount->isNegative = isNegative;
     amount->value = value;
     amount->ref = CRYPTO_REF_ASSIGN (cryptoAmountRelease);
@@ -60,10 +60,11 @@ cryptoAmountCreateInternal (BRCryptoCurrency currency,
 }
 
 private_extern BRCryptoAmount
-cryptoAmountCreate (BRCryptoCurrency currency,
+cryptoAmountCreate (BRCryptoUnit unit,
                     BRCryptoBoolean isNegative,
                     UInt256 value) {
-    return cryptoAmountCreateInternal (currency, isNegative, value, 1);
+    // Given a UInt256 -> conversion to unit already complete.
+    return cryptoAmountCreateInternal (unit, isNegative, value, 1);
 }
 
 static BRCryptoAmount
@@ -78,7 +79,7 @@ cryptoAmountCreateUInt256 (UInt256 v,
         v = mulUInt256_Overflow (v, createUInt256Power(decimals, &powOverflow), &mulOverflow);
 
     return (powOverflow || mulOverflow ? NULL
-            : cryptoAmountCreateInternal (cryptoUnitGetCurrency (unit), isNegative, v, 0));
+            : cryptoAmountCreateInternal (unit, isNegative, v, 1));
 }
 
 extern BRCryptoAmount
@@ -89,10 +90,10 @@ cryptoAmountCreateDouble (double value,
 
     return (overflow
             ? NULL
-            : cryptoAmountCreateInternal (cryptoUnitGetCurrency(unit),
+            : cryptoAmountCreateInternal (unit,
                                           (value < 0.0 ? CRYPTO_TRUE : CRYPTO_FALSE),
                                           valueAsUInt256,
-                                          0));
+                                          1));
 }
 
 extern BRCryptoAmount
@@ -126,19 +127,24 @@ cryptoAmountCreateString (const char *value,
 static void
 cryptoAmountRelease (BRCryptoAmount amount) {
 //    printf ("Amount: Release\n");
-    cryptoCurrencyGive (amount->currency);
+    cryptoUnitGive (amount->unit);
     free (amount);
+}
+
+extern BRCryptoUnit
+cryptoAmountGetUnit (BRCryptoAmount amount) {
+    return cryptoUnitTake (amount->unit);
 }
 
 extern BRCryptoCurrency
 cryptoAmountGetCurrency (BRCryptoAmount amount) {
-    return cryptoCurrencyTake (amount->currency);
+    return cryptoUnitGetCurrency(amount->unit);
 }
 
 extern BRCryptoBoolean
 cryptoAmountHasCurrency (BRCryptoAmount amount,
                          BRCryptoCurrency currency) {
-    return AS_CRYPTO_BOOLEAN (amount->currency == currency);
+    return cryptoUnitHasCurrency(amount->unit, currency);
 }
 
 extern BRCryptoBoolean
@@ -149,7 +155,7 @@ cryptoAmountIsNegative (BRCryptoAmount amount) {
 extern BRCryptoBoolean
 cryptoAmountIsCompatible (BRCryptoAmount a1,
                           BRCryptoAmount a2) {
-    return cryptoCurrencyIsIdentical (a1->currency, a2->currency);
+    return cryptoUnitIsCompatible (a1->unit, a2->unit);
 }
 
 static BRCryptoComparison
@@ -182,12 +188,12 @@ cryptoAmountCompare (BRCryptoAmount a1,
 extern BRCryptoAmount
 cryptoAmountAdd (BRCryptoAmount a1,
                  BRCryptoAmount a2) {
-    assert (CRYPTO_TRUE == cryptoAmountIsCompatible(a1, a2));
+    assert (CRYPTO_TRUE == cryptoAmountIsCompatible (a1, a2));
 
     int overflow = 0;
     UInt256 sum = addUInt256_Overflow(a1->value, a2->value, &overflow);
 
-    return overflow ? NULL : cryptoAmountCreate (a1->currency, CRYPTO_FALSE, sum);
+    return overflow ? NULL : cryptoAmountCreate (a1->unit, CRYPTO_FALSE, sum);
 }
 
 extern BRCryptoAmount
@@ -199,29 +205,37 @@ cryptoAmountSub (BRCryptoAmount a1,
     if (CRYPTO_TRUE == a1->isNegative && CRYPTO_TRUE != a2->isNegative) {
         // (-x) - y = - (x + y)
         UInt256 value = addUInt256_Overflow (a1->value, a2->value, &overflow);
-        return overflow ? NULL : cryptoAmountCreate (a1->currency, CRYPTO_TRUE, value);
+        return overflow ? NULL : cryptoAmountCreate (a1->unit, CRYPTO_TRUE, value);
     }
     else if (CRYPTO_TRUE != a1->isNegative && CRYPTO_TRUE == a2->isNegative) {
         // x - (-y) = x + y
         UInt256 value = addUInt256_Overflow (a1->value, a2->value, &overflow);
-        return overflow ? NULL : cryptoAmountCreate(a1->currency, CRYPTO_FALSE, value);
+        return overflow ? NULL : cryptoAmountCreate(a1->unit, CRYPTO_FALSE, value);
     }
     else if (CRYPTO_TRUE == a1->isNegative && CRYPTO_TRUE == a2->isNegative) {
         // (-x) - (-y) = y - x
         UInt256 value = subUInt256_Negative (a2->value, a1->value, &negative);
-        return cryptoAmountCreate (a1->currency, AS_CRYPTO_BOOLEAN(negative), value);
+        return cryptoAmountCreate (a1->unit, AS_CRYPTO_BOOLEAN(negative), value);
     }
     else {
         UInt256 value = subUInt256_Negative (a1->value, a2->value, &negative);
-        return cryptoAmountCreate (a1->currency, AS_CRYPTO_BOOLEAN(negative), value);
+        return cryptoAmountCreate (a1->unit, AS_CRYPTO_BOOLEAN(negative), value);
     }
 }
 
 extern BRCryptoAmount
 cryptoAmountNegate (BRCryptoAmount amount) {
-    return cryptoAmountCreate (amount->currency,
+    return cryptoAmountCreate (amount->unit,
                                CRYPTO_TRUE == amount->isNegative ? CRYPTO_FALSE : CRYPTO_TRUE,
                                amount->value);
+}
+
+extern BRCryptoAmount
+cryptoAmountConvertToUnit (BRCryptoAmount amount,
+                           BRCryptoUnit unit) {
+    return (CRYPTO_TRUE != cryptoUnitIsCompatible (amount->unit, unit)
+            ? NULL
+            : cryptoAmountCreate (unit, amount->isNegative, amount->value));
 }
 
 extern double

--- a/crypto/BRCryptoAmount.h
+++ b/crypto/BRCryptoAmount.h
@@ -43,19 +43,61 @@ extern "C" {
 
     typedef struct BRCryptoAmountRecord *BRCryptoAmount;
 
+    /**
+     * Create an amount from `value` in `unit`.  If the amount is "2 Bitcoin" then, for example,
+     * the amount can be created from either of {2.0, BTC} or {2e8, SAT}.
+     *
+     * @note The internal representation is always as a UInt256 in the currency's baseUnit (aka
+     * the 'integer unit').  This allows easy arithmetic operations w/o conversions.  Conversions
+     * to the base unit happens on creation, and conversion from the base unit happens on display.
+     *
+     * @param value
+     * @param unit
+     *
+     * @return An amount
+     */
     extern BRCryptoAmount
     cryptoAmountCreateDouble (double value,
                               BRCryptoUnit unit);
 
+    /**
+     * Create an amount form `value` in `unit`.  See discusion on `cryptoAmountCreateDouble()`
+     *
+     * @param value
+     * @param unit
+     *
+     *@return An Amount
+     */
     extern BRCryptoAmount
     cryptoAmountCreateInteger (int64_t value,
                                BRCryptoUnit unit);
 
+    /**
+     * Create an amount from `value` and `unit`. See discusion on `cryptoAmountCreateDouble()`
+     *
+     * @note there are some constraints on `const char *value` that need to be described.
+     *
+     * @param value
+     * @param isNegative
+     * @param unit
+     *
+     * @return An amount
+     */
     extern BRCryptoAmount
     cryptoAmountCreateString (const char *value,
                               BRCryptoBoolean isNegative,
                               BRCryptoUnit unit);
 
+    /**
+     * Returns the amount's unit.
+     *
+     * @param amount The amount
+     *
+     * @return The amount's unit, typically use for default display w/ an incremented reference
+     *    count (aka 'taken')
+     */
+    extern BRCryptoUnit
+    cryptoAmountGetUnit (BRCryptoAmount amount);
 
     /**
      * Returns the amount's currency
@@ -74,6 +116,16 @@ extern "C" {
     extern BRCryptoBoolean
     cryptoAmountIsNegative (BRCryptoAmount amount);
 
+
+    /**
+     * Check of two amount's are compatible; they are compatible if they have the same currency and
+     * thus can be added.
+     *
+     * @param a1
+     * @param a2
+     *
+     * @return
+     */
     extern BRCryptoBoolean
     cryptoAmountIsCompatible (BRCryptoAmount a1,
                               BRCryptoAmount a2);
@@ -92,17 +144,51 @@ extern "C" {
 
     extern BRCryptoAmount
     cryptoAmountNegate (BRCryptoAmount amount);
-    
+
+    /**
+     * Convert `amount` into `unit`
+     *
+     * @param amount
+     * @param unit
+     *
+     * @note: if `unit` is incompatible, then NULL is returned.
+     *
+     * @return An amount
+     */
+    extern BRCryptoAmount
+    cryptoAmountConvertToUnit (BRCryptoAmount amount,
+                               BRCryptoUnit unit);
+
+    /**
+     * Return `amount` as a double in `unit`.  For example, if amount is "2 BTC" and unit is
+     * SAT then the returned value will be 2e8; if amount is "2e6 SAT" and unit is "BTC" then the
+     * return value will be 0.02.
+     *
+     * @param amount
+     * @param unit
+     * @param overflow
+     *
+     * @return A double
+     */
     extern double
     cryptoAmountGetDouble (BRCryptoAmount amount,
                            BRCryptoUnit unit,
                            BRCryptoBoolean *overflow);
 
+    /**
+     * Return `amount` as a UInt64 if the representation of `amount` in the base unit is less than
+     * or equal to UINT64_MAX; otherwise set overflow.
+     *
+     * @param amount
+     * @param overflow
+     *
+     * @return
+     */
     extern uint64_t
     cryptoAmountGetIntegerRaw (BRCryptoAmount amount,
                                BRCryptoBoolean *overflow);
 
-    // Private-ish
+    // Private-ish (this is *ALWAYS* in the currency's base (aka INTEGER) unit.)
     extern UInt256
     cryptoAmountGetValue (BRCryptoAmount amount);
 

--- a/crypto/BRCryptoFeeBasis.c
+++ b/crypto/BRCryptoFeeBasis.c
@@ -112,10 +112,10 @@ cryptoFeeBasisGetPricePerCostFactorAsUInt256 (BRCryptoFeeBasis feeBasis) {
 
 extern BRCryptoAmount
 cryptoFeeBasisGetPricePerCostFactor (BRCryptoFeeBasis feeBasis) {
-    return cryptoAmountCreateInternal (cryptoUnitGetCurrency (feeBasis->unit),
+    return cryptoAmountCreateInternal (feeBasis->unit,
                                        CRYPTO_FALSE,
                                        cryptoFeeBasisGetPricePerCostFactorAsUInt256 (feeBasis),
-                                       0);
+                                       1);
 }
 
 extern BRCryptoUnit
@@ -143,10 +143,10 @@ cryptoFeeBasisGetFee (BRCryptoFeeBasis feeBasis) {
     switch (feeBasis->type) {
         case BLOCK_CHAIN_TYPE_BTC: {
             double fee = (((double) feeBasis->u.btc.feePerKB) * feeBasis->u.btc.sizeInByte) / 1000.0;
-            return cryptoAmountCreateInternal (cryptoUnitGetCurrency (feeBasis->unit),
+            return cryptoAmountCreateInternal (feeBasis->unit,
                                                CRYPTO_FALSE,
                                                createUInt256 (round (fee)),
-                                               0);
+                                               1);
         }
             
         case BLOCK_CHAIN_TYPE_ETH:
@@ -161,10 +161,10 @@ cryptoFeeBasisGetFee (BRCryptoFeeBasis feeBasis) {
 
             return (overflow
                     ? NULL
-                    : cryptoAmountCreateInternal (cryptoUnitGetCurrency (feeBasis->unit),
+                    : cryptoAmountCreateInternal (feeBasis->unit,
                                                   CRYPTO_FALSE,
                                                   value,
-                                                  0));
+                                                  1));
         }
     }
 }

--- a/crypto/BRCryptoPrivate.h
+++ b/crypto/BRCryptoPrivate.h
@@ -113,12 +113,12 @@ extern "C" {
     /// MARK: - Amount
 
     private_extern BRCryptoAmount
-    cryptoAmountCreate (BRCryptoCurrency currency,
+    cryptoAmountCreate (BRCryptoUnit unit,
                         BRCryptoBoolean isNegative,
                         UInt256 value);
 
     private_extern BRCryptoAmount
-    cryptoAmountCreateInternal (BRCryptoCurrency currency,
+    cryptoAmountCreateInternal (BRCryptoUnit unit,
                                 BRCryptoBoolean isNegative,
                                 UInt256 value,
                                 int takeCurrency);

--- a/crypto/BRCryptoTransfer.c
+++ b/crypto/BRCryptoTransfer.c
@@ -229,7 +229,6 @@ cryptoTransferGetTargetAddress (BRCryptoTransfer transfer) {
 static BRCryptoAmount
 cryptoTransferGetAmountAsSign (BRCryptoTransfer transfer, BRCryptoBoolean isNegative) {
     BRCryptoAmount   amount;
-    BRCryptoCurrency currency = cryptoUnitGetCurrency (transfer->unit);
 
     switch (transfer->type) {
         case BLOCK_CHAIN_TYPE_BTC: {
@@ -241,19 +240,19 @@ cryptoTransferGetAmountAsSign (BRCryptoTransfer transfer, BRCryptoBoolean isNega
 
             switch (cryptoTransferGetDirection(transfer)) {
                 case CRYPTO_TRANSFER_RECOVERED:
-                    amount = cryptoAmountCreate (currency,
-                                               isNegative,
-                                               createUInt256(send));
+                    amount = cryptoAmountCreate (transfer->unit,
+                                                 isNegative,
+                                                 createUInt256(send));
                     break;
 
                 case CRYPTO_TRANSFER_SENT:
-                    amount = cryptoAmountCreate (currency,
+                    amount = cryptoAmountCreate (transfer->unit,
                                                isNegative,
                                                createUInt256(send - fee - recv));
                     break;
 
                 case CRYPTO_TRANSFER_RECEIVED:
-                    amount = cryptoAmountCreate (currency,
+                    amount = cryptoAmountCreate (transfer->unit,
                                                isNegative,
                                                createUInt256(recv));
                     break;
@@ -267,13 +266,13 @@ cryptoTransferGetAmountAsSign (BRCryptoTransfer transfer, BRCryptoBoolean isNega
             BREthereumAmount ethAmount = transferGetAmount(transfer->u.eth.tid);
             switch (amountGetType(ethAmount)) {
                 case AMOUNT_ETHER:
-                    amount = cryptoAmountCreate (currency,
+                    amount = cryptoAmountCreate (transfer->unit,
                                                isNegative,
                                                etherGetValue(amountGetEther(ethAmount), WEI));
                     break;
 
                 case AMOUNT_TOKEN:
-                    amount = cryptoAmountCreate (currency,
+                    amount = cryptoAmountCreate (transfer->unit,
                                                isNegative,
                                                amountGetTokenQuantity(ethAmount).valueAsInteger);
                     break;
@@ -287,14 +286,13 @@ cryptoTransferGetAmountAsSign (BRCryptoTransfer transfer, BRCryptoBoolean isNega
             BRGenericWalletManager gwm = transfer->u.gen.gwm;
             BRGenericTransfer tid = transfer->u.gen.tid;
 
-            amount = cryptoAmountCreate (currency,
+            amount = cryptoAmountCreate (transfer->unit,
                                        isNegative,
                                        gwmTransferGetAmount (gwm, tid));
             break;
         }
     }
 
-    cryptoCurrencyGive (currency);
     return amount;
 }
 
@@ -306,11 +304,10 @@ cryptoTransferGetAmount (BRCryptoTransfer transfer) {
 extern BRCryptoAmount
 cryptoTransferGetAmountDirected (BRCryptoTransfer transfer) {
     BRCryptoAmount   amount;
-    BRCryptoCurrency currency = cryptoUnitGetCurrency (transfer->unit);
 
     switch (cryptoTransferGetDirection(transfer)) {
         case CRYPTO_TRANSFER_RECOVERED: {
-            amount = cryptoAmountCreate (currency,
+            amount = cryptoAmountCreate (transfer->unit,
                                          CRYPTO_FALSE,
                                          UINT256_ZERO);
             break;
@@ -330,7 +327,6 @@ cryptoTransferGetAmountDirected (BRCryptoTransfer transfer) {
         default: assert(0);
     }
 
-    cryptoCurrencyGive (currency);
     return amount;
 }
 

--- a/crypto/BRCryptoWallet.c
+++ b/crypto/BRCryptoWallet.c
@@ -210,9 +210,7 @@ cryptoWalletGetBalance (BRCryptoWallet wallet) {
             BRWallet *wid = wallet->u.btc.wid;
 
             UInt256 value = createUInt256 (BRWalletBalance (wid));
-            BRCryptoCurrency currency = cryptoWalletGetCurrency (wallet);
-            BRCryptoAmount amount = cryptoAmountCreate (currency, CRYPTO_FALSE, value);
-            cryptoCurrencyGive (currency);
+            BRCryptoAmount amount = cryptoAmountCreate (wallet->unit, CRYPTO_FALSE, value);
             return amount;
         }
         case BLOCK_CHAIN_TYPE_ETH: {
@@ -221,9 +219,7 @@ cryptoWalletGetBalance (BRCryptoWallet wallet) {
 
             BREthereumAmount balance = ewmWalletGetBalance (ewm, wid);
             UInt256 value = balance.type == AMOUNT_ETHER ? balance.u.ether.valueInWEI : balance.u.tokenQuantity.valueAsInteger;
-            BRCryptoCurrency currency = cryptoWalletGetCurrency (wallet);
-            BRCryptoAmount amount = cryptoAmountCreate (currency, CRYPTO_FALSE, value);
-            cryptoCurrencyGive (currency);
+            BRCryptoAmount amount = cryptoAmountCreate (wallet->unit, CRYPTO_FALSE, value);
             return amount;
         }
         case BLOCK_CHAIN_TYPE_GEN: {
@@ -232,9 +228,7 @@ cryptoWalletGetBalance (BRCryptoWallet wallet) {
 
             // TODO: How does the GEN wallet know the balance?  Holds tranactions? (not currently)
             UInt256 value = gwmWalletGetBalance (gwm, wid);
-            BRCryptoCurrency currency = cryptoWalletGetCurrency (wallet);
-            BRCryptoAmount amount = cryptoAmountCreate (currency, CRYPTO_FALSE, value);
-            cryptoCurrencyGive (currency);
+            BRCryptoAmount amount = cryptoAmountCreate (wallet->unit, CRYPTO_FALSE, value);
             return amount;
         }
     }

--- a/crypto/BRCryptoWalletManagerClient.c
+++ b/crypto/BRCryptoWalletManagerClient.c
@@ -1029,7 +1029,7 @@ cwmWalletEventAsETH (BREthereumClientContext context,
                                  : amountGetTokenQuantity(amount).valueAsInteger);
 
                 // Use currency to create a cyrptoAmount in the base unit (implicitly).
-                BRCryptoAmount cryptoAmount = cryptoAmountCreate(currency, CRYPTO_FALSE, value);
+                BRCryptoAmount cryptoAmount = cryptoAmountCreate(unit, CRYPTO_FALSE, value);
 
                 cryptoUnitGive(unit);
                 cryptoCurrencyGive(currency);


### PR DESCRIPTION
This changes the initializer of `Amount(core:unit:take)` into just `Amount(core:take)` making it analogous to *all* other initializers given a Crypto C instance.  Importantly, in some Swift/Java contexts, the Unit does not need to be held as it is 100% provided by Crypto C.  (TransferConfirmation's fee as one example).

Requires Java changes.