### PR TITLE
CORE-437: In BRCryptoAddress, handle bitcoin cash addresses

### DIFF
--- a/Java/CoreCrypto/src/androidTest/java/com/breadwallet/corecrypto/AddressAIT.java
+++ b/Java/CoreCrypto/src/androidTest/java/com/breadwallet/corecrypto/AddressAIT.java
@@ -81,7 +81,39 @@ public class AddressAIT {
         Address b1 = ob1.get();
         assertEquals("1CC3X2gu58d6wXUWMffpuzN9JAfTUWu4Kj", b1.toString());
 
-        // TODO: Expand coverage
+        assertFalse(network.addressFor("qp0k6fs6q2hzmpyps3vtwmpx80j9w0r0acmp8l6e9v").isPresent());
+        assertFalse(network.addressFor("bitcoincash:qp0k6fs6q2hzmpyps3vtwmpx80j9w0r0acmp8l6e9v").isPresent());
+    }
+
+    @Test
+    public void testAddressCreateAsBchOnMainnet() {
+        Currency bch = Currency.create("Bitcoin-Cash", "Bitcoin Cash", "bch", "native", null);
+
+        Unit satoshi_bch = Unit.create(bch, "BCH-SAT", "Satoshi", "SAT");
+        Unit btc_bch = Unit.create(bch, "BCH-BTC", "Bitcoin", "B", satoshi_bch, UnsignedInteger.valueOf(8));
+
+        NetworkAssociation association = new NetworkAssociation(satoshi_bch, btc_bch, new HashSet<>(Arrays.asList(satoshi_bch, btc_bch)));
+
+        Map<Currency, NetworkAssociation> associations = new HashMap<>();
+        associations.put(bch, association);
+
+        NetworkFee fee = NetworkFee.create(UnsignedLong.valueOf(30 * 1000), Amount.create(1000, satoshi_bch));
+        List<NetworkFee> fees = Collections.singletonList(fee);
+
+        Network network = Network.create("bitcoin-mainnet", "Bitcoin", true, bch, UnsignedLong.valueOf(100000), associations, fees);
+
+        Optional<Address> ob1 = network.addressFor("bitcoincash:qp0k6fs6q2hzmpyps3vtwmpx80j9w0r0acmp8l6e9v");
+        assertTrue(ob1.isPresent());
+        Address b1 = ob1.get();
+        assertEquals("bitcoincash:qp0k6fs6q2hzmpyps3vtwmpx80j9w0r0acmp8l6e9v", b1.toString());
+
+        ob1 = network.addressFor("qp0k6fs6q2hzmpyps3vtwmpx80j9w0r0acmp8l6e9v");
+        assertTrue(ob1.isPresent());
+        b1 = ob1.get();
+        assertEquals("bitcoincash:qp0k6fs6q2hzmpyps3vtwmpx80j9w0r0acmp8l6e9v", b1.toString());
+
+        assertFalse(network.addressFor("bc1qar0srrr7xfkvy5l643lydnw9re59gtzzwf5mdq").isPresent());
+        assertFalse(network.addressFor("1BvBMSEYstWetqTFn5Au4m4GFg7xJaNVN2").isPresent());
     }
 
     @Test
@@ -196,6 +228,36 @@ public class AddressAIT {
         assertEquals("mm7DDqVkFd35XcWecFipfTYM5dByBzn7nq", b1.toString());
 
         // TODO: Expand coverage
+    }
+
+    @Test
+    public void testAddressCreateAsBchOnTestnet() {
+        Currency bch = Currency.create("Bitcoin-Cash", "Bitcoin Cash", "bch", "native", null);
+
+        Unit satoshi_bch = Unit.create(bch, "BCH-SAT", "Satoshi", "SAT");
+        Unit btc_bch = Unit.create(bch, "BCH-BTC", "Bitcoin", "B", satoshi_bch, UnsignedInteger.valueOf(8));
+
+        NetworkAssociation association = new NetworkAssociation(satoshi_bch, btc_bch, new HashSet<>(Arrays.asList(satoshi_bch, btc_bch)));
+
+        Map<Currency, NetworkAssociation> associations = new HashMap<>();
+        associations.put(bch, association);
+
+        NetworkFee fee = NetworkFee.create(UnsignedLong.valueOf(30 * 1000), Amount.create(1000, satoshi_bch));
+        List<NetworkFee> fees = Collections.singletonList(fee);
+
+        Network network = Network.create("bitcoin-mainnet", "Bitcoin", false, bch, UnsignedLong.valueOf(100000), associations, fees);
+
+        Optional<Address> ob1 = network.addressFor("bchtest:pr6m7j9njldwwzlg9v7v53unlr4jkmx6eyvwc0uz5t");
+        assertTrue(ob1.isPresent());
+        Address b1 = ob1.get();
+        assertEquals("bchtest:pr6m7j9njldwwzlg9v7v53unlr4jkmx6eyvwc0uz5t", b1.toString());
+
+        ob1 = network.addressFor("pr6m7j9njldwwzlg9v7v53unlr4jkmx6eyvwc0uz5t");
+        assertTrue(ob1.isPresent());
+        b1 = ob1.get();
+        assertEquals("bchtest:pr6m7j9njldwwzlg9v7v53unlr4jkmx6eyvwc0uz5t", b1.toString());
+
+        assertFalse(network.addressFor("bc1qar0srrr7xfkvy5l643lydnw9re59gtzzwf5mdq").isPresent());
     }
 
     @Test

--- a/Swift/BRCryptoTests/BRCryptoAccountTests.swift
+++ b/Swift/BRCryptoTests/BRCryptoAccountTests.swift
@@ -113,12 +113,45 @@ class BRCryptoAccountTests: XCTestCase {
                                associations: [:],
                                fees: [fee])
 
-        let b1 = Address.create (string: "1CC3X2gu58d6wXUWMffpuzN9JAfTUWu4Kj", network: network)
+        XCTAssertEqual(network.addressFor("1CC3X2gu58d6wXUWMffpuzN9JAfTUWu4Kj")?.description,
+                       "1CC3X2gu58d6wXUWMffpuzN9JAfTUWu4Kj")
 
-        XCTAssertNotNil (b1)
-        XCTAssertEqual("1CC3X2gu58d6wXUWMffpuzN9JAfTUWu4Kj",  b1?.description)
-
+        XCTAssertNil (network.addressFor("qp0k6fs6q2hzmpyps3vtwmpx80j9w0r0acmp8l6e9v"))
+        XCTAssertNil (network.addressFor("bitcoincash:qp0k6fs6q2hzmpyps3vtwmpx80j9w0r0acmp8l6e9v"))
     }
+
+    func testAddressBCH () {
+        let bch = Currency (uids: "Bitcoin-Cash",  name: "Bitcoin Cash",  code: "BCH", type: "native", issuer: nil)
+        let BCH_SATOSHI = BRCrypto.Unit (currency: bch, uids: "BCH-SAT",  name: "BCHSatoshi", symbol: "BCHSAT")
+
+        let fee = NetworkFee (timeInternalInMilliseconds: 1000,
+                              pricePerCostFactor: Amount.create(double: 25, unit: BCH_SATOSHI))
+        let network = Network (uids: "bitcoin-cash-mainnet",
+                               name: "bitcoin-cash-name",
+                               isMainnet: true,
+                               currency: bch,
+                               height: 100000,
+                               associations: [:],
+                               fees: [fee])
+
+        XCTAssertEqual (network.addressFor("bitcoincash:qp0k6fs6q2hzmpyps3vtwmpx80j9w0r0acmp8l6e9v")?.description,
+                        "bitcoincash:qp0k6fs6q2hzmpyps3vtwmpx80j9w0r0acmp8l6e9v")
+
+        XCTAssertEqual (network.addressFor("qp0k6fs6q2hzmpyps3vtwmpx80j9w0r0acmp8l6e9v")?.description,
+                        "bitcoincash:qp0k6fs6q2hzmpyps3vtwmpx80j9w0r0acmp8l6e9v")
+
+        XCTAssertNil (network.addressFor("bc1qar0srrr7xfkvy5l643lydnw9re59gtzzwf5mdq"))
+        XCTAssertNil (network.addressFor("1BvBMSEYstWetqTFn5Au4m4GFg7xJaNVN2"))
+    }
+/*
+        let addr1 = bch.addressFor("bitcoincash:qp0k6fs6q2hzmpyps3vtwmpx80j9w0r0acmp8l6e9v") // cashaddr with prefix is valid
+        let addr2 = bch.addressFor("qp0k6fs6q2hzmpyps3vtwmpx80j9w0r0acmp8l6e9v") // cashaddr without prefix is valid
+        addr1.description == "qp0k6fs6q2hzmpyps3vtwmpx80j9w0r0acmp8l6e9v” // prefix is not included
+        addr2.description == "qp0k6fs6q2hzmpyps3vtwmpx80j9w0r0acmp8l6e9v”
+        bch.addressFor("bc1qar0srrr7xfkvy5l643lydnw9re59gtzzwf5mdq") == nil  // bech32 not valid for bch
+        bch.addressFor("1BvBMSEYstWetqTFn5Au4m4GFg7xJaNVN2") == nil  // p2pkh not valid for bch
+        btc.addressFor(“qp0k6fs6q2hzmpyps3vtwmpx80j9w0r0acmp8l6e9v”) == nil // cashaddr not valid for btc
+*/
 
     func testAddressScheme () {
         XCTAssertEqual (AddressScheme.btcLegacy,  AddressScheme(core: AddressScheme.btcLegacy.core))

--- a/Swift/BRCryptoTests/BRCryptoAccountTests.swift
+++ b/Swift/BRCryptoTests/BRCryptoAccountTests.swift
@@ -142,7 +142,40 @@ class BRCryptoAccountTests: XCTestCase {
 
         XCTAssertNil (network.addressFor("bc1qar0srrr7xfkvy5l643lydnw9re59gtzzwf5mdq"))
         XCTAssertNil (network.addressFor("1BvBMSEYstWetqTFn5Au4m4GFg7xJaNVN2"))
+
+        // TODO: Testnet BCH Addresses work as Mainnet BCH Addresses
+        //        XCTAssertNil (network.addressFor("bchtest:pr6m7j9njldwwzlg9v7v53unlr4jkmx6eyvwc0uz5t"))
+        //        XCTAssertNil (network.addressFor("pr6m7j9njldwwzlg9v7v53unlr4jkmx6eyvwc0uz5t"))
     }
+
+    func testAddressBCHTestnet () {
+        let bch = Currency (uids: "Bitcoin-Cash",  name: "Bitcoin Cash",  code: "BCH", type: "native", issuer: nil)
+        let BCH_SATOSHI = BRCrypto.Unit (currency: bch, uids: "BCH-SAT",  name: "BCHSatoshi", symbol: "BCHSAT")
+
+        let fee = NetworkFee (timeInternalInMilliseconds: 1000,
+                              pricePerCostFactor: Amount.create(double: 25, unit: BCH_SATOSHI))
+        let network = Network (uids: "bitcoin-cash-mainnet",
+                               name: "bitcoin-cash-name",
+                               isMainnet: false,
+                               currency: bch,
+                               height: 100000,
+                               associations: [:],
+                               fees: [fee])
+
+        XCTAssertEqual (network.addressFor("bchtest:pr6m7j9njldwwzlg9v7v53unlr4jkmx6eyvwc0uz5t")?.description,
+                        "bchtest:pr6m7j9njldwwzlg9v7v53unlr4jkmx6eyvwc0uz5t")
+
+        XCTAssertEqual (network.addressFor("pr6m7j9njldwwzlg9v7v53unlr4jkmx6eyvwc0uz5t")?.description,
+                        "bchtest:pr6m7j9njldwwzlg9v7v53unlr4jkmx6eyvwc0uz5t")
+
+        XCTAssertNil (network.addressFor("bc1qar0srrr7xfkvy5l643lydnw9re59gtzzwf5mdq"))
+
+        // TODO: Testnet BCH Addresses work as Mainnet BCH Addresses
+        //        XCTAssertNil (network.addressFor("1BvBMSEYstWetqTFn5Au4m4GFg7xJaNVN2"))
+        //        XCTAssertNil (network.addressFor("qp0k6fs6q2hzmpyps3vtwmpx80j9w0r0acmp8l6e9v"))
+        //        XCTAssertNil (network.addressFor("bitcoincash:qp0k6fs6q2hzmpyps3vtwmpx80j9w0r0acmp8l6e9v"))
+    }
+
 /*
         let addr1 = bch.addressFor("bitcoincash:qp0k6fs6q2hzmpyps3vtwmpx80j9w0r0acmp8l6e9v") // cashaddr with prefix is valid
         let addr2 = bch.addressFor("qp0k6fs6q2hzmpyps3vtwmpx80j9w0r0acmp8l6e9v") // cashaddr without prefix is valid

--- a/Swift/BRCryptoTests/BRCryptoBaseTests.swift
+++ b/Swift/BRCryptoTests/BRCryptoBaseTests.swift
@@ -51,7 +51,7 @@ class BRCryptoBaseTests: XCTestCase {
 
     var account: Account!
 
-    func prepareAccount (_ spec: AccountSpecification? = nil) {
+    func prepareAccount (_ spec: AccountSpecification? = nil, identifier: String? = nil) {
         let defaultSpecification = AccountSpecification (dict: [
             "identifier": "ginger",
             "paperKey":   "ginger settle marine tissue robot crane night number ramp coast roast critic",
@@ -64,6 +64,10 @@ class BRCryptoBaseTests: XCTestCase {
             : AccountSpecification.loadFrom(configPath: configPath, defaultSpecification: defaultSpecification))
             .filter { $0.network == (isMainnet ? "mainnet" : "testnet") }
 
+        // If there is an identifier, filter
+        if let id = identifier {
+            self.accountSpecifications.removeAll { $0.identifier != id }
+        }
         let specifiction = accountSpecification!
 
         /// Create the account

--- a/Swift/BRCryptoTests/BRCryptoWalletTests.swift
+++ b/Swift/BRCryptoTests/BRCryptoWalletTests.swift
@@ -167,6 +167,40 @@ class BRCryptoWalletTests: BRCryptoSystemBaseTests {
             ]))
     }
 
+    func testWalletBCH() {
+        isMainnet = false
+        currencyCodesNeeded = ["bch"]
+        modeMap = ["bch":WalletManagerMode.p2p_only]
+        prepareAccount (AccountSpecification (dict: [
+            "identifier": "ginger",
+            "paperKey":   "ginger settle marine tissue robot crane night number ramp coast roast critic",
+            "timestamp":  "2018-01-01",
+            "network":    (isMainnet ? "mainnet" : "testnet")
+            ]))
+        prepareSystem ()
+
+        let walletManagerDisconnectExpectation = XCTestExpectation (description: "Wallet Manager Disconnect")
+        listener.managerHandlers += [
+            { (system: System, manager:WalletManager, event: WalletManagerEvent) in
+                if case let .changed(_, newState) = event, case .disconnected = newState {
+                    walletManagerDisconnectExpectation.fulfill()
+                }
+            }]
+
+        let network: Network! = system.networks.first { "bch" == $0.currency.code && isMainnet == $0.isMainnet }
+        XCTAssertNotNil (network)
+
+        let manager: WalletManager! = system.managers.first { $0.network == network }
+        XCTAssertNotNil (manager)
+
+        let wallet = manager.primaryWallet
+        XCTAssertNotNil(wallet)
+
+        // Checking the wallet address as BCHH
+        let walletAddress = wallet.source
+        XCTAssertTrue (walletAddress.description.starts (with: (isMainnet ? "bitcoincash" : "bchtest")))
+    }
+
     func testWalletETH() {
         isMainnet = false
         currencyCodesNeeded = ["eth"]

--- a/bitcoin/BRWalletManager.c
+++ b/bitcoin/BRWalletManager.c
@@ -714,6 +714,11 @@ BRWalletManagerGetWallet (BRWalletManager manager) {
     return manager->wallet;
 }
 
+extern int
+BRWalletManagerHandlesBTC (BRWalletManager manager) {
+    return BRChainParamsIsBitcoin (manager->chainParams);
+}
+
 extern void
 BRWalletManagerConnect (BRWalletManager manager) {
     pthread_mutex_lock (&manager->lock);

--- a/bitcoin/BRWalletManager.h
+++ b/bitcoin/BRWalletManager.h
@@ -308,6 +308,13 @@ extern BRWallet *
 BRWalletManagerGetWallet (BRWalletManager manager);
 
 /**
+ * Return `1` if `manager` handles BTC; otherwise `0` if BCH.  Note: the `BRChainParams` determine
+ * BTC vs BCH.
+ */
+extern int
+BRWalletManagerHandlesBTC (BRWalletManager manager);
+
+/**
  * Creates an unsigned transaction that sends the specified amount from the wallet to the given address.
  *
  * @returns NULL on failure, or a transaction on success; the returned transaction must be freed using BRTransactionFree()

--- a/bitcoin/test.c
+++ b/bitcoin/test.c
@@ -365,6 +365,25 @@ int BRBCashAddrTests()
     if (l != 0)
         r = 0, fprintf(stderr, "\n***FAILED*** %s: BRBCashAddrDecode() test 1", __func__);
 
+    s = "bitcoincash:qpm2qsznhks23z7629mms6s4cwef74vcwvy22gdx6a"; // "bitcoincash:qp0k6fs6q2hzmpyps3vtwmpx80j9w0r0acmp8l6e9v";
+    l = BRBCashAddrDecode(addr, s);
+    if (l == 0)
+        r = 0, fprintf(stderr, "\n***FAILED*** %s: BRBCashAddrDecode() test 2", __func__);
+
+    s = "qpm2qsznhks23z7629mms6s4cwef74vcwvy22gdx6a"; // "bitcoincash:qp0k6fs6q2hzmpyps3vtwmpx80j9w0r0acmp8l6e9v";
+    l = BRBCashAddrDecode(addr, s);
+    if (l == 0)
+        r = 0, fprintf(stderr, "\n***FAILED*** %s: BRBCashAddrDecode() test 3", __func__);
+
+    s = "qp0k6fs6q2hzmpyps3vtwmpx80j9w0r0acmp8l6e9v";
+    l = BRBCashAddrDecode(addr, s);
+    if (l == 0)
+        r = 0, fprintf(stderr, "\n***FAILED*** %s: BRBCashAddrDecode() test 4", __func__);
+
+    // Expected, not valid
+    if (0 != BRAddressIsValid (BITCOIN_ADDRESS_PARAMS, "qp0k6fs6q2hzmpyps3vtwmpx80j9w0r0acmp8l6e9v"))
+        r = 0, fprintf(stderr, "\n***FAILED*** %s: BRAddressIsValid() test 5", __func__);
+
     if (! r) fprintf(stderr, "\n                                    ");
     return r;
 }

--- a/crypto/BRCryptoAddress.h
+++ b/crypto/BRCryptoAddress.h
@@ -50,6 +50,14 @@ extern "C" {
     cryptoAddressCreateFromStringAsBTC (BRAddressParams params, const char *address);
 
     /**
+     * Create an addres from a NULL terminated BCH address string.
+     *
+     * @return An address or NULL if the address string is invalid.
+     */
+    extern BRCryptoAddress
+    cryptoAddressCreateFromStringAsBCH (BRAddressParams params, const char *bchAddress);
+
+    /**
      * Create an address from a NULL terminated ETH address string.
      *
      * An addresss string will be of the form "0x8fB4..." (with prefix)

--- a/crypto/BRCryptoNetwork.c
+++ b/crypto/BRCryptoNetwork.c
@@ -506,7 +506,9 @@ cryptoNetworkCreateAddressFromString (BRCryptoNetwork network,
     switch (network->type) {
 
         case BLOCK_CHAIN_TYPE_BTC:
-            return cryptoAddressCreateFromStringAsBTC (network->u.btc.params->addrParams, string);
+            return (BRChainParamsIsBitcoin (network->u.btc.params)
+                    ? cryptoAddressCreateFromStringAsBTC (network->u.btc.params->addrParams, string)
+                    : cryptoAddressCreateFromStringAsBCH (network->u.btc.params->addrParams, string));
 
         case BLOCK_CHAIN_TYPE_ETH:
             return cryptoAddressCreateFromStringAsETH (string);

--- a/crypto/BRCryptoPrivate.h
+++ b/crypto/BRCryptoPrivate.h
@@ -126,7 +126,8 @@ extern "C" {
     /// MARK: - Address
 
     private_extern BRCryptoAddress
-    cryptoAddressCreateAsBTC (BRAddress btc);
+    cryptoAddressCreateAsBTC (BRAddress btc,
+                              BRCryptoBoolean isBTC);  // TRUE if BTC; FALSE if BCH
 
     private_extern BRCryptoAddress
     cryptoAddressCreateAsETH (BREthereumAddress eth);
@@ -193,7 +194,8 @@ extern "C" {
     cryptoTransferCreateAsBTC (BRCryptoUnit unit,
                                BRCryptoUnit unitForFee,
                                BRWallet *wid,
-                               OwnershipKept BRTransaction *tid);
+                               OwnershipKept BRTransaction *tid,
+                               BRCryptoBoolean isBTC); // TRUE if BTC; FALSE if BCH
 
     private_extern BRCryptoTransfer
     cryptoTransferCreateAsETH (BRCryptoUnit unit,

--- a/crypto/BRCryptoTransfer.c
+++ b/crypto/BRCryptoTransfer.c
@@ -117,7 +117,8 @@ extern BRCryptoTransfer
 cryptoTransferCreateAsBTC (BRCryptoUnit unit,
                            BRCryptoUnit unitForFee,
                            BRWallet *wid,
-                           OwnershipKept BRTransaction *tid) {
+                           OwnershipKept BRTransaction *tid,
+                           BRCryptoBoolean isBTC) {
     BRAddressParams  addressParams = BRWalletGetAddressParams (wid);
     BRCryptoTransfer transfer      = cryptoTransferCreateInternal (BLOCK_CHAIN_TYPE_BTC, unit, unitForFee);
     transfer->u.btc.tid = tid;
@@ -141,7 +142,7 @@ cryptoTransferCreateAsBTC (BRCryptoUnit unit,
 
             if (inputsContain == BRWalletContainsAddress(wid, address)) {
                 assert (addressSize < sizeof (BRAddress));
-                transfer->sourceAddress = cryptoAddressCreateAsBTC (BRAddressFill (addressParams, address));
+                transfer->sourceAddress = cryptoAddressCreateAsBTC (BRAddressFill (addressParams, address), isBTC);
                 break;
             }
         }
@@ -164,7 +165,7 @@ cryptoTransferCreateAsBTC (BRCryptoUnit unit,
             // returned by `BRWalletContainsAddress()`
             if (outputsContain == BRWalletContainsAddress(wid, address)) {
                 assert (addressSize < sizeof (BRAddress));
-                transfer->targetAddress = cryptoAddressCreateAsBTC (BRAddressFill (addressParams, address));
+                transfer->targetAddress = cryptoAddressCreateAsBTC (BRAddressFill (addressParams, address), isBTC);
                 break;
             }
         }

--- a/crypto/BRCryptoWallet.c
+++ b/crypto/BRCryptoWallet.c
@@ -350,7 +350,7 @@ cryptoWalletGetAddress (BRCryptoWallet wallet,
             BRAddress btcAddress = (CRYPTO_ADDRESS_SCHEME_BTC_SEGWIT == addressScheme
                                     ? BRWalletReceiveAddress(wid)
                                     : BRWalletLegacyAddress (wid));
-            return cryptoAddressCreateAsBTC (btcAddress);
+            return cryptoAddressCreateAsBTC (btcAddress, AS_CRYPTO_BOOLEAN (BRWalletManagerHandlesBTC(wallet->u.btc.bwm)));
             }
 
         case BLOCK_CHAIN_TYPE_ETH: {
@@ -493,7 +493,8 @@ cryptoWalletCreateTransfer (BRCryptoWallet  wallet,
 
             BRTransaction *tid = BRWalletManagerCreateTransaction (bwm, wid, value, addr,
                                                                    cryptoFeeBasisAsBTC(estimatedFeeBasis));
-            transfer = NULL == tid ? NULL : cryptoTransferCreateAsBTC (unit, unitForFee, wid, tid);
+            transfer = NULL == tid ? NULL : cryptoTransferCreateAsBTC (unit, unitForFee, wid, tid,
+                                                                       AS_CRYPTO_BOOLEAN(BRWalletManagerHandlesBTC(bwm)));
             break;
         }
 

--- a/crypto/BRCryptoWalletManagerClient.c
+++ b/crypto/BRCryptoWalletManagerClient.c
@@ -512,12 +512,14 @@ cwmTransactionEventAsBTC (BRWalletManagerClientContext context,
 
             BRCryptoUnit unit         = cryptoWalletGetUnit (wallet);
             BRCryptoUnit unitForFee   = cryptoWalletGetUnitForFee(wallet);
+            BRCryptoBoolean isBTC     = AS_CRYPTO_BOOLEAN (BRWalletManagerHandlesBTC(btcManager));
 
             // The transfer finally - based on the wallet's currency (BTC)
             transfer = cryptoTransferCreateAsBTC (unit,
                                                   unitForFee,
                                                   cryptoWalletAsBTC (wallet),
-                                                  btcTransaction);
+                                                  btcTransaction,
+                                                  isBTC);
 
             // Generate a CRYPTO transfer event for CREATED'...
             cwm->listener.transferEventCallback (cwm->listener.context,
@@ -578,12 +580,14 @@ cwmTransactionEventAsBTC (BRWalletManagerClientContext context,
             if (NULL == transfer) {
                 BRCryptoUnit unit         = cryptoWalletGetUnit (wallet);
                 BRCryptoUnit unitForFee   = cryptoWalletGetUnitForFee(wallet);
+                BRCryptoBoolean isBTC     = AS_CRYPTO_BOOLEAN (BRWalletManagerHandlesBTC(btcManager));
 
                 // The transfer finally - based on the wallet's currency (BTC)
                 transfer = cryptoTransferCreateAsBTC (unit,
                                                       unitForFee,
                                                       cryptoWalletAsBTC (wallet),
-                                                      btcTransaction);
+                                                      btcTransaction,
+                                                      isBTC);
 
                 // Generate a CRYPTO transfer event for CREATED'...
                 cwm->listener.transferEventCallback (cwm->listener.context,


### PR DESCRIPTION
The behavior with testnet is pending.  (BCH testnet has unexpected behavior; a BTC testnet test case is needed).