### PR TITLE
CORE-282: BRCryptoWalletMigrator

### DIFF
--- a/Swift/BRCrypto/BRCryptoAmount.swift
+++ b/Swift/BRCrypto/BRCryptoAmount.swift
@@ -56,6 +56,17 @@ public final class Amount {
             .string (as: pair.quoteUnit, formatter: formatter)
     }
 
+    /// INTERNAL: Returns the low uint64_t value optionally.
+    internal var integerRawSmall: UInt64? {
+        var overflow: BRCryptoBoolean = CRYPTO_FALSE
+        let value = cryptoAmountGetIntegerRaw (core, &overflow)
+        return CRYPTO_TRUE == overflow ? nil : value
+    }
+
+    internal var integerRaw: UInt256 {
+        return cryptoAmountGetValue(core)
+    }
+
     ///
     /// Return a 'raw string' (as an integer in self's base unit) using `base` and `preface`.
     /// Caution is warranted: this is a string w/o any context (currency in a particular Unit).

--- a/Swift/BRCrypto/BRCryptoSystem.swift
+++ b/Swift/BRCrypto/BRCryptoSystem.swift
@@ -1222,7 +1222,12 @@ extension System {
     /// - btc:
     ///
     public enum PeerBlob {
-        case btc
+        case btc (
+            address: UInt32,  // UInt128 { .u32 = { 0, 0, 0xffff, <address> }}
+            port: UInt16,
+            services: UInt64,
+            timestamp: UInt32?
+        )
     }
 
     ///
@@ -1337,12 +1342,17 @@ extension System {
                 }
             }
         }
-
+        
         try peerBlobs.forEach { (blob: PeerBlob) in
-            guard case .btc = blob
+            guard case let .btc (blob) = blob
                 else { throw MigrateError.peer }
-
-            let status = cryptoWalletMigratorHandlePeerAsBTC (migrator)
+            
+            let status = cryptoWalletMigratorHandlePeerAsBTC (migrator,
+                                                              blob.address,
+                                                              blob.port,
+                                                              blob.services,
+                                                              blob.timestamp ?? 0)
+            
             if status.type != CRYPTO_WALLET_MIGRATOR_SUCCESS {
                 throw MigrateError.peer
             }
@@ -1400,7 +1410,6 @@ extension System {
             return nil
         }
     }
-
 }
 
 extension BRCryptoTransferEventType: CustomStringConvertible {

--- a/Swift/BRCrypto/BRCryptoTransfer.swift
+++ b/Swift/BRCrypto/BRCryptoTransfer.swift
@@ -182,6 +182,14 @@ public enum TransferDirection: Equatable {
         default: self = .sent;  precondition(false)
         }
     }
+
+    internal var core: BRCryptoTransferDirection {
+        switch self {
+        case .sent:      return CRYPTO_TRANSFER_SENT
+        case .received:  return CRYPTO_TRANSFER_RECEIVED
+        case .recovered: return CRYPTO_TRANSFER_RECOVERED
+        }
+    }
 }
 
 ///

--- a/Swift/BRCryptoTests/BRCryptoCommonTests.swift
+++ b/Swift/BRCryptoTests/BRCryptoCommonTests.swift
@@ -8,7 +8,7 @@
 import XCTest
 import Foundation
 @testable import BRCrypto
-import BRCryptoC
+import BRCryptoC // UInt256 <==> Secret
 
 class BRCryptoCommonTests: XCTestCase {
 

--- a/Swift/BRCryptoTests/BRCryptoDebugSupport.swift
+++ b/Swift/BRCryptoTests/BRCryptoDebugSupport.swift
@@ -7,7 +7,6 @@
 //
 
 @testable import BRCrypto
-import BRCryptoC
 
 ///
 /// Event Matching
@@ -169,7 +168,7 @@ extension Array where Element:MatchableEvent {
 
 extension Amount: CustomDebugStringConvertible {
     public var debugDescription: String {
-        let value = cryptoAmountGetValue(core)
+        let value = self.integerRaw
         return "Amount: {\(value.u64.3), \(value.u64.2), \(value.u64.1), \(value.u64.0)}: \(unit.name)"
     }
 }

--- a/Swift/BRCryptoTests/BRCryptoTransferTests.swift
+++ b/Swift/BRCryptoTests/BRCryptoTransferTests.swift
@@ -11,7 +11,6 @@
 
 import XCTest
 @testable import BRCrypto
-import BRCryptoC
 
 struct TransferResult {
     let target: Bool
@@ -27,8 +26,7 @@ struct TransferResult {
         guard let transferHash = transfer.hash?.description, self.hash == transferHash
             else { return false }
 
-        var overflow: BRCryptoBoolean = CRYPTO_FALSE
-        guard amount == cryptoAmountGetIntegerRaw(transfer.amount.core, &overflow)
+        guard let transferInteger = transfer.amount.integerRawSmall, amount == transferInteger
             else { return false }
 
        guard let transferConfirmation = transfer.confirmation // , self.confirmation == transferConfirmation
@@ -273,9 +271,9 @@ class BRCryptoTransferTests: BRCryptoSystemBaseTests {
     }
 
     func testTransferDirection () {
-        XCTAssertEqual(TransferDirection.sent,      TransferDirection (core: BRCryptoTransferDirection (rawValue: 0)))
-        XCTAssertEqual(TransferDirection.received,  TransferDirection (core: BRCryptoTransferDirection (rawValue: 1)))
-        XCTAssertEqual(TransferDirection.recovered, TransferDirection (core: BRCryptoTransferDirection (rawValue: 2)))
+        XCTAssertEqual(TransferDirection.sent,      TransferDirection (core: TransferDirection.sent.core))
+        XCTAssertEqual(TransferDirection.received,  TransferDirection (core: TransferDirection.received.core))
+        XCTAssertEqual(TransferDirection.recovered, TransferDirection (core: TransferDirection.recovered.core))
     }
 
     func testTransferHash () {

--- a/Swift/BRCryptoTests/BRCryptoWalletManagerTests.swift
+++ b/Swift/BRCryptoTests/BRCryptoWalletManagerTests.swift
@@ -278,7 +278,7 @@ class BRCryptoWalletManagerTests: BRCryptoSystemBaseTests {
         //
         // Produce an invalid transferBlobs and  check for a failure
         //
-        let muckedTransferBlobs = [(bytes: [UInt8](arrayLiteral: 0, 1, 2), blockHeight: UInt32(0), timestamp: UInt32(0))]
+        let muckedTransferBlobs = [System.TransactionBlob.btc (bytes: [UInt8](arrayLiteral: 0, 1, 2), blockHeight: UInt32(0), timestamp: UInt32(0))]
         let muckedListener = MigrateSystemListener (transactionBlobs: muckedTransferBlobs)
         let muckedQuery    = system.query
         let muckedPath     = system.path + "mucked"

--- a/Swift/BRCryptoTests/BRCryptoWalletManagerTests.swift
+++ b/Swift/BRCryptoTests/BRCryptoWalletManagerTests.swift
@@ -203,4 +203,146 @@ class BRCryptoWalletManagerTests: BRCryptoSystemBaseTests {
              EventMatcher (event: WalletManagerEvent.changed(oldState: WalletManagerState.connected, newState: WalletManagerState.disconnected)),
             ]))
     }
+
+    func testWalletManagerMigrateBTC () {
+        isMainnet = false
+        currencyCodesNeeded = ["btc"]
+        modeMap = ["btc":WalletManagerMode.api_only]
+        prepareAccount (AccountSpecification (dict: [
+            "identifier": "ginger",
+            "paperKey":   "ginger settle marine tissue robot crane night number ramp coast roast critic",
+            "timestamp":  "2018-01-01",
+            "network":    (isMainnet ? "mainnet" : "testnet")
+            ]))
+        prepareSystem ()
+
+        let walletManagerDisconnectExpectation = XCTestExpectation (description: "Wallet Manager Disconnect")
+        listener.managerHandlers += [
+            { (system: System, manager:WalletManager, event: WalletManagerEvent) in
+                if case let .changed(_, newState) = event, case .disconnected = newState {
+                    walletManagerDisconnectExpectation.fulfill()
+                }
+            }]
+
+        let network: Network! = system.networks.first { "btc" == $0.currency.code && isMainnet == $0.isMainnet }
+        XCTAssertNotNil (network)
+
+        let manager: WalletManager! = system.managers.first { $0.network == network }
+        XCTAssertNotNil (manager)
+
+        let wallet = manager.primaryWallet
+        XCTAssertNotNil(wallet)
+
+        // Connect
+        listener.transferCount = 25
+        manager.connect()
+        wait (for: [self.listener.transferExpectation], timeout: 120)
+
+        sleep (10) // allow some 'ongoing' syncs to occur; don't want to see events for these.
+        manager.disconnect()
+        wait (for: [walletManagerDisconnectExpectation], timeout: 5)
+
+        let transfers = wallet.transfers
+        XCTAssertTrue (transfers.count >= 25)
+        XCTAssertTrue (transfers.allSatisfy { nil != $0.hash })
+
+        // Get the blobs (for testing)
+        let transferBlobs = transfers.map { system.asBlob(transfer: $0)! }
+
+        // Create a new system with MigrateSystemListener (see below).  This listener will
+        // create a BTC wallet manager with transfers migrated from `TransferBlobs`
+        let migrateListener = MigrateSystemListener (transactionBlobs: transferBlobs)
+        let migrateQuery    = system.query
+        let migratePath     = system.path + "Migrate"
+
+        let migrateSystem = System (listener: migrateListener,
+                                    account: system.account,
+                                    onMainnet: system.onMainnet,
+                                    path: migratePath,
+                                    query: migrateQuery)
+
+        // transfers annonced on `configure`
+        migrateListener.transferCount = transfers.count
+        migrateSystem.configure()
+        wait (for: [migrateListener.migratedManagerExpectation], timeout: 30)
+        wait (for: [migrateListener.transferExpectation], timeout: 30)
+
+        // Get the transfers from the migratedManager's primary wallet.
+        let migratedTransfers = migrateListener.migratedManager.primaryWallet.transfers
+
+        // Compare the count; then compare the hash sets as equal.
+        XCTAssertEqual (transfers.count, migratedTransfers.count)
+        XCTAssertEqual (Set (transfers.map { $0.hash! }), Set (migratedTransfers.map { $0.hash! }))
+    }
+}
+
+class MigrateSystemListener: SystemListener {
+    let transactionBlobs: [System.TransactionBlob]
+
+    var migratedNetwork: Network! = nil
+    var migratedManager: WalletManager! = nil
+
+    var migratedManagerExpectation = XCTestExpectation (description: "Migrated Manager")
+    init (transactionBlobs: [System.TransactionBlob]) {
+        self.transactionBlobs = transactionBlobs
+    }
+
+    func handleSystemEvent(system: System, event: SystemEvent) {
+        switch event {
+        case .created: break
+        case .networkAdded(let network):
+            // Network of interest
+            if system.onMainnet == network.isMainnet
+                && network.currency.code == Currency.codeAsBTC
+                && nil == migratedNetwork {
+
+                migratedNetwork = network
+
+                // Migrate
+                if (system.migrateRequired(network: network)) {
+                    try! system.migrateStorage (network: network,
+                                                transactionBlobs: transactionBlobs,
+                                                blockBlobs: [],
+                                                peerBlobs: [])
+                }
+
+                // Wallet Manager
+                let _ = system.createWalletManager (network: network,
+                                                    mode: system.defaultMode(network: network),
+                                                    addressScheme: system.defaultAddressScheme(network: network))
+            }
+
+        case .managerAdded(let manager):
+            if nil == migratedManager && manager.network == migratedNetwork {
+                migratedManager = manager
+                migratedManagerExpectation.fulfill()
+            }
+        }
+    }
+
+    func handleManagerEvent(system: System, manager: WalletManager, event: WalletManagerEvent) {
+    }
+
+    func handleWalletEvent(system: System, manager: WalletManager, wallet: Wallet, event: WalletEvent) {
+    }
+
+    var transferIncluded: Bool = false
+    var transferCount: Int = 0;
+//    var transferHandlers: [TransferEventHandler] = []
+//    var transferEvents: [TransferEvent] = []
+    var transferExpectation = XCTestExpectation (description: "TransferExpectation")
+
+    func handleTransferEvent(system: System, manager: WalletManager, wallet: Wallet, transfer: Transfer, event: TransferEvent) {
+        if transferIncluded, case .included = transfer.state {
+            if 1 == transferCount { transferExpectation.fulfill()}
+            if 1 <= transferCount { transferCount -= 1 }
+        }
+        else if case .created = transfer.state {
+            if 1 == transferCount { transferExpectation.fulfill()}
+            if 1 <= transferCount { transferCount -= 1 }
+        }
+    }
+
+    func handleNetworkEvent(system: System, network: Network, event: NetworkEvent) {
+    }
 }

--- a/bitcoin/BRWalletManager.c
+++ b/bitcoin/BRWalletManager.c
@@ -563,42 +563,7 @@ BRWalletManagerNew (BRWalletManagerClient client,
                                                                fileServiceSpecificationsCount,
                                                                fileServiceSpecifications);
     if (NULL == bwm->fileService) return bwmCreateErrorHandler (bwm, 1, "create");
-#if 0
-    bwm->fileService = fileServiceCreate (baseStoragePath, currencyName, networkName,
-                                          bwm,
-                                          bwmFileServiceErrorHandler);
-    if (NULL == bwm->fileService) return bwmCreateErrorHandler (bwm, 1, "create");
 
-    /// Transaction
-    if (1 != fileServiceDefineType (bwm->fileService, fileServiceTypeTransactions, WALLET_MANAGER_TRANSACTION_VERSION_1,
-                                    (BRFileServiceContext) bwm,
-                                    fileServiceTypeTransactionV1Identifier,
-                                    fileServiceTypeTransactionV1Reader,
-                                    fileServiceTypeTransactionV1Writer) ||
-        1 != fileServiceDefineCurrentVersion (bwm->fileService, fileServiceTypeTransactions,
-                                              WALLET_MANAGER_TRANSACTION_VERSION_1))
-        return bwmCreateErrorHandler (bwm, 1, fileServiceTypeTransactions);
-
-    /// Block
-    if (1 != fileServiceDefineType (bwm->fileService, fileServiceTypeBlocks, WALLET_MANAGER_BLOCK_VERSION_1,
-                                    (BRFileServiceContext) bwm,
-                                    fileServiceTypeBlockV1Identifier,
-                                    fileServiceTypeBlockV1Reader,
-                                    fileServiceTypeBlockV1Writer) ||
-        1 != fileServiceDefineCurrentVersion (bwm->fileService, fileServiceTypeBlocks,
-                                              WALLET_MANAGER_BLOCK_VERSION_1))
-        return bwmCreateErrorHandler (bwm, 1, fileServiceTypeBlocks);
-
-    /// Peer
-    if (1 != fileServiceDefineType (bwm->fileService, fileServiceTypePeers, WALLET_MANAGER_PEER_VERSION_1,
-                                    (BRFileServiceContext) bwm,
-                                    fileServiceTypePeerV1Identifier,
-                                    fileServiceTypePeerV1Reader,
-                                    fileServiceTypePeerV1Writer) ||
-        1 != fileServiceDefineCurrentVersion (bwm->fileService, fileServiceTypePeers,
-                                              WALLET_MANAGER_PEER_VERSION_1))
-        return bwmCreateErrorHandler (bwm, 1, fileServiceTypePeers);
-#endif
     /// Load transactions for the wallet manager.
     BRArrayOf(BRTransaction*) transactions = initialTransactionsLoad(bwm);
     /// Load blocks and peers for the peer manager.

--- a/bitcoin/BRWalletManager.h
+++ b/bitcoin/BRWalletManager.h
@@ -28,6 +28,7 @@
 
 #include <stdio.h>
 #include "BRSyncMode.h"
+#include "BRFileService.h"
 #include "BRBase.h"                 // Ownership
 #include "BRBIP32Sequence.h"        // BRMasterPubKey
 #include "BRChainParams.h"          // BRChainParams (*NOT THE STATIC DECLARATIONS*)
@@ -336,6 +337,18 @@ BRWalletManagerEstimateFeeForTransfer (BRWalletManager manager,
                                        BRCookie cookie,
                                        uint64_t transferAmount,
                                        uint64_t feePerKb);
+
+extern BRFileService
+BRWalletManagerCreateFileService (const BRChainParams *params,
+                                  const char *storagePath,
+                                  BRFileServiceContext context,
+                                  BRFileServiceErrorHandler handler);
+
+extern void
+BRWalletManagerExtractFileServiceTypes (BRFileService fileService,
+                                        const char **transactions,
+                                        const char **blocks,
+                                        const char **peers);
 
 #ifdef __cplusplus
 }

--- a/crypto/BRCryptoPrivate.h
+++ b/crypto/BRCryptoPrivate.h
@@ -233,6 +233,13 @@ extern "C" {
     cryptoTransferHasGEN (BRCryptoTransfer transfer,
                           BRGenericTransfer gen);
 
+    private_extern void
+    cryptoTransferExtractBlobAsBTC (BRCryptoTransfer transfer,
+                                    uint8_t **bytes,
+                                    size_t   *bytesCount,
+                                    uint32_t *blockHeight,
+                                    uint32_t *timestamp);
+
     /// MARK: - Network Fee
     private_extern BRCryptoNetworkFee
     cryptoNetworkFeeCreate (uint64_t confirmationTimeInMilliseconds,

--- a/crypto/BRCryptoTransfer.c
+++ b/crypto/BRCryptoTransfer.c
@@ -663,3 +663,20 @@ cryptoTransferEqual (BRCryptoTransfer t1, BRCryptoTransfer t2) {
                                             (BLOCK_CHAIN_TYPE_GEN == t1->type && cryptoTransferEqualAsGEN (t1, t2)))));
 }
 
+private_extern void
+cryptoTransferExtractBlobAsBTC (BRCryptoTransfer transfer,
+                                uint8_t **bytes,
+                                size_t   *bytesCount,
+                                uint32_t *blockHeight,
+                                uint32_t *timestamp) {
+    assert (NULL != bytes && NULL != bytesCount);
+
+    BRTransaction *tx = cryptoTransferAsBTC (transfer);
+
+    *bytesCount = BRTransactionSerialize (tx, NULL, 0);
+    *bytes = malloc (*bytesCount);
+    BRTransactionSerialize (tx, *bytes, *bytesCount);
+
+    if (NULL != blockHeight) *blockHeight = tx->blockHeight;
+    if (NULL != timestamp)   *timestamp   = tx->timestamp;
+}

--- a/crypto/BRCryptoWalletManager.c
+++ b/crypto/BRCryptoWalletManager.c
@@ -706,7 +706,7 @@ cryptoWalletMigratorHandleTransactionAsBTC (BRCryptoWalletMigrator migrator,
     BRTransaction *tx = BRTransactionParse(bytes, bytesCount);
     if (NULL == tx)
         return (BRCryptoWalletMigratorStatus) {
-            CRYPTO_WALLET_MIGRATOR_ERROR_1
+            CRYPTO_WALLET_MIGRATOR_ERROR_TRANSACTION
         };
 
     tx->blockHeight = blockHeight;
@@ -719,7 +719,7 @@ cryptoWalletMigratorHandleTransactionAsBTC (BRCryptoWalletMigrator migrator,
 
     if (migrator->theErrorHackHappened)
         return (BRCryptoWalletMigratorStatus) {
-            CRYPTO_WALLET_MIGRATOR_ERROR_2
+            CRYPTO_WALLET_MIGRATOR_ERROR_TRANSACTION
         };
     else
         return (BRCryptoWalletMigratorStatus) {
@@ -757,7 +757,7 @@ cryptoWalletMigratorHandleBlockAsBTC (BRCryptoWalletMigrator migrator,
     fileServiceSave (migrator->fileService, migrator->fileServiceBlockType, block);
     if (migrator->theErrorHackHappened)
         return (BRCryptoWalletMigratorStatus) {
-            CRYPTO_WALLET_MIGRATOR_ERROR_2
+            CRYPTO_WALLET_MIGRATOR_ERROR_BLOCK
         };
     else
         return (BRCryptoWalletMigratorStatus) {
@@ -766,11 +766,27 @@ cryptoWalletMigratorHandleBlockAsBTC (BRCryptoWalletMigrator migrator,
 }
 
 extern BRCryptoWalletMigratorStatus
-cryptoWalletMigratorHandlePeerAsBTC (BRCryptoWalletMigrator migrator /* ... */) {
-//    BRPeer peer;
-//    memset (&peer, 0, sizeof (BRPeer));
-//    fileServiceSave (migrator->fileService, migrator->fileServicePeerType, &peer);
-    return (BRCryptoWalletMigratorStatus) {
-        CRYPTO_WALLET_MIGRATOR_SUCCESS
-    };
+cryptoWalletMigratorHandlePeerAsBTC (BRCryptoWalletMigrator migrator,
+                                     uint32_t address,
+                                     uint16_t port,
+                                     uint64_t services,
+                                     uint32_t timestamp) {
+    BRPeer peer;
+
+    peer.address = (UInt128) { .u32 = { 0, 0, 0xffff, address }};
+    peer.port = port;
+    peer.services = services;
+    peer.timestamp = timestamp;
+    peer.flags = 0;
+
+    theErrorHackReset(migrator);
+    fileServiceSave (migrator->fileService, migrator->fileServicePeerType, &peer);
+    if (migrator->theErrorHackHappened)
+        return (BRCryptoWalletMigratorStatus) {
+            CRYPTO_WALLET_MIGRATOR_ERROR_PEER
+        };
+    else
+        return (BRCryptoWalletMigratorStatus) {
+            CRYPTO_WALLET_MIGRATOR_SUCCESS
+        };
 }

--- a/crypto/BRCryptoWalletManager.c
+++ b/crypto/BRCryptoWalletManager.c
@@ -698,11 +698,11 @@ cryptoWalletMigratorRelease (BRCryptoWalletMigrator migrator) {
 }
 
 extern BRCryptoWalletMigratorStatus
-cryptoWalletMigratorHandleTransaction (BRCryptoWalletMigrator migrator,
-                                       const uint8_t *bytes,
-                                       size_t bytesCount,
-                                       uint32_t blockHeight,
-                                       uint32_t timestamp) {
+cryptoWalletMigratorHandleTransactionAsBTC (BRCryptoWalletMigrator migrator,
+                                            const uint8_t *bytes,
+                                            size_t bytesCount,
+                                            uint32_t blockHeight,
+                                            uint32_t timestamp) {
     BRTransaction *tx = BRTransactionParse(bytes, bytesCount);
     if (NULL == tx)
         return (BRCryptoWalletMigratorStatus) {
@@ -728,17 +728,17 @@ cryptoWalletMigratorHandleTransaction (BRCryptoWalletMigrator migrator,
 }
 
 extern BRCryptoWalletMigratorStatus
-cryptoWalletMigratorHandleBlock (BRCryptoWalletMigrator migrator,
-                                 uint32_t height,
-                                 uint32_t nonce,
-                                 uint32_t target,
-                                 uint32_t txCount,
-                                 uint32_t version,
-                                 uint32_t timestamp,
-                                 uint8_t *flags,  size_t flagsLen,
-                                 UInt256 *hashes, size_t hashesCount,
-                                 UInt256 merkleRoot,
-                                 UInt256 prevBlock) {
+cryptoWalletMigratorHandleBlockAsBTC (BRCryptoWalletMigrator migrator,
+                                      uint32_t height,
+                                      uint32_t nonce,
+                                      uint32_t target,
+                                      uint32_t txCount,
+                                      uint32_t version,
+                                      uint32_t timestamp,
+                                      uint8_t *flags,  size_t flagsLen,
+                                      UInt256 *hashes, size_t hashesCount,
+                                      UInt256 merkleRoot,
+                                      UInt256 prevBlock) {
     BRMerkleBlock *block = BRMerkleBlockNew();
     block->height = height;
     block->nonce  = nonce;
@@ -766,7 +766,7 @@ cryptoWalletMigratorHandleBlock (BRCryptoWalletMigrator migrator,
 }
 
 extern BRCryptoWalletMigratorStatus
-cryptoWalletMigratorHandlePeer (BRCryptoWalletMigrator migrator /* ... */) {
+cryptoWalletMigratorHandlePeerAsBTC (BRCryptoWalletMigrator migrator /* ... */) {
 //    BRPeer peer;
 //    memset (&peer, 0, sizeof (BRPeer));
 //    fileServiceSave (migrator->fileService, migrator->fileServicePeerType, &peer);

--- a/crypto/BRCryptoWalletManager.h
+++ b/crypto/BRCryptoWalletManager.h
@@ -198,8 +198,9 @@ extern "C" {
 
     typedef enum {
         CRYPTO_WALLET_MIGRATOR_SUCCESS,
-        CRYPTO_WALLET_MIGRATOR_ERROR_1,
-        CRYPTO_WALLET_MIGRATOR_ERROR_2,
+        CRYPTO_WALLET_MIGRATOR_ERROR_TRANSACTION,
+        CRYPTO_WALLET_MIGRATOR_ERROR_BLOCK,
+        CRYPTO_WALLET_MIGRATOR_ERROR_PEER
     } BRCryptoWalletMigratorStatusType;
 
     typedef struct {
@@ -235,7 +236,11 @@ extern "C" {
                                           UInt256 prevBlock);
 
     extern BRCryptoWalletMigratorStatus
-    cryptoWalletMigratorHandlePeerAsBTC (BRCryptoWalletMigrator migrator /* ... */);
+    cryptoWalletMigratorHandlePeerAsBTC (BRCryptoWalletMigrator migrator,
+                                         uint32_t address,
+                                         uint16_t port,
+                                         uint64_t services,
+                                         uint32_t timestamp);
 
 #ifdef __cplusplus
 }

--- a/crypto/BRCryptoWalletManager.h
+++ b/crypto/BRCryptoWalletManager.h
@@ -196,29 +196,45 @@ extern "C" {
     
     typedef struct BRCryptoWalletMigratorRecord *BRCryptoWalletMigrator;
 
-    extern BRCryptoWalletMigrator
+    typedef enum {
+        CRYPTO_WALLET_MIGRATOR_SUCCESS,
+        CRYPTO_WALLET_MIGRATOR_ERROR_1,
+        CRYPTO_WALLET_MIGRATOR_ERROR_2,
+    } BRCryptoWalletMigratorStatusType;
+
+    typedef struct {
+        BRCryptoWalletMigratorStatusType type;
+        // union {} u;
+    } BRCryptoWalletMigratorStatus;
+
+    extern BRCryptoWalletMigrator // NULL on error
     cryptoWalletMigratorCreate (BRCryptoNetwork network,
                                 const char *storagePath);
 
     extern void
     cryptoWalletMigratorRelease (BRCryptoWalletMigrator migrator);
 
-    extern void
+    extern BRCryptoWalletMigratorStatus
     cryptoWalletMigratorHandleTransaction (BRCryptoWalletMigrator migrator,
                                            const uint8_t *bytes,
                                            size_t bytesCount,
                                            uint32_t blockHeight,
                                            uint32_t timestamp);
 
-    extern void
+    extern BRCryptoWalletMigratorStatus
     cryptoWalletMigratorHandleBlock (BRCryptoWalletMigrator migrator,
                                      uint32_t height,
                                      uint32_t nonce,
-                                     uint32_t target
-                                     // ...
-    );
+                                     uint32_t target,
+                                     uint32_t txCount,
+                                     uint32_t version,
+                                     uint32_t timestamp,
+                                     uint8_t *flags,  size_t flagsLen,
+                                     UInt256 *hashes, size_t hashesCount,
+                                     UInt256 merkleRoot,
+                                     UInt256 prevBlock);
 
-    extern void
+    extern BRCryptoWalletMigratorStatus
     cryptoWalletMigratorHandlePeer (BRCryptoWalletMigrator migrator /* ... */);
 
 #ifdef __cplusplus

--- a/crypto/BRCryptoWalletManager.h
+++ b/crypto/BRCryptoWalletManager.h
@@ -192,6 +192,35 @@ extern "C" {
 
     DECLARE_CRYPTO_GIVE_TAKE (BRCryptoWalletManager, cryptoWalletManager);
 
+    /// MARK: Wallet Migrator
+    
+    typedef struct BRCryptoWalletMigratorRecord *BRCryptoWalletMigrator;
+
+    extern BRCryptoWalletMigrator
+    cryptoWalletMigratorCreate (BRCryptoNetwork network,
+                                const char *storagePath);
+
+    extern void
+    cryptoWalletMigratorRelease (BRCryptoWalletMigrator migrator);
+
+    extern void
+    cryptoWalletMigratorHandleTransaction (BRCryptoWalletMigrator migrator,
+                                           const uint8_t *bytes,
+                                           size_t bytesCount,
+                                           uint32_t blockHeight,
+                                           uint32_t timestamp);
+
+    extern void
+    cryptoWalletMigratorHandleBlock (BRCryptoWalletMigrator migrator,
+                                     uint32_t height,
+                                     uint32_t nonce,
+                                     uint32_t target
+                                     // ...
+    );
+
+    extern void
+    cryptoWalletMigratorHandlePeer (BRCryptoWalletMigrator migrator /* ... */);
+
 #ifdef __cplusplus
 }
 #endif

--- a/crypto/BRCryptoWalletManager.h
+++ b/crypto/BRCryptoWalletManager.h
@@ -215,27 +215,27 @@ extern "C" {
     cryptoWalletMigratorRelease (BRCryptoWalletMigrator migrator);
 
     extern BRCryptoWalletMigratorStatus
-    cryptoWalletMigratorHandleTransaction (BRCryptoWalletMigrator migrator,
-                                           const uint8_t *bytes,
-                                           size_t bytesCount,
-                                           uint32_t blockHeight,
-                                           uint32_t timestamp);
+    cryptoWalletMigratorHandleTransactionAsBTC (BRCryptoWalletMigrator migrator,
+                                                const uint8_t *bytes,
+                                                size_t bytesCount,
+                                                uint32_t blockHeight,
+                                                uint32_t timestamp);
 
     extern BRCryptoWalletMigratorStatus
-    cryptoWalletMigratorHandleBlock (BRCryptoWalletMigrator migrator,
-                                     uint32_t height,
-                                     uint32_t nonce,
-                                     uint32_t target,
-                                     uint32_t txCount,
-                                     uint32_t version,
-                                     uint32_t timestamp,
-                                     uint8_t *flags,  size_t flagsLen,
-                                     UInt256 *hashes, size_t hashesCount,
-                                     UInt256 merkleRoot,
-                                     UInt256 prevBlock);
+    cryptoWalletMigratorHandleBlockAsBTC (BRCryptoWalletMigrator migrator,
+                                          uint32_t height,
+                                          uint32_t nonce,
+                                          uint32_t target,
+                                          uint32_t txCount,
+                                          uint32_t version,
+                                          uint32_t timestamp,
+                                          uint8_t *flags,  size_t flagsLen,
+                                          UInt256 *hashes, size_t hashesCount,
+                                          UInt256 merkleRoot,
+                                          UInt256 prevBlock);
 
     extern BRCryptoWalletMigratorStatus
-    cryptoWalletMigratorHandlePeer (BRCryptoWalletMigrator migrator /* ... */);
+    cryptoWalletMigratorHandlePeerAsBTC (BRCryptoWalletMigrator migrator /* ... */);
 
 #ifdef __cplusplus
 }

--- a/support/BRFileService.h
+++ b/support/BRFileService.h
@@ -184,4 +184,28 @@ fileServiceDefineCurrentVersion (BRFileService fs,
                                  const char *type,
                                  BRFileServiceVersion version);
 
+// Version limit can increase with maximum number of version, historically.
+#define FILE_SERVICE_TYPE_SPECIFICATION_NUMBER_OF_VERSION_LIMIT   (5)
+
+typedef struct {
+    const char *type;
+    BRFileServiceVersion defaultVersion;
+    size_t versionsCount;
+    struct {
+        BRFileServiceVersion version;
+        BRFileServiceIdentifier identifier;
+        BRFileServiceReader reader;
+        BRFileServiceWriter writer;
+    } versions [FILE_SERVICE_TYPE_SPECIFICATION_NUMBER_OF_VERSION_LIMIT];
+} BRFileServiceTypeSpecification;
+
+extern BRFileService
+fileServiceCreateFromTypeSpecfications (const char *basePath,
+                                        const char *currency,
+                                        const char *network,
+                                        BRFileServiceContext context,
+                                        BRFileServiceErrorHandler handler,
+                                        size_t specificationsCount,
+                                        BRFileServiceTypeSpecification *specfications);
+
 #endif /* BRFileService_h */


### PR DESCRIPTION
Note that the 'Random Cleanup' has unrelated changes (in BRCryptoAmount.swfit, BRCryptoTransfer.swift, BRCryptoCommonTests.swift, and BRCryptoTransferTests.swift)

Includes changes to BRFileService to add a fileServiceCreateFromTypeSpecfications() - so that BRWalletManagerNew() and BRWalletManagerCreateFileService() can produce the same BRFileService for BTC.