### PR TITLE
CORE-492: Implement cryptoTransferGetConfirmedFeeBasis()

### DIFF
--- a/Java/Core/CMakeLists.txt
+++ b/Java/Core/CMakeLists.txt
@@ -158,6 +158,8 @@ target_sources (core
                 src/main/cpp/core/ethereum/base/BREthereumEther.h
                 src/main/cpp/core/ethereum/base/BREthereumGas.c
                 src/main/cpp/core/ethereum/base/BREthereumGas.h
+                src/main/cpp/core/ethereum/base/BREthereumFeeBasis.c
+                src/main/cpp/core/ethereum/base/BREthereumFeeBasis.h
                 src/main/cpp/core/ethereum/base/BREthereumHash.c
                 src/main/cpp/core/ethereum/base/BREthereumHash.h
                 src/main/cpp/core/ethereum/base/BREthereumData.c

--- a/Java/CoreNative/CMakeLists.txt
+++ b/Java/CoreNative/CMakeLists.txt
@@ -148,6 +148,8 @@ target_sources (crypto
                 src/main/cpp/core/ethereum/base/BREthereumEther.h
                 src/main/cpp/core/ethereum/base/BREthereumGas.c
                 src/main/cpp/core/ethereum/base/BREthereumGas.h
+                src/main/cpp/core/ethereum/base/BREthereumFeeBasis.c
+                src/main/cpp/core/ethereum/base/BREthereumFeeBasis.h
                 src/main/cpp/core/ethereum/base/BREthereumHash.c
                 src/main/cpp/core/ethereum/base/BREthereumHash.h
                 src/main/cpp/core/ethereum/base/BREthereumData.c

--- a/Swift/BRCore.xcodeproj/project.pbxproj
+++ b/Swift/BRCore.xcodeproj/project.pbxproj
@@ -48,11 +48,11 @@
 		3C54A7FF2121F1D200C57B1B /* BREthereumMessage.c in Sources */ = {isa = PBXBuildFile; fileRef = 3C54A7FE2121F1D200C57B1B /* BREthereumMessage.c */; };
 		3C54A8022122284900C57B1B /* BREthereumNode.c in Sources */ = {isa = PBXBuildFile; fileRef = 3C54A8012122284900C57B1B /* BREthereumNode.c */; };
 		3C54A80521234C9700C57B1B /* BREthereumNodeEndpoint.c in Sources */ = {isa = PBXBuildFile; fileRef = 3C54A80421234C9700C57B1B /* BREthereumNodeEndpoint.c */; };
+		3C56C97D22F8F8C20054AD21 /* BRCryptoStatus.c in Sources */ = {isa = PBXBuildFile; fileRef = 3C56C97C22F8F8C20054AD21 /* BRCryptoStatus.c */; };
 		3C56C97F22FA27DD0054AD21 /* TransferCreateRecvController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C56C97E22FA27DD0054AD21 /* TransferCreateRecvController.swift */; };
 		3C56C98122FA28190054AD21 /* TransferCreatePaymentController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C56C98022FA28190054AD21 /* TransferCreatePaymentController.swift */; };
 		3C56C98322FA28310054AD21 /* TransferCreateSweepController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C56C98222FA28310054AD21 /* TransferCreateSweepController.swift */; };
 		3C56C98522FA2B630054AD21 /* TransferCreateController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C56C98422FA2B620054AD21 /* TransferCreateController.swift */; };
-		3C56C97D22F8F8C20054AD21 /* BRCryptoStatus.c in Sources */ = {isa = PBXBuildFile; fileRef = 3C56C97C22F8F8C20054AD21 /* BRCryptoStatus.c */; };
 		3C5C02392212035B0052E010 /* libresolv.tbd in Frameworks */ = {isa = PBXBuildFile; fileRef = 3CEF5FC9220513FC0010A811 /* libresolv.tbd */; };
 		3C5F5E75212C82310038B732 /* BREthereumMPT.c in Sources */ = {isa = PBXBuildFile; fileRef = 3C5F5E74212C82310038B732 /* BREthereumMPT.c */; };
 		3C6B172F2131CB5B003C313B /* main.c in Sources */ = {isa = PBXBuildFile; fileRef = 3C6B172E2131CB5B003C313B /* main.c */; };
@@ -158,6 +158,7 @@
 		3C9B8DF322BD55CA0060C3A9 /* BRRippleTransaction.c in Sources */ = {isa = PBXBuildFile; fileRef = C3C453DE226E2C62004CC0C7 /* BRRippleTransaction.c */; };
 		3C9B8DF422BD55CA0060C3A9 /* BRRippleWallet.c in Sources */ = {isa = PBXBuildFile; fileRef = C3C864A3227C6B490055120E /* BRRippleWallet.c */; };
 		3CA15F80221648D200C84E65 /* libresolv.tbd in Frameworks */ = {isa = PBXBuildFile; fileRef = 3CA15F7F221648D200C84E65 /* libresolv.tbd */; };
+		3CA63972230336D9006DD57B /* BREthereumFeeBasis.c in Sources */ = {isa = PBXBuildFile; fileRef = 3CA63971230336D9006DD57B /* BREthereumFeeBasis.c */; };
 		3CAB60A920AF8C8500810CE4 /* CoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3CAB60A820AF8C8500810CE4 /* CoreTests.swift */; };
 		3CAB60AB20AF8C8500810CE4 /* libCore.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 3CAB609B20AF8C5D00810CE4 /* libCore.a */; };
 		3CAB60B120AF8D1A00810CE4 /* BREthereumEther.c in Sources */ = {isa = PBXBuildFile; fileRef = 3C2A53B320AF595400C430F6 /* BREthereumEther.c */; };
@@ -469,12 +470,12 @@
 		3C54A8012122284900C57B1B /* BREthereumNode.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = BREthereumNode.c; sourceTree = "<group>"; };
 		3C54A80321234C9700C57B1B /* BREthereumNodeEndpoint.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = BREthereumNodeEndpoint.h; sourceTree = "<group>"; };
 		3C54A80421234C9700C57B1B /* BREthereumNodeEndpoint.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = BREthereumNodeEndpoint.c; sourceTree = "<group>"; };
+		3C56C97B22F8F8C20054AD21 /* BRCryptoStatus.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = BRCryptoStatus.h; sourceTree = "<group>"; };
+		3C56C97C22F8F8C20054AD21 /* BRCryptoStatus.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = BRCryptoStatus.c; sourceTree = "<group>"; };
 		3C56C97E22FA27DD0054AD21 /* TransferCreateRecvController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TransferCreateRecvController.swift; sourceTree = "<group>"; };
 		3C56C98022FA28190054AD21 /* TransferCreatePaymentController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TransferCreatePaymentController.swift; sourceTree = "<group>"; };
 		3C56C98222FA28310054AD21 /* TransferCreateSweepController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TransferCreateSweepController.swift; sourceTree = "<group>"; };
 		3C56C98422FA2B620054AD21 /* TransferCreateController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TransferCreateController.swift; sourceTree = "<group>"; };
-		3C56C97B22F8F8C20054AD21 /* BRCryptoStatus.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = BRCryptoStatus.h; sourceTree = "<group>"; };
-		3C56C97C22F8F8C20054AD21 /* BRCryptoStatus.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = BRCryptoStatus.c; sourceTree = "<group>"; };
 		3C590F3220950C720005597B /* BRBIP32Sequence.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = BRBIP32Sequence.c; sourceTree = "<group>"; };
 		3C590F3320950C720005597B /* BRBIP39Mnemonic.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = BRBIP39Mnemonic.h; sourceTree = "<group>"; };
 		3C590F3420950C720005597B /* BRAddress.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = BRAddress.c; sourceTree = "<group>"; };
@@ -570,6 +571,8 @@
 		3C9B8DE622BD52940060C3A9 /* BRGenericHandlers.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = BRGenericHandlers.c; sourceTree = "<group>"; };
 		3CA15F7E221645B400C84E65 /* test.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = test.h; sourceTree = "<group>"; };
 		3CA15F7F221648D200C84E65 /* libresolv.tbd */ = {isa = PBXFileReference; lastKnownFileType = "sourcecode.text-based-dylib-definition"; name = libresolv.tbd; path = Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.14.sdk/usr/lib/libresolv.tbd; sourceTree = DEVELOPER_DIR; };
+		3CA63970230336D9006DD57B /* BREthereumFeeBasis.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = BREthereumFeeBasis.h; sourceTree = "<group>"; };
+		3CA63971230336D9006DD57B /* BREthereumFeeBasis.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = BREthereumFeeBasis.c; sourceTree = "<group>"; };
 		3CA74EA920AF622D00EDF3E7 /* BRKeyECIES.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = BRKeyECIES.c; sourceTree = "<group>"; };
 		3CA74EAA20AF622D00EDF3E7 /* BRKeyECIES.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = BRKeyECIES.h; sourceTree = "<group>"; };
 		3CAB609B20AF8C5D00810CE4 /* libCore.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libCore.a; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -958,6 +961,8 @@
 				3C2A53B320AF595400C430F6 /* BREthereumEther.c */,
 				3C2A53AF20AF595400C430F6 /* BREthereumGas.h */,
 				3C2A53B520AF595400C430F6 /* BREthereumGas.c */,
+				3CA63970230336D9006DD57B /* BREthereumFeeBasis.h */,
+				3CA63971230336D9006DD57B /* BREthereumFeeBasis.c */,
 				3C2A53B420AF595400C430F6 /* BREthereumHash.h */,
 				3C2A53B020AF595400C430F6 /* BREthereumHash.c */,
 				3CF0FC8E21657D7A000DE3FE /* BREthereumData.h */,
@@ -1830,6 +1835,7 @@
 				3C386DD020C6F5E40065E355 /* BREthereumBCSEvent.c in Sources */,
 				3C3B37FD20D82335004F9928 /* BREventAlarm.c in Sources */,
 				3CCB136A2253C84E00ADCDB9 /* BRSyncMode.c in Sources */,
+				3CA63972230336D9006DD57B /* BREthereumFeeBasis.c in Sources */,
 				3CAB60CA20AF8D1A00810CE4 /* BREthereumLESFrameCoder.c in Sources */,
 				3CCD36B121A5BB8D0032637A /* BRWalletManager.c in Sources */,
 				CA92F7902100F9CA0015C966 /* BRKeccak.c in Sources */,

--- a/Swift/BRCrypto/BRCryptoTransfer.swift
+++ b/Swift/BRCrypto/BRCryptoTransfer.swift
@@ -68,7 +68,10 @@ public final class Transfer: Equatable {
     ///
     /// The basis for the estimated fee.  This is only not-nil if we have created the transfer
     /// IN THIS MEMORY INSTANCE (assume this for now).
-    public let estimatedFeeBasis: TransferFeeBasis?
+    public var estimatedFeeBasis: TransferFeeBasis? {
+        return cryptoTransferGetEstimatedFeeBasis (core)
+            .map { TransferFeeBasis (core: $0, take: false) }
+    }
 
     /// The basis for the confirmed fee.
     public var confirmedFeeBasis: TransferFeeBasis? {
@@ -116,9 +119,6 @@ public final class Transfer: Equatable {
 
         self.unit       = Unit (core: cryptoTransferGetUnitForAmount (core), take: false)
         self.unitForFee = Unit (core: cryptoTransferGetUnitForFee (core),    take: false)
-
-        self.estimatedFeeBasis = cryptoTransferGetEstimatedFeeBasis (core)
-            .map { TransferFeeBasis (core: $0, take: false) }
 
         // Other properties
         self.amount         = Amount (core: cryptoTransferGetAmount (core),        take: false)

--- a/bitcoin/BRWalletManager.c
+++ b/bitcoin/BRWalletManager.c
@@ -738,8 +738,15 @@ extern BRTransaction *
 BRWalletManagerCreateTransaction (BRWalletManager manager,
                                   BRWallet *wallet,
                                   uint64_t amount,
-                                  const char *addr) {
+                                  const char *addr,
+                                  uint64_t feePerKb) {
+    pthread_mutex_lock (&manager->lock);
+    uint64_t feePerKbSaved = BRWalletFeePerKb (wallet);
+    BRWalletSetFeePerKb (wallet, feePerKb);
     BRTransaction *transaction = BRWalletCreateTransaction (wallet, amount, addr);
+    BRWalletSetFeePerKb (wallet, feePerKbSaved);
+    pthread_mutex_unlock (&manager->lock);
+
     if (NULL != transaction) {
         assert (NULL != manager->client.funcTransactionEvent);
         manager->client.funcTransactionEvent (manager->client.context,

--- a/bitcoin/BRWalletManager.h
+++ b/bitcoin/BRWalletManager.h
@@ -312,7 +312,8 @@ extern BRTransaction *
 BRWalletManagerCreateTransaction (BRWalletManager manager,
                                   BRWallet *wallet,
                                   uint64_t amount,
-                                  const char *addr);
+                                  const char *addr,
+                                  uint64_t feePerKb);
 
 /**
  * Signs any inputs in transaction that can be signed using private keys from the wallet.

--- a/crypto/BRCryptoFeeBasis.c
+++ b/crypto/BRCryptoFeeBasis.c
@@ -76,7 +76,7 @@ cryptoFeeBasisCreateAsETH (BRCryptoUnit unit,
 private_extern BRCryptoFeeBasis
 cryptoFeeBasisCreateAsGEN (BRCryptoUnit unit,
                            BRGenericWalletManager gwm,
-                           BRGenericFeeBasis bid) {
+                           OwnershipGiven BRGenericFeeBasis bid) {
     BRCryptoFeeBasis feeBasis = cryptoFeeBasisCreateInternal (BLOCK_CHAIN_TYPE_GEN, unit);
     feeBasis->u.gen.gwm = gwm;
     feeBasis->u.gen.bid = bid;
@@ -87,6 +87,14 @@ cryptoFeeBasisCreateAsGEN (BRCryptoUnit unit,
 static void
 cryptoFeeBasisRelease (BRCryptoFeeBasis feeBasis) {
     cryptoUnitGive (feeBasis->unit);
+    switch (feeBasis->type) {
+        case BLOCK_CHAIN_TYPE_BTC: break;
+        case BLOCK_CHAIN_TYPE_ETH: break;
+
+        case BLOCK_CHAIN_TYPE_GEN:
+            // TODO: Release BRGenericFeeBasis
+            break;
+    }
     free (feeBasis);
 }
 

--- a/crypto/BRCryptoPrivate.h
+++ b/crypto/BRCryptoPrivate.h
@@ -181,7 +181,7 @@ extern "C" {
     private_extern BRCryptoFeeBasis
     cryptoFeeBasisCreateAsGEN (BRCryptoUnit unit,
                                BRGenericWalletManager gwm,
-                               BRGenericFeeBasis bid);
+                               OwnershipGiven BRGenericFeeBasis bid);
 
     /// MARK: Transfer
 
@@ -199,7 +199,8 @@ extern "C" {
     cryptoTransferCreateAsETH (BRCryptoUnit unit,
                                BRCryptoUnit unitForFee,
                                BREthereumEWM ewm,
-                               BREthereumTransfer tid);
+                               BREthereumTransfer tid,
+                               BRCryptoFeeBasis feeBasisEstimated);
 
     extern BRCryptoTransfer
     cryptoTransferCreateAsGEN (BRCryptoUnit unit,
@@ -207,6 +208,10 @@ extern "C" {
                                BRGenericWalletManager gwm,
                                BRGenericTransfer tid);
 
+    private_extern void
+    cryptoTransferSetConfirmedFeeBasis (BRCryptoTransfer transfer,
+                                        BRCryptoFeeBasis feeBasisConfirmed);
+    
     private_extern BRTransaction *
     cryptoTransferAsBTC (BRCryptoTransfer transfer);
 

--- a/ethereum/base/BREthereumBase.h
+++ b/ethereum/base/BREthereumBase.h
@@ -21,6 +21,7 @@
 #include "BREthereumLogic.h"
 #include "BREthereumEther.h"
 #include "BREthereumGas.h"
+#include "BREthereumFeeBasis.h"
 #include "BREthereumHash.h"
 #include "BREthereumData.h"
 #include "BREthereumAddress.h"

--- a/ethereum/base/BREthereumFeeBasis.c
+++ b/ethereum/base/BREthereumFeeBasis.c
@@ -1,0 +1,36 @@
+//
+//  BREthereumFeeBasis.c
+//  Core
+//
+//  Created by Ed Gamble on 8/13/19.
+//  Copyright © 2019 Breadwinner AG. All rights reserved.
+//
+//  See the LICENSE file at the project root for license information.
+//  See the CONTRIBUTORS file at the project root for a list of contributors.
+
+#include "BREthereumFeeBasis.h"
+
+extern BREthereumFeeBasis
+feeBasisCreate (BREthereumGas limit,
+                BREthereumGasPrice price) {
+    return (BREthereumFeeBasis) {
+        FEE_BASIS_GAS,
+        { .gas = { limit, price }}
+    };
+}
+
+extern BREthereumEther
+feeBasisGetFee (BREthereumFeeBasis feeBasis, int *overflow) {  // BREthereumBoolean
+    *overflow = 0;
+
+    switch (feeBasis.type) {
+        case FEE_BASIS_NONE:
+            return etherCreateZero();
+
+        case FEE_BASIS_GAS:
+            return etherCreate (mulUInt256_Overflow (feeBasis.u.gas.price.etherPerGas.valueInWEI,
+                                                     createUInt256 (feeBasis.u.gas.limit.amountOfGas),
+                                                     overflow));
+    }
+}
+

--- a/ethereum/base/BREthereumFeeBasis.h
+++ b/ethereum/base/BREthereumFeeBasis.h
@@ -1,0 +1,38 @@
+//
+//  BREthereumFeeBasis.h
+//  Core
+//
+//  Created by Ed Gamble on 8/13/19.
+//  Copyright © 2019 Breadwinner AG.  All rights reserved.
+//
+//  See the LICENSE file at the project root for license information.
+//  See the CONTRIBUTORS file at the project root for a list of contributors.
+
+#ifndef BR_Ethereum_Fee_Basis_h
+#define BR_Ethereum_Fee_Basis_h
+
+#include "BREthereumGas.h"
+
+typedef enum {
+    FEE_BASIS_NONE,
+    FEE_BASIS_GAS
+} BREthereumFeeBasisType;
+
+typedef struct {
+    BREthereumFeeBasisType type;
+    union {
+        struct {
+            BREthereumGas limit;
+            BREthereumGasPrice price;
+        } gas;
+    } u;
+} BREthereumFeeBasis;
+
+extern BREthereumFeeBasis
+feeBasisCreate (BREthereumGas limit,
+                BREthereumGasPrice price);
+
+extern BREthereumEther
+feeBasisGetFee (BREthereumFeeBasis feeBasis, int *overflow);
+
+#endif /* BR_Ethereum_Fee_Basis_h */

--- a/ethereum/blockchain/BREthereumTransaction.c
+++ b/ethereum/blockchain/BREthereumTransaction.c
@@ -175,22 +175,34 @@ transactionGetAmount(BREthereumTransaction transaction) {
     return transaction->amount;
 }
 
+extern BREthereumFeeBasis
+transactionGetFeeBasis (BREthereumTransaction transaction) {
+    BREthereumGas gas = (ETHEREUM_BOOLEAN_IS_TRUE(transactionIsConfirmed(transaction))
+                         ? transaction->status.u.included.gasUsed
+                         : transaction->gasLimit);
+
+    return (BREthereumFeeBasis) {
+        FEE_BASIS_GAS,
+        { gas, transaction->gasPrice }
+    };
+}
+
 extern BREthereumEther
 transactionGetFee (BREthereumTransaction transaction, int *overflow) {
-    return etherCreate
-    (mulUInt256_Overflow(transaction->gasPrice.etherPerGas.valueInWEI,
-                         createUInt256 (ETHEREUM_BOOLEAN_IS_TRUE(transactionIsConfirmed(transaction))
-                                        ? transaction->status.u.included.gasUsed.amountOfGas
-                                        : transaction->gasLimit.amountOfGas),
-                         overflow));
+    return feeBasisGetFee (transactionGetFeeBasis(transaction), overflow);
+}
+
+extern BREthereumFeeBasis
+transactionGetFeeBasisLimit (BREthereumTransaction transaction) {
+    return (BREthereumFeeBasis) {
+        FEE_BASIS_GAS,
+        { transaction-> gasLimit, transaction->gasPrice }
+    };
 }
 
 extern BREthereumEther
 transactionGetFeeLimit (BREthereumTransaction transaction, int *overflow) {
-    return etherCreate
-    (mulUInt256_Overflow(transaction->gasPrice.etherPerGas.valueInWEI,
-                         createUInt256 (transaction->gasLimit.amountOfGas),
-                         overflow));
+    return feeBasisGetFee (transactionGetFeeBasisLimit(transaction), overflow);
 }
 
 extern BREthereumGasPrice

--- a/ethereum/blockchain/BREthereumTransaction.h
+++ b/ethereum/blockchain/BREthereumTransaction.h
@@ -75,15 +75,28 @@ extern BREthereumEther
 transactionGetAmount(BREthereumTransaction transaction);
 
 /**
- * Return the fee (in Ether) for transaction.  If the transaction is confirmed (aka blocked) then
- * the value returned is the actual fee paid (as gasUsed * gasPrice); if the transaction is not
- * confirmed then an estimated fee is returned (as gasEstimate * gasPrice).
+ * Return the feeBais for transaction.  If the transaction is confirmed (aka blocked) then
+ * the value returned is the actual feeBasis paid {gasUsed, gasPrice}; if the transaction is not
+ * confirmed then an estimated feeBasis is returned {gasEstimate, gasPrice}.
+ */
+extern BREthereumFeeBasis
+transactionGetFeeBasis (BREthereumTransaction transaction);
+
+/**
+ * Return the fee (in Ether) for transaction based on `transactionGetFeeBasis()`
  */
 extern BREthereumEther
 transactionGetFee (BREthereumTransaction transaction, int *overflow);
 
 /**
- * Return the maximum fee (in Ether) for transaction (as gasLimit * gasPrice).
+ * Return the feeBasis for transaction {gasLimit, gasPrice}
+ */
+extern BREthereumFeeBasis
+transactionGetFeeBasisLimit (BREthereumTransaction transaction);
+
+/**
+ * Return the maximum fee (in Ether) for transaction (as gasLimit * gasPrice) from
+ * transactionGetFeeBasisLimit()
  */
 extern BREthereumEther
 transactionGetFeeLimit (BREthereumTransaction transaction, int *overflow);

--- a/ethereum/ewm/BREthereumBase.h
+++ b/ethereum/ewm/BREthereumBase.h
@@ -108,25 +108,6 @@ typedef struct BREthereumWalletRecord *BREthereumWallet;
  */
 typedef struct BREthereumEWMRecord *BREthereumEWM;
 
-typedef enum {
-    FEE_BASIS_NONE,
-    FEE_BASIS_GAS
-} BREthereumFeeBasisType;
-
-typedef struct {
-    BREthereumFeeBasisType type;
-    union {
-        struct {
-            BREthereumGas limit;
-            BREthereumGasPrice price;
-        } gas;
-    } u;
-} BREthereumFeeBasis;
-
-extern BREthereumFeeBasis
-feeBasisCreate (BREthereumGas limit,
-                BREthereumGasPrice price);
-
 //
 // Errors - Right Up Front - 'The Emperor Has No Clothes' ??
 //

--- a/ethereum/ewm/BREthereumEWM.c
+++ b/ethereum/ewm/BREthereumEWM.c
@@ -2567,13 +2567,3 @@ ewmTransferDelete (BREthereumEWM ewm,
     // Null the ewm's `tid` - MUST NOT array_rm() as all `tid` holders will be dead.
     transferRelease(transfer);
 }
-
-extern BREthereumFeeBasis
-feeBasisCreate (BREthereumGas limit,
-                BREthereumGasPrice price) {
-    return (BREthereumFeeBasis) {
-        FEE_BASIS_GAS,
-        { .gas = { limit, price }}
-    };
-}
-


### PR DESCRIPTION
Add `BRCryptoFeeBasis feeBasisConfirmed` to `struct BRCryptoTransferRecord`; set `feeBasisConfirmed` when a transfer (BTC, ETH, etc) is TRANSFER_INCLUDED.  Set feeBasisEstimated when created - either directly upon `cryptoWalletCreateTransfer()` or after the fact when the BTC, ETH, etc `TRANSFER_CREATED` event is handled.

Created as a draft until CORE-478/PR-148 is merged - so tests can be extended.  (However, in a test merge of CORE-478, previously failing unit tests are fixed by this CORE-492 branch.)