### PR TITLE
CORE-305: Rework Ethereum Events

### DIFF
--- a/Swift/BRCrypto/BRCryptoSystem.swift
+++ b/Swift/BRCrypto/BRCryptoSystem.swift
@@ -1224,7 +1224,7 @@ extension BREthereumPeerEventType: CustomStringConvertible {
     }
 }
 
-extension BREthereumTransferEvent: CustomStringConvertible {
+extension BREthereumTransferEventType: CustomStringConvertible {
     public var description: String {
         switch self {
         case TRANSFER_EVENT_CREATED: return "Created"

--- a/Swift/BRCrypto/BRCryptoSystem.swift
+++ b/Swift/BRCrypto/BRCryptoSystem.swift
@@ -1204,7 +1204,7 @@ extension BRTransactionEventType: CustomStringConvertible {
     }
 }
 
-extension BREthereumTokenEvent: CustomStringConvertible {
+extension BREthereumTokenEventType: CustomStringConvertible {
     public var description: String {
         switch self {
         case TOKEN_EVENT_CREATED: return "Created"
@@ -1214,7 +1214,7 @@ extension BREthereumTokenEvent: CustomStringConvertible {
     }
 }
 
-extension BREthereumPeerEvent: CustomStringConvertible {
+extension BREthereumPeerEventType: CustomStringConvertible {
     public var description: String {
         switch self {
         case PEER_EVENT_CREATED: return "Created"

--- a/Swift/BRCrypto/BRCryptoSystem.swift
+++ b/Swift/BRCrypto/BRCryptoSystem.swift
@@ -8,8 +8,7 @@
 //  See the LICENSE file at the project root for license information.
 //  See the CONTRIBUTORS file at the project root for a list of contributors.
 //
-import Foundation
-import Darwin.C.stdatomic // atomic_fetch_add
+import Foundation  // Data, DispatchQueue
 import BRCryptoC
 
 ///
@@ -1162,108 +1161,6 @@ extension System {
                                   btc: clientBTC,
                                   eth: clientETH,
                                   gen: clientGEN)
-    }
-}
-
-extension BRWalletManagerEventType: CustomStringConvertible {
-    public var description: String {
-        switch self {
-        case BITCOIN_WALLET_MANAGER_CREATED: return "Created"
-        case BITCOIN_WALLET_MANAGER_CONNECTED: return "Connected"
-        case BITCOIN_WALLET_MANAGER_DISCONNECTED: return "Disconnected"
-        case BITCOIN_WALLET_MANAGER_SYNC_STARTED: return "Sync Started"
-        case BITCOIN_WALLET_MANAGER_SYNC_PROGRESS: return "Sync Progress"
-        case BITCOIN_WALLET_MANAGER_SYNC_STOPPED: return "Sync Stopped"
-        case BITCOIN_WALLET_MANAGER_BLOCK_HEIGHT_UPDATED: return "Block Height Updated"
-        default: return "<<unknown>>"
-        }
-    }
-}
-
-extension BRWalletEventType: CustomStringConvertible {
-    public var description: String {
-        switch self {
-        case BITCOIN_WALLET_CREATED: return "Created"
-        case BITCOIN_WALLET_BALANCE_UPDATED: return "Balance Updated"
-        case BITCOIN_WALLET_TRANSACTION_SUBMITTED: return "Transaction Submitted"
-        case BITCOIN_WALLET_FEE_PER_KB_UPDATED: return "FeePerKB Updated"
-        case BITCOIN_WALLET_DELETED: return "Deleted"
-        default: return "<<unknown>>"
-        }
-    }
-}
-
-extension BRTransactionEventType: CustomStringConvertible {
-    public var description: String {
-        switch self {
-        case BITCOIN_TRANSACTION_ADDED: return "Added"
-        case BITCOIN_TRANSACTION_UPDATED: return "Updated"
-        case BITCOIN_TRANSACTION_DELETED: return "Deleted"
-        default: return "<<unknown>>"
-        }
-    }
-}
-
-extension BREthereumTokenEventType: CustomStringConvertible {
-    public var description: String {
-        switch self {
-        case TOKEN_EVENT_CREATED: return "Created"
-        case TOKEN_EVENT_DELETED: return "Deleted"
-        default: return "<<unknown>>"
-        }
-    }
-}
-
-extension BREthereumPeerEventType: CustomStringConvertible {
-    public var description: String {
-        switch self {
-        case PEER_EVENT_CREATED: return "Created"
-        case PEER_EVENT_DELETED: return "Deleted"
-        default: return "<<unknown>>"
-        }
-    }
-}
-
-extension BREthereumTransferEventType: CustomStringConvertible {
-    public var description: String {
-        switch self {
-        case TRANSFER_EVENT_CREATED: return "Created"
-        case TRANSFER_EVENT_SIGNED: return "Signed"
-        case TRANSFER_EVENT_SUBMITTED: return "Submitted"
-        case TRANSFER_EVENT_INCLUDED: return "Included"
-        case TRANSFER_EVENT_ERRORED: return "Errored"
-        case TRANSFER_EVENT_GAS_ESTIMATE_UPDATED: return "Gas Estimate Updated"
-        case TRANSFER_EVENT_DELETED: return "Deleted"
-        default: return "<<unknown>>"
-        }
-    }
-}
-
-extension BREthereumWalletEventType: CustomStringConvertible {
-    public var description: String {
-        switch self {
-        case WALLET_EVENT_CREATED: return "Created"
-        case WALLET_EVENT_BALANCE_UPDATED: return "Balance Updated"
-        case WALLET_EVENT_DEFAULT_GAS_LIMIT_UPDATED: return "Default Gas Limit Updated"
-        case WALLET_EVENT_DEFAULT_GAS_PRICE_UPDATED: return "Default Gas Price Updated"
-        case WALLET_EVENT_FEE_ESTIMATED: return "Fee Estimated"
-        case WALLET_EVENT_DELETED: return "Deleted"
-        default: return "<<unknown>>"
-        }
-    }
-}
-
-extension BREthereumEWMEventType: CustomStringConvertible {
-    public var description: String {
-        switch self {
-        case EWM_EVENT_CREATED: return "Created"
-        case EWM_EVENT_CHANGED: return "Changed"
-        case EWM_EVENT_SYNC_PROGRESS: return "Sync Progress"
-        case EWM_EVENT_BLOCK_HEIGHT_UPDATED: return "Block Height Updated"
-        case EWM_EVENT_NETWORK_UNAVAILABLE: return "Network Unavailable"
-        case EWM_EVENT_DELETED: return "Deleted"
-        default: return "<<unknown>>"
-        }
     }
 }
 

--- a/Swift/BRCrypto/BRCryptoSystem.swift
+++ b/Swift/BRCrypto/BRCryptoSystem.swift
@@ -1253,15 +1253,14 @@ extension BREthereumWalletEventType: CustomStringConvertible {
     }
 }
 
-extension BREthereumEWMEvent: CustomStringConvertible {
+extension BREthereumEWMEventType: CustomStringConvertible {
     public var description: String {
         switch self {
         case EWM_EVENT_CREATED: return "Created"
-        case EWM_EVENT_SYNC_STARTED: return "Sync Started"
-        case EWM_EVENT_SYNC_CONTINUES: return "Sync Continues"
-        case EWM_EVENT_SYNC_STOPPED: return "Sync Stopped"
-        case EWM_EVENT_NETWORK_UNAVAILABLE: return "Network Unavailable"
+        case EWM_EVENT_CHANGED: return "Changed"
+        case EWM_EVENT_SYNC_PROGRESS: return "Sync Progress"
         case EWM_EVENT_BLOCK_HEIGHT_UPDATED: return "Block Height Updated"
+        case EWM_EVENT_NETWORK_UNAVAILABLE: return "Network Unavailable"
         case EWM_EVENT_DELETED: return "Deleted"
         default: return "<<unknown>>"
         }

--- a/crypto/BRCryptoWalletManagerClient.c
+++ b/crypto/BRCryptoWalletManagerClient.c
@@ -954,9 +954,7 @@ static void
 cwmWalletEventAsETH (BREthereumClientContext context,
                      BREthereumEWM ewm,
                      BREthereumWallet wid,
-                     BREthereumWalletEvent event,
-                     BREthereumStatus status,
-                     const char *errorDescription) {
+                     BREthereumWalletEvent event) {
     BRCryptoWalletManager cwm = context;
     if (NULL == cwm->u.eth) cwm->u.eth = ewm;
 
@@ -1095,7 +1093,7 @@ cwmWalletEventAsETH (BREthereumClientContext context,
 
         case WALLET_EVENT_FEE_ESTIMATED:
             if (NULL != wallet) {
-                if (SUCCESS == status) {
+                if (SUCCESS == event.status) {
                     BRCryptoUnit feeUnit = cryptoWalletGetUnitForFee(wallet);
 
                     BRCryptoFeeBasis feeBasis = cryptoFeeBasisCreateAsETH (feeUnit, event.u.feeEstimate.gasEstimate, event.u.feeEstimate.gasPrice);
@@ -1120,7 +1118,7 @@ cwmWalletEventAsETH (BREthereumClientContext context,
                                                       (BRCryptoWalletEvent) {
                                                            CRYPTO_WALLET_EVENT_FEE_BASIS_ESTIMATED,
                                                            { .feeBasisEstimated = {
-                                                               cryptoStatusFromETH (status),
+                                                               cryptoStatusFromETH (event.status),
                                                                event.u.feeEstimate.cookie,
                                                            }}
                                                        });

--- a/crypto/BRCryptoWalletManagerClient.c
+++ b/crypto/BRCryptoWalletManagerClient.c
@@ -1193,9 +1193,7 @@ cwmTransactionEventAsETH (BREthereumClientContext context,
                           BREthereumEWM ewm,
                           BREthereumWallet wid,
                           BREthereumTransfer tid,
-                          BREthereumTransferEvent event,
-                          BREthereumStatus status,
-                          const char *errorDescription) {
+                          BREthereumTransferEvent event) {
     BRCryptoWalletManager cwm = context;
     BRCryptoWallet wallet     = cryptoWalletManagerFindWalletAsETH (cwm, wid); // taken
 
@@ -1204,14 +1202,14 @@ cwmTransactionEventAsETH (BREthereumClientContext context,
 
     BRCryptoTransfer transfer = cryptoWalletFindTransferAsETH (wallet, tid);   // taken
 
-    assert (NULL != transfer || TRANSFER_EVENT_CREATED == event);
+    assert (NULL != transfer || TRANSFER_EVENT_CREATED == event.type);
 
     // We'll transition from `oldState` to `newState`; get some placeholder values in place.
     BRCryptoTransferState oldState = { CRYPTO_TRANSFER_STATE_CREATED };
     BRCryptoTransferState newState = { CRYPTO_TRANSFER_STATE_CREATED };
     if (NULL != transfer) oldState = cryptoTransferGetState (transfer);
 
-    switch (event) {
+    switch (event.type) {
         case TRANSFER_EVENT_CREATED: {
             assert (NULL == transfer);
 

--- a/crypto/BRCryptoWalletManagerClient.c
+++ b/crypto/BRCryptoWalletManagerClient.c
@@ -945,11 +945,7 @@ cwmWalletManagerEventAsETH (BREthereumClientContext context,
 static void
 cwmPeerEventAsETH (BREthereumClientContext context,
                    BREthereumEWM ewm,
-                   //BREthereumWallet wid,
-                   //BREthereumTransactionId tid,
-                   BREthereumPeerEvent event,
-                   BREthereumStatus status,
-                   const char *errorDescription) {
+                   BREthereumPeerEvent event) {
     BRCryptoWalletManager cwm = context;
     (void) cwm;
 }
@@ -1162,7 +1158,7 @@ cwmEventTokenAsETH (BREthereumClientContext context,
 
     BRCryptoWalletManager cwm = context;
 
-    switch (event) {
+    switch (event.type) {
         case TOKEN_EVENT_CREATED: {
             BRCryptoNetwork network = cryptoWalletManagerGetNetwork (cwm);
 

--- a/ethereum/ewm/BREthereumClient.h
+++ b/ethereum/ewm/BREthereumClient.h
@@ -291,6 +291,7 @@ extern "C" {
 
     typedef struct {
         BREthereumWalletEventType type;
+        BREthereumStatus status;
         union {
             struct {
                 BREthereumCookie cookie;
@@ -298,16 +299,15 @@ extern "C" {
                 BREthereumGasPrice gasPrice;
             } feeEstimate;
         } u;
+        char errorDescription[16];
     } BREthereumWalletEvent;
 
-#define WALLET_NUMBER_OF_EVENTS  (1 + WALLET_EVENT_DELETED)
+#define WALLET_NUMBER_OF_EVENT_TYPES  (1 + WALLET_EVENT_DELETED)
 
     typedef void (*BREthereumClientHandlerWalletEvent) (BREthereumClientContext context,
                                                         BREthereumEWM ewm,
                                                         BREthereumWallet wid,
-                                                        BREthereumWalletEvent event,
-                                                        BREthereumStatus status,
-                                                        const char *errorDescription);
+                                                        BREthereumWalletEvent event);
 
     typedef enum {
         BLOCK_EVENT_CREATED = 0,

--- a/ethereum/ewm/BREthereumClient.h
+++ b/ethereum/ewm/BREthereumClient.h
@@ -383,24 +383,49 @@ extern "C" {
                                                        BREthereumTokenEvent event);
 
     typedef enum {
-        EWM_EVENT_CREATED = 0,
-        EWM_EVENT_SYNC_STARTED,
-        EWM_EVENT_SYNC_CONTINUES,
-        EWM_EVENT_SYNC_STOPPED,
-        EWM_EVENT_NETWORK_UNAVAILABLE,
-        EWM_EVENT_BLOCK_HEIGHT_UPDATED,
-        EWM_EVENT_DELETED
-    } BREthereumEWMEvent;
+        EWM_STATE_CREATED,
+        EWM_STATE_CONNECTED,
+        EWM_STATE_SYNCING,
+        EWM_STATE_DISCONNECTED,
+        EWM_STATE_DELETED
+    } BREthereumEWMState;
 
-#define EWM_NUMBER_OF_EVENTS   (1 + EWM_EVENT_DELETED)
+    typedef enum {
+        EWM_EVENT_CREATED = 0,
+        EWM_EVENT_CHANGED,
+
+        EWM_EVENT_SYNC_PROGRESS,
+        EWM_EVENT_BLOCK_HEIGHT_UPDATED,
+        EWM_EVENT_NETWORK_UNAVAILABLE,
+
+        EWM_EVENT_DELETED,
+    } BREthereumEWMEventType;
+
+#define EWM_NUMBER_OF_EVENT_TYPES   (1 + EWM_EVENT_DELETED)
+
+    typedef struct {
+        BREthereumEWMEventType type;
+        BREthereumStatus status;
+        union {
+            struct {
+                BREthereumEWMState oldState;
+                BREthereumEWMState newState;
+            } changed;
+            struct {
+                double percent;
+            } syncProgress;
+            struct {
+                uint64_t value;
+            } blockHeight;
+        } u;
+        char errorDescription[16];
+    } BREthereumEWMEvent;
 
     typedef void (*BREthereumClientHandlerEWMEvent) (BREthereumClientContext context,
                                                      BREthereumEWM ewm,
                                                      // BREthereumWallet wid,
                                                      // BREthereumTransaction tid,
-                                                     BREthereumEWMEvent event,
-                                                     BREthereumStatus status,
-                                                     const char *errorDescription);
+                                                     BREthereumEWMEvent event);
 
     //
     // EWM Configuration

--- a/ethereum/ewm/BREthereumClient.h
+++ b/ethereum/ewm/BREthereumClient.h
@@ -309,6 +309,7 @@ extern "C" {
                                                         BREthereumWallet wid,
                                                         BREthereumWalletEvent event);
 
+#if defined (NEVER_DEFINED)
     typedef enum {
         BLOCK_EVENT_CREATED = 0,
 
@@ -316,17 +317,20 @@ extern "C" {
         BLOCK_EVENT_ORPHANED,
 
         BLOCK_EVENT_DELETED
+    } BREthereumBlockEventType;
+
+#define BLOCK_NUMBER_OF_EVENT_TYPES (1 + BLOCK_EVENT_DELETED)
+
+    typedef struct {
+        BREthereumBlockEventType type;
+        BREthereumStatus status;
+        char errorDescription[16];
     } BREthereumBlockEvent;
 
-#define BLOCK_NUMBER_OF_EVENTS (1 + BLOCK_EVENT_DELETED)
-
-#if defined (NEVER_DEFINED)
     typedef void (*BREthereumClientHandlerBlockEvent) (BREthereumClientContext context,
                                                        BREthereumEWM ewm,
                                                        BREthereumBlock bid,
-                                                       BREthereumBlockEvent event,
-                                                       BREthereumStatus status,
-                                                       const char *errorDescription);
+                                                       BREthereumBlockEvent event);
 #endif
 
     typedef enum {

--- a/ethereum/ewm/BREthereumClient.h
+++ b/ethereum/ewm/BREthereumClient.h
@@ -358,25 +358,34 @@ extern "C" {
         PEER_EVENT_CREATED = 0,
         PEER_EVENT_DELETED
         // added/removed/updated
-    } BREthereumPeerEvent;
+    } BREthereumPeerEventType;
 
-#define PEER_NUMBER_OF_EVENTS   (1 + PEER_EVENT_DELETED)
+#define PEER_NUMBER_OF_EVENT_TYPES   (1 + PEER_EVENT_DELETED)
+    typedef struct {
+        BREthereumPeerEventType type;
+        BREthereumStatus status;
+        // union { } u;
+        char errorDescription[16];
+    } BREthereumPeerEvent;
 
     typedef void (*BREthereumClientHandlerPeerEvent) (BREthereumClientContext context,
                                                       BREthereumEWM ewm,
-                                                      // BREthereumWallet wid,
-                                                      // BREthereumTransaction tid,
-                                                      BREthereumPeerEvent event,
-                                                      BREthereumStatus status,
-                                                      const char *errorDescription);
+                                                      BREthereumPeerEvent event);
 
     typedef enum {
         TOKEN_EVENT_CREATED = 0,
         TOKEN_EVENT_DELETED
+    } BREthereumTokenEventType;
+
+#define TOKEN_NUMBER_OF_EVENT_TYPES  (1 + TOKEN_EVENT_DELETED)
+
+    typedef struct {
+        BREthereumTokenEventType type;
+        BREthereumStatus status;
+        // union {} u;
+        char errorDescription[16];
     } BREthereumTokenEvent;
-
-#define TOKEN_NUMBER_OF_EVENTS  (1 + TOKEN_EVENT_DELETED)
-
+    
     typedef void (*BREthereumClientHandlerTokenEvent) (BREthereumClientContext context,
                                                        BREthereumEWM ewm,
                                                        BREthereumToken token,

--- a/ethereum/ewm/BREthereumClient.h
+++ b/ethereum/ewm/BREthereumClient.h
@@ -342,17 +342,22 @@ extern "C" {
         TRANSFER_EVENT_GAS_ESTIMATE_UPDATED,
 
         TRANSFER_EVENT_DELETED
-    } BREthereumTransferEvent;
+    } BREthereumTransferEventType;
 
-#define TRANSACTION_NUMBER_OF_EVENTS (1 + TRANSACTION_EVENT_DELETED)
+#define TRANSACTION_NUMBER_OF_EVENT_TYPES (1 + TRANSACTION_EVENT_DELETED)
+
+    typedef struct {
+        BREthereumTransferEventType type;
+        BREthereumStatus status;
+        // uniont {} u;
+        char errorDescription[16];
+    } BREthereumTransferEvent;
 
     typedef void (*BREthereumClientHandlerTransferEvent) (BREthereumClientContext context,
                                                           BREthereumEWM ewm,
                                                           BREthereumWallet wid,
                                                           BREthereumTransfer tid,
-                                                          BREthereumTransferEvent event,
-                                                          BREthereumStatus status,
-                                                          const char *errorDescription);
+                                                          BREthereumTransferEvent event);
 
     typedef enum {
         PEER_EVENT_CREATED = 0,

--- a/ethereum/ewm/BREthereumEWM.c
+++ b/ethereum/ewm/BREthereumEWM.c
@@ -1127,7 +1127,10 @@ ewmInsertWallet (BREthereumEWM ewm,
                  BREthereumWallet wallet) {
     pthread_mutex_lock(&ewm->lock);
     array_add (ewm->wallets, wallet);
-    ewmSignalWalletEvent (ewm, wallet, (BREthereumWalletEvent) { WALLET_EVENT_CREATED }, SUCCESS, NULL);
+    ewmSignalWalletEvent (ewm, wallet, (BREthereumWalletEvent) {
+        WALLET_EVENT_CREATED,
+        SUCCESS
+    });
     pthread_mutex_unlock(&ewm->lock);
 }
 
@@ -1510,9 +1513,10 @@ ewmWalletSetDefaultGasLimit(BREthereumEWM ewm,
     walletSetDefaultGasLimit(wallet, gasLimit);
     ewmSignalWalletEvent(ewm,
                          wallet,
-                         (BREthereumWalletEvent) { WALLET_EVENT_DEFAULT_GAS_LIMIT_UPDATED },
-                         SUCCESS,
-                         NULL);
+                         (BREthereumWalletEvent) {
+                             WALLET_EVENT_DEFAULT_GAS_LIMIT_UPDATED,
+                             SUCCESS
+                         });
 }
 
 extern BREthereumGasPrice
@@ -1528,9 +1532,10 @@ ewmWalletSetDefaultGasPrice(BREthereumEWM ewm,
     walletSetDefaultGasPrice(wallet, gasPrice);
     ewmSignalWalletEvent(ewm,
                          wallet,
-                         (BREthereumWalletEvent) { WALLET_EVENT_DEFAULT_GAS_PRICE_UPDATED },
-                         SUCCESS,
-                         NULL);
+                         (BREthereumWalletEvent) {
+                             WALLET_EVENT_DEFAULT_GAS_PRICE_UPDATED,
+                             SUCCESS
+                         });
 }
 
 
@@ -1553,8 +1558,10 @@ ewmHandleGasPrice (BREthereumEWM ewm,
 
     ewmSignalWalletEvent(ewm,
                          wallet,
-                         (BREthereumWalletEvent) { WALLET_EVENT_DEFAULT_GAS_PRICE_UPDATED },
-                         SUCCESS, NULL);
+                         (BREthereumWalletEvent) {
+                             WALLET_EVENT_DEFAULT_GAS_PRICE_UPDATED,
+                             SUCCESS
+                         });
 
     pthread_mutex_unlock(&ewm->lock);
 }
@@ -1667,9 +1674,10 @@ ewmHandleBalance (BREthereumEWM ewm,
         walletSetBalance(wallet, amount);
         ewmSignalWalletEvent (ewm,
                               wallet,
-                              (BREthereumWalletEvent) { WALLET_EVENT_BALANCE_UPDATED },
-                              SUCCESS,
-                              NULL);
+                              (BREthereumWalletEvent) {
+                                  WALLET_EVENT_BALANCE_UPDATED,
+                                  SUCCESS
+                              });
 
         {
             char *amountAsString = (AMOUNT_ETHER == amountGetType(amount)
@@ -2096,15 +2104,17 @@ ewmUpdateWalletBalance(BREthereumEWM ewm,
 
     if (NULL == wallet) {
         ewmSignalWalletEvent(ewm, wallet,
-                             (BREthereumWalletEvent) { WALLET_EVENT_BALANCE_UPDATED },
-                             ERROR_UNKNOWN_WALLET,
-                             NULL);
+                             (BREthereumWalletEvent) {
+                                 WALLET_EVENT_BALANCE_UPDATED,
+                                 ERROR_UNKNOWN_WALLET
+                             });
 
     } else if (ETHEREUM_BOOLEAN_IS_FALSE(ewmIsConnected(ewm))) {
         ewmSignalWalletEvent(ewm, wallet,
-                             (BREthereumWalletEvent) { WALLET_EVENT_BALANCE_UPDATED },
-                             ERROR_NODE_NOT_CONNECTED,
-                             NULL);
+                             (BREthereumWalletEvent) {
+                                 WALLET_EVENT_BALANCE_UPDATED,
+                                 ERROR_NODE_NOT_CONNECTED
+                             });
     } else {
         switch (ewm->mode) {
             case BRD_ONLY:

--- a/ethereum/ewm/BREthereumEWMClient.c
+++ b/ethereum/ewm/BREthereumEWMClient.c
@@ -68,15 +68,17 @@ ewmUpdateGasPrice (BREthereumEWM ewm,
 
     if (NULL == wallet) {
         ewmSignalWalletEvent(ewm, wallet,
-                             (BREthereumWalletEvent) { WALLET_EVENT_DEFAULT_GAS_PRICE_UPDATED },
-                             ERROR_UNKNOWN_WALLET,
-                             NULL);
+                             (BREthereumWalletEvent) {
+                                 WALLET_EVENT_DEFAULT_GAS_PRICE_UPDATED,
+                                 ERROR_UNKNOWN_WALLET
+                             });
 
     } else if (ETHEREUM_BOOLEAN_IS_FALSE(ewmIsConnected(ewm))) {
         ewmSignalWalletEvent(ewm, wallet,
-                             (BREthereumWalletEvent) { WALLET_EVENT_DEFAULT_GAS_PRICE_UPDATED },
-                             ERROR_NODE_NOT_CONNECTED,
-                             NULL);
+                             (BREthereumWalletEvent) {
+                                 WALLET_EVENT_DEFAULT_GAS_PRICE_UPDATED,
+                                 ERROR_NODE_NOT_CONNECTED
+                             });
     } else {
         switch (ewm->mode) {
             case BRD_ONLY:
@@ -220,9 +222,11 @@ ewmHandlGasEstimateSuccess (BREthereumEWM ewm,
                             BREthereumGasPrice gasPrice) {
     ewmSignalWalletEvent (ewm,
                           wallet,
-                          (BREthereumWalletEvent) {WALLET_EVENT_FEE_ESTIMATED, {.feeEstimate = {cookie, gasEstimate, gasPrice}}},
-                          SUCCESS,
-                          NULL);
+                          (BREthereumWalletEvent) {
+                              WALLET_EVENT_FEE_ESTIMATED,
+                              SUCCESS,
+                              {.feeEstimate = {cookie, gasEstimate, gasPrice }}
+                          });
 }
 
 extern void
@@ -232,9 +236,11 @@ ewmHandlGasEstimateFailure (BREthereumEWM ewm,
                             BREthereumStatus status) {
     ewmSignalWalletEvent (ewm,
                           wallet,
-                          (BREthereumWalletEvent) {WALLET_EVENT_FEE_ESTIMATED, {.feeEstimate = {cookie}}},
-                          status,
-                          NULL);
+                          (BREthereumWalletEvent) {
+                              WALLET_EVENT_FEE_ESTIMATED,
+                              SUCCESS,
+                              {.feeEstimate = {cookie}}
+                          });
 }
 
 // ==============================================================================================
@@ -831,17 +837,12 @@ ewmAnnounceTokenComplete (BREthereumEWM ewm,
 
 extern void
 ewmHandleWalletEvent(BREthereumEWM ewm,
-                           BREthereumWallet wid,
-                           BREthereumWalletEvent event,
-                           BREthereumStatus status,
-                           const char *errorDescription) {
-    ewm->client.funcWalletEvent
-    (ewm->client.context,
-     ewm,
-     wid,
-     event,
-     status,
-     errorDescription);
+                     BREthereumWallet wid,
+                     BREthereumWalletEvent event) {
+    ewm->client.funcWalletEvent (ewm->client.context,
+                                 ewm,
+                                 wid,
+                                 event);
 }
 
 #if defined (NEVER_DEFINED)

--- a/ethereum/ewm/BREthereumEWMClient.c
+++ b/ethereum/ewm/BREthereumEWMClient.c
@@ -863,16 +863,14 @@ ewmHandleBlockEvent(BREthereumEWM ewm,
 static int
 ewmNeedTransferSave (BREthereumEWM ewm,
                      BREthereumTransferEvent event) {
-    return (TRANSFER_EVENT_GAS_ESTIMATE_UPDATED != event);
+    return (TRANSFER_EVENT_GAS_ESTIMATE_UPDATED != event.type);
 }
 
 extern void
 ewmHandleTransferEvent (BREthereumEWM ewm,
                         BREthereumWallet wallet,
                         BREthereumTransfer transfer,
-                        BREthereumTransferEvent event,
-                        BREthereumStatus status,
-                        const char *errorDescription) {
+                        BREthereumTransferEvent event) {
 
     // If `transfer` represents a token transfer that we've created/submitted, then we won't have
     // the actual `log` until the corresponding originating transaction is included.  We won't
@@ -898,10 +896,10 @@ ewmHandleTransferEvent (BREthereumEWM ewm,
             // We know that only on SIGNED do we have a transaction hash.  Only on
             // included do we have a log hash.  Thus we might see CHANGE_UPD w/o a
             // CHANGE_ADD - and that is NOT a problem.
-            BREthereumClientChangeType type = ((event == TRANSFER_EVENT_CREATED ||
-                                                event == TRANSFER_EVENT_SIGNED)
+            BREthereumClientChangeType type = ((event.type == TRANSFER_EVENT_CREATED ||
+                                                event.type == TRANSFER_EVENT_SIGNED)
                                                ? CLIENT_CHANGE_ADD
-                                               : (event == TRANSFER_EVENT_DELETED
+                                               : (event.type == TRANSFER_EVENT_DELETED
                                                   ? CLIENT_CHANGE_REM
                                                   : CLIENT_CHANGE_UPD));
 
@@ -918,9 +916,7 @@ ewmHandleTransferEvent (BREthereumEWM ewm,
                                    ewm,
                                    wallet,
                                    transfer,
-                                   event,
-                                   status,
-                                   errorDescription);
+                                   event);
 }
 
 extern void

--- a/ethereum/ewm/BREthereumEWMClient.c
+++ b/ethereum/ewm/BREthereumEWMClient.c
@@ -755,7 +755,7 @@ ewmHandleAnnounceToken (BREthereumEWM ewm,
     ewm->client.funcTokenEvent (ewm->client.context,
                                 ewm,
                                 token,
-                                TOKEN_EVENT_CREATED);
+                                (BREthereumTokenEvent) {TOKEN_EVENT_CREATED, SUCCESS });
 
     ewmClientAnnounceTokenBundleRelease(bundle);
 }
@@ -925,23 +925,15 @@ ewmHandleTransferEvent (BREthereumEWM ewm,
 
 extern void
 ewmHandlePeerEvent(BREthereumEWM ewm,
-                         // BREthereumWallet wid,
-                         // BREthereumTransaction tid,
-                         BREthereumPeerEvent event,
-                         BREthereumStatus status,
-                         const char *errorDescription) {
+                   BREthereumPeerEvent event) {
     ewm->client.funcPeerEvent (ewm->client.context,
                                ewm,
-                               // event->wid,
-                               // event->tid,
-                               event,
-                               status,
-                               errorDescription);
+                               event);
 }
 
 extern void
 ewmHandleEWMEvent(BREthereumEWM ewm,
-                        BREthereumEWMEvent event) {
+                  BREthereumEWMEvent event) {
     ewm->client.funcEWMEvent (ewm->client.context,
                               ewm,
                               event);

--- a/ethereum/ewm/BREthereumEWMClient.c
+++ b/ethereum/ewm/BREthereumEWMClient.c
@@ -849,15 +849,11 @@ ewmHandleWalletEvent(BREthereumEWM ewm,
 extern void
 ewmHandleBlockEvent(BREthereumEWM ewm,
                           BREthereumBlock block,
-                          BREthereumBlockEvent event,
-                          BREthereumStatus status,
-                          const char *errorDescription) {
+                          BREthereumBlockEvent event) {
     ewm->client.funcBlockEvent (ewm->client.context,
                                 ewm,
                                 block,
-                                event,
-                                status,
-                                errorDescription);
+                                event);
 }
 #endif
 

--- a/ethereum/ewm/BREthereumEWMClient.c
+++ b/ethereum/ewm/BREthereumEWMClient.c
@@ -941,18 +941,10 @@ ewmHandlePeerEvent(BREthereumEWM ewm,
 
 extern void
 ewmHandleEWMEvent(BREthereumEWM ewm,
-                        // BREthereumWallet wid,
-                        // BREthereumTransaction tid,
-                        BREthereumEWMEvent event,
-                        BREthereumStatus status,
-                        const char *errorDescription) {
+                        BREthereumEWMEvent event) {
     ewm->client.funcEWMEvent (ewm->client.context,
                               ewm,
-                              //event->wid,
-                              // event->tid,
-                              event,
-                              status,
-                              errorDescription);
+                              event);
 }
 
 

--- a/ethereum/ewm/BREthereumEWMEvent.c
+++ b/ethereum/ewm/BREthereumEWMEvent.c
@@ -421,21 +421,17 @@ typedef struct {
     BREthereumEWM ewm;
     BREthereumWallet wid;
     BREthereumWalletEvent event;
-    BREthereumStatus status;
-    const char *errorDescription;
 } BREthereumEWMClientWalletEvent;
 
-#define CLIENT_WALLET_EVENT_INITIALIZER(ewm, wid, vent, status, desc)  \
-{ { NULL, &ewmClientWalletEventType }, (ewm), (wid), (event), (status), (desc) }
+#define CLIENT_WALLET_EVENT_INITIALIZER(ewm, wid, event)  \
+{ { NULL, &ewmClientWalletEventType }, (ewm), (wid), (event) }
 
 static void
 ewmClientWalletEventDispatcher(BREventHandler ignore,
                                BREthereumEWMClientWalletEvent *event) {
     ewmHandleWalletEvent(event->ewm,
                          event->wid,
-                         event->event,
-                         event->status,
-                         event->errorDescription);
+                         event->event);
 }
 
 static BREventType ewmClientWalletEventType = {
@@ -447,11 +443,9 @@ static BREventType ewmClientWalletEventType = {
 extern void
 ewmSignalWalletEvent(BREthereumEWM ewm,
                      BREthereumWallet wid,
-                     BREthereumWalletEvent event,
-                     BREthereumStatus status,
-                     const char *errorDescription) {
+                     BREthereumWalletEvent event) {
     BREthereumEWMClientWalletEvent message =
-    CLIENT_WALLET_EVENT_INITIALIZER (ewm, wid, event, status, errorDescription);
+    CLIENT_WALLET_EVENT_INITIALIZER (ewm, wid, event);
     eventHandlerSignalEvent(ewm->handler, (BREvent*) &message);
 }
 

--- a/ethereum/ewm/BREthereumEWMEvent.c
+++ b/ethereum/ewm/BREthereumEWMEvent.c
@@ -508,12 +508,10 @@ typedef struct {
     BREthereumWallet wid;
     BREthereumTransfer tid;
     BREthereumTransferEvent event;
-    BREthereumStatus status;
-    const char *errorDescription;
 } BREthereumEWMClientTransactionEvent;
 
-#define CLIENT_TRANSACTION_EVENT_INITIALIZER(ewm, wid, tid, event, status, desc)  \
-{ { NULL, &ewmClientTransactionEventType }, (ewm), (wid), (tid), (event), (status), (desc) }
+#define CLIENT_TRANSACTION_EVENT_INITIALIZER(ewm, wid, tid, event)  \
+{ { NULL, &ewmClientTransactionEventType }, (ewm), (wid), (tid), (event) }
 
 static void
 ewmClientTransactionEventDispatcher(BREventHandler ignore,
@@ -521,9 +519,7 @@ ewmClientTransactionEventDispatcher(BREventHandler ignore,
     ewmHandleTransferEvent(event->ewm,
                            event->wid,
                            event->tid,
-                           event->event,
-                           event->status,
-                           event->errorDescription);
+                           event->event);
 }
 
 static BREventType ewmClientTransactionEventType = {
@@ -536,11 +532,9 @@ extern void
 ewmSignalTransferEvent(BREthereumEWM ewm,
                        BREthereumWallet wid,
                        BREthereumTransfer tid,
-                       BREthereumTransferEvent event,
-                       BREthereumStatus status,
-                       const char *errorDescription) {
+                       BREthereumTransferEvent event) {
     BREthereumEWMClientTransactionEvent message =
-    CLIENT_TRANSACTION_EVENT_INITIALIZER (ewm, wid, tid, event, status, errorDescription);
+    CLIENT_TRANSACTION_EVENT_INITIALIZER (ewm, wid, tid, event);
     eventHandlerSignalEvent(ewm->handler, (BREvent*) &message);
 }
 

--- a/ethereum/ewm/BREthereumEWMEvent.c
+++ b/ethereum/ewm/BREthereumEWMEvent.c
@@ -458,21 +458,17 @@ typedef struct {
     BREthereumEWM ewm;
     BREthereumBlock bid;
     BREthereumBlockEvent event;
-    BREthereumStatus status;
-    const char *errorDescription;
 } BREthereumEWMClientBlockEvent;
 
-#define CLIENT_BLOCK_EVENT_INITIALIZER(ewm, bid, event, status, desc)  \
-{ { NULL, &ewmClientBlockEventType }, (ewm), (bid), (event), (status), (desc) }
+#define CLIENT_BLOCK_EVENT_INITIALIZER(ewm, bid, event)  \
+{ { NULL, &ewmClientBlockEventType }, (ewm), (bid), (event) }
 
 static void
 ewmClientBlockEventDispatcher(BREventHandler ignore,
                               BREthereumEWMClientBlockEvent *event) {
     ewmHandleBlockEvent(event->ewm,
                         event->bid,
-                        event->event,
-                        event->status,
-                        event->errorDescription);
+                        event->event);
 }
 
 static BREventType ewmClientBlockEventType = {
@@ -484,11 +480,9 @@ static BREventType ewmClientBlockEventType = {
 extern void
 ewmSignalBlockEvent(BREthereumEWM ewm,
                     BREthereumBlock bid,
-                    BREthereumBlockEvent event,
-                    BREthereumStatus status,
-                    const char *errorDescription) {
+                    BREthereumBlockEvent event) {
     BREthereumEWMClientBlockEvent message =
-    CLIENT_BLOCK_EVENT_INITIALIZER (ewm, bid, event, status, errorDescription);
+    CLIENT_BLOCK_EVENT_INITIALIZER (ewm, bid, event);
     eventHandlerSignalEvent(ewm->handlerForMain, (BREvent*) &message);
 }
 #endif

--- a/ethereum/ewm/BREthereumEWMEvent.c
+++ b/ethereum/ewm/BREthereumEWMEvent.c
@@ -550,20 +550,17 @@ ewmSignalTransferEvent(BREthereumEWM ewm,
 typedef struct {
     struct BREventRecord base;
     BREthereumEWM ewm;
-    // BREthereumWallet wid;
-    // BREthereumTransaction tid;
     BREthereumPeerEvent event;
-    BREthereumStatus status;
-    const char *errorDescription;
+
 } BREthereumEWMClientPeerEvent;
 
-#define CLIENT_PEER_EVENT_INITIALIZER(ewm, /* wid, tid,*/ event, status, desc)  \
-{ { NULL, &ewmClientPeerEventType }, (ewm), /*(wid), (tid),*/ (event), (status), (desc) }
+#define CLIENT_PEER_EVENT_INITIALIZER(ewm, /* wid, tid,*/ event)  \
+{ { NULL, &ewmClientPeerEventType }, (ewm), /*(wid), (tid),*/ (event) }
 
 static void
 ewmClientPeerEventDispatcher(BREventHandler ignore,
                              BREthereumEWMClientPeerEvent *event) {
-    ewmHandlePeerEvent(event->ewm, event->event, event->status, event->errorDescription);
+    ewmHandlePeerEvent(event->ewm, event->event);
 }
 
 static BREventType ewmClientPeerEventType = {
@@ -574,13 +571,9 @@ static BREventType ewmClientPeerEventType = {
 
 extern void
 ewmSignalPeerEvent(BREthereumEWM ewm,
-                   // BREthereumWallet wid,
-                   // BREthereumTransaction tid,
-                   BREthereumPeerEvent event,
-                   BREthereumStatus status,
-                   const char *errorDescription) {
+                    BREthereumPeerEvent event) {
     BREthereumEWMClientPeerEvent message =
-    CLIENT_PEER_EVENT_INITIALIZER (ewm, /* wid, tid,*/ event, status, errorDescription);
+    CLIENT_PEER_EVENT_INITIALIZER (ewm, /* wid, tid,*/ event);
     eventHandlerSignalEvent(ewm->handler, (BREvent*) &message);
 }
 

--- a/ethereum/ewm/BREthereumEWMEvent.c
+++ b/ethereum/ewm/BREthereumEWMEvent.c
@@ -590,20 +590,16 @@ ewmSignalPeerEvent(BREthereumEWM ewm,
 typedef struct {
     struct BREventRecord base;
     BREthereumEWM ewm;
-    // BREthereumWallet wid;
-    // BREthereumTransaction tid;
     BREthereumEWMEvent event;
-    BREthereumStatus status;
-    const char *errorDescription;
 } BREthereumEWMClientEWMEvent;
 
-#define CLIENT_EWM_EVENT_INITIALIZER(ewm, /* wid, tid,*/ event, status, desc)  \
-{ { NULL, &ewmClientEWMEventType }, (ewm), /*(wid), (tid),*/ (event), (status), (desc) }
+#define CLIENT_EWM_EVENT_INITIALIZER(ewm, /* wid, tid,*/ event)  \
+{ { NULL, &ewmClientEWMEventType }, (ewm), /*(wid), (tid),*/ (event) }
 
 static void
 ewmClientEWMEventDispatcher(BREventHandler ignore,
                             BREthereumEWMClientEWMEvent *event) {
-    ewmHandleEWMEvent(event->ewm, event->event, event->status, event->errorDescription);
+    ewmHandleEWMEvent(event->ewm, event->event);
 }
 
 static BREventType ewmClientEWMEventType = {
@@ -614,13 +610,9 @@ static BREventType ewmClientEWMEventType = {
 
 extern void
 ewmSignalEWMEvent(BREthereumEWM ewm,
-                  // BREthereumWallet wid,
-                  // BREthereumTransaction tid,
-                  BREthereumEWMEvent event,
-                  BREthereumStatus status,
-                  const char *errorDescription) {
+                  BREthereumEWMEvent event) {
     BREthereumEWMClientEWMEvent message =
-    CLIENT_EWM_EVENT_INITIALIZER (ewm, /* wid, tid,*/ event, status, errorDescription);
+    CLIENT_EWM_EVENT_INITIALIZER (ewm, /* wid, tid,*/ event);
     eventHandlerSignalEvent(ewm->handler, (BREvent*) &message);
 }
 

--- a/ethereum/ewm/BREthereumEWMPrivate.h
+++ b/ethereum/ewm/BREthereumEWMPrivate.h
@@ -532,16 +532,12 @@ ewmSignalAnnounceNonce (BREthereumEWM ewm,
 extern void
 ewmHandleWalletEvent(BREthereumEWM ewm,
                            BREthereumWallet wid,
-                           BREthereumWalletEvent event,
-                           BREthereumStatus status,
-                           const char *errorDescription);
+                           BREthereumWalletEvent event);
 
 extern void
 ewmSignalWalletEvent(BREthereumEWM ewm,
                            BREthereumWallet wid,
-                           BREthereumWalletEvent event,
-                           BREthereumStatus status,
-                           const char *errorDescription);
+                           BREthereumWalletEvent event);
 
 //
 // Block Event

--- a/ethereum/ewm/BREthereumEWMPrivate.h
+++ b/ethereum/ewm/BREthereumEWMPrivate.h
@@ -44,15 +44,6 @@ typedef enum {
 #define DEFAULT_BLOCK_CAPACITY 100
 #define DEFAULT_TRANSACTION_CAPACITY 1000
 
-typedef enum {
-    LIGHT_NODE_CREATED,
-    LIGHT_NODE_CONNECTING,
-    LIGHT_NODE_CONNECTED,
-    LIGHT_NODE_DISCONNECTING,
-    LIGHT_NODE_DISCONNECTED,
-    LIGHT_NODE_ERRORED
-} BREthereumEWMState;
-
 /// MISPLACED
 extern void
 ewmInsertWallet (BREthereumEWM ewm,
@@ -613,19 +604,11 @@ ewmHandlePeerEvent(BREthereumEWM ewm,
 //
 extern void
 ewmSignalEWMEvent(BREthereumEWM ewm,
-                        // BREthereumWallet wid,
-                        // BREthereumTransaction tid,
-                        BREthereumEWMEvent event,
-                        BREthereumStatus status,
-                        const char *errorDescription);
+                  BREthereumEWMEvent event);
 
 extern void
 ewmHandleEWMEvent(BREthereumEWM ewm,
-                        // BREthereumWallet wid,
-                        // BREthereumTransaction tid,
-                        BREthereumEWMEvent event,
-                        BREthereumStatus status,
-                        const char *errorDescription);
+                  BREthereumEWMEvent event);
 
 /// MARK: - Handler For Main
 

--- a/ethereum/ewm/BREthereumEWMPrivate.h
+++ b/ethereum/ewm/BREthereumEWMPrivate.h
@@ -567,19 +567,15 @@ ewmHandleBlockEvent(BREthereumEWM ewm,
 
 extern void
 ewmSignalTransferEvent(BREthereumEWM ewm,
-                             BREthereumWallet wid,
-                             BREthereumTransfer tid,
-                             BREthereumTransferEvent event,
-                             BREthereumStatus status,
-                             const char *errorDescription);
+                       BREthereumWallet wid,
+                       BREthereumTransfer tid,
+                       BREthereumTransferEvent event);
 
 extern void
 ewmHandleTransferEvent(BREthereumEWM ewm,
-                             BREthereumWallet wid,
-                             BREthereumTransfer tid,
-                             BREthereumTransferEvent event,
-                             BREthereumStatus status,
-                             const char *errorDescription);
+                       BREthereumWallet wid,
+                       BREthereumTransfer tid,
+                       BREthereumTransferEvent event);
 //
 // Peer Event
 //

--- a/ethereum/ewm/BREthereumEWMPrivate.h
+++ b/ethereum/ewm/BREthereumEWMPrivate.h
@@ -546,16 +546,12 @@ ewmSignalWalletEvent(BREthereumEWM ewm,
 extern void
 ewmSignalBlockEvent(BREthereumEWM ewm,
                           BREthereumBlock bid,
-                          BREthereumBlockEvent event,
-                          BREthereumStatus status,
-                          const char *errorDescription);
+                          BREthereumBlockEvent event);
 
 extern void
 ewmHandleBlockEvent(BREthereumEWM ewm,
                           BREthereumBlock bid,
-                          BREthereumBlockEvent event,
-                          BREthereumStatus status,
-                          const char *errorDescription);
+                          BREthereumBlockEvent event);
 #endif
 //
 // Transfer Event

--- a/ethereum/ewm/BREthereumEWMPrivate.h
+++ b/ethereum/ewm/BREthereumEWMPrivate.h
@@ -585,19 +585,11 @@ ewmHandleTransferEvent(BREthereumEWM ewm,
 //
 extern void
 ewmSignalPeerEvent(BREthereumEWM ewm,
-                         // BREthereumWallet wid,
-                         // BREthereumTransaction tid,
-                         BREthereumPeerEvent event,
-                         BREthereumStatus status,
-                         const char *errorDescription);
+                   BREthereumPeerEvent event);
 
 extern void
 ewmHandlePeerEvent(BREthereumEWM ewm,
-                         // BREthereumWallet wid,
-                         // BREthereumTransaction tid,
-                         BREthereumPeerEvent event,
-                         BREthereumStatus status,
-                         const char *errorDescription);
+                   BREthereumPeerEvent event);
 
 //
 // EWM Event

--- a/ethereum/ewm/testEwm.c
+++ b/ethereum/ewm/testEwm.c
@@ -497,10 +497,8 @@ clientEventTransfer (BREthereumClientContext context,
                      BREthereumEWM ewm,
                      BREthereumWallet wid,
                      BREthereumTransfer tid,
-                     BREthereumTransferEvent event,
-                     BREthereumStatus status,
-                     const char *errorDescription) {
-    fprintf (stdout, "ETH: TST: TransferEvent: tid=%p, ev=%d\n", tid, event);
+                     BREthereumTransferEvent event) {
+    fprintf (stdout, "ETH: TST: TransferEvent: tid=%p, ev=%d\n", tid, event.type);
 }
 
 static void

--- a/ethereum/ewm/testEwm.c
+++ b/ethereum/ewm/testEwm.c
@@ -459,9 +459,7 @@ static void
 clientEventWallet (BREthereumClientContext context,
                    BREthereumEWM ewm,
                    BREthereumWallet wid,
-                   BREthereumWalletEvent event,
-                   BREthereumStatus status,
-                   const char *errorDescription) {
+                   BREthereumWalletEvent event) {
     fprintf (stdout, "ETH: TST: WalletEvent: wid=%p, ev=%d\n", wid, event.type);
     switch (event.type) {
         case WALLET_EVENT_BALANCE_UPDATED:

--- a/ethereum/ewm/testEwm.c
+++ b/ethereum/ewm/testEwm.c
@@ -517,12 +517,8 @@ clientEventPeer (BREthereumClientContext context,
 static void
 clientEventEWM (BREthereumClientContext context,
                 BREthereumEWM ewm,
-                //BREthereumWallet wid,
-                //BREthereumTransactionId tid,
-                BREthereumEWMEvent event,
-                BREthereumStatus status,
-                const char *errorDescription) {
-    fprintf (stdout, "ETH: TST: EWMEvent: ev=%d\n", event);
+                BREthereumEWMEvent event) {
+    fprintf (stdout, "ETH: TST: EWMEvent: ev=%d\n", event.type);
 }
 
 static void

--- a/ethereum/ewm/testEwm.c
+++ b/ethereum/ewm/testEwm.c
@@ -483,10 +483,8 @@ static void
 clientEventBlock (BREthereumClientContext context,
                   BREthereumEWM ewm,
                   BREthereumBlockId bid,
-                  BREthereumBlockEvent event,
-                  BREthereumStatus status,
-                  const char *errorDescription) {
-    fprintf (stdout, "ETH: TST: BlockEvent: bid=%d, ev=%d\n", bid, event);
+                  BREthereumBlockEvent event) {
+    fprintf (stdout, "ETH: TST: BlockEvent: bid=%d, ev=%d\n", bid, event.type);
 }
 #endif
 

--- a/ethereum/ewm/testEwm.c
+++ b/ethereum/ewm/testEwm.c
@@ -477,7 +477,7 @@ clientEventToken (BREthereumClientContext context,
                    BREthereumEWM ewm,
                    BREthereumToken token,
                    BREthereumTokenEvent event) {
-    fprintf (stdout, "ETH: TST: TokenEvent: wid=%p, ev=%d\n", token, event);
+    fprintf (stdout, "ETH: TST: TokenEvent: wid=%p, ev=%d\n", token, event.type);
 }
 
 #if defined (NEVER_DEFINED)
@@ -506,12 +506,8 @@ clientEventTransfer (BREthereumClientContext context,
 static void
 clientEventPeer (BREthereumClientContext context,
                  BREthereumEWM ewm,
-                 //BREthereumWallet wid,
-                 //BREthereumTransactionId tid,
-                 BREthereumPeerEvent event,
-                 BREthereumStatus status,
-                 const char *errorDescription) {
-    fprintf (stdout, "ETH: TST: PeerEvent: ev=%d\n", event);
+                 BREthereumPeerEvent event) {
+    fprintf (stdout, "ETH: TST: PeerEvent: ev=%d\n", event.type);
 }
 
 static void


### PR DESCRIPTION
(Done in support of CORE-486 and CORE-491)

Ethereum event interfaces passed `(..., event (as an enum), status, error )`.  Changed to be 
```
typedef struct {
   type,
   status,
   union { /* event specific data */} u;
   error
} event;
```
This structured approach allows one to pass values back in an event.
