### PR TITLE
CORE-500: For System.migrate, add `hash` to BlockBlob.

### DIFF
--- a/Swift/BRCrypto/BRCryptoSystem.swift
+++ b/Swift/BRCrypto/BRCryptoSystem.swift
@@ -1204,6 +1204,7 @@ extension System {
     ///
     public enum BlockBlob {
         case btc (
+            hash: BlockHash,
             height: UInt32,
             nonce: UInt32,
             target: UInt32,
@@ -1318,6 +1319,7 @@ extension System {
                 else { return }
 
             guard blob.hashes.allSatisfy (System.validateBlockHash(_:)),
+                System.validateBlockHash(blob.hash),
                 System.validateBlockHash(blob.merkleRoot),
                 System.validateBlockHash(blob.prevBlock)
                 else { throw MigrateError.block }
@@ -1326,12 +1328,14 @@ extension System {
             var hashes = blob.hashes
             let hashesCount = blob.hashes.count
 
+            let hash: UInt256 = blob.hash.withUnsafeBytes { $0.load (as: UInt256.self) }
             let merkleRoot: UInt256 = blob.merkleRoot.withUnsafeBytes { $0.load (as: UInt256.self) }
             let prevBlock:  UInt256 = blob.prevBlock.withUnsafeBytes  { $0.load (as: UInt256.self) }
 
             try hashes.withUnsafeMutableBytes { (hashesBytes: UnsafeMutableRawBufferPointer) -> Void in
                 let hashesAddr = hashesBytes.baseAddress?.assumingMemoryBound(to: UInt256.self)
                 let status = cryptoWalletMigratorHandleBlockAsBTC (migrator,
+                                                                   hash,
                                                                    blob.height,
                                                                    blob.nonce,
                                                                    blob.target,

--- a/crypto/BRCryptoWalletManager.c
+++ b/crypto/BRCryptoWalletManager.c
@@ -787,6 +787,7 @@ cryptoWalletMigratorHandleTransactionAsBTC (BRCryptoWalletMigrator migrator,
 
 extern BRCryptoWalletMigratorStatus
 cryptoWalletMigratorHandleBlockAsBTC (BRCryptoWalletMigrator migrator,
+                                      UInt256 hash,
                                       uint32_t height,
                                       uint32_t nonce,
                                       uint32_t target,
@@ -798,6 +799,7 @@ cryptoWalletMigratorHandleBlockAsBTC (BRCryptoWalletMigrator migrator,
                                       UInt256 merkleRoot,
                                       UInt256 prevBlock) {
     BRMerkleBlock *block = BRMerkleBlockNew();
+    block->blockHash = hash;
     block->height = height;
     block->nonce  = nonce;
     block->target = target;

--- a/crypto/BRCryptoWalletManager.h
+++ b/crypto/BRCryptoWalletManager.h
@@ -230,6 +230,7 @@ extern "C" {
 
     extern BRCryptoWalletMigratorStatus
     cryptoWalletMigratorHandleBlockAsBTC (BRCryptoWalletMigrator migrator,
+                                          UInt256 hash,
                                           uint32_t height,
                                           uint32_t nonce,
                                           uint32_t target,


### PR DESCRIPTION
Overlooked blockHash in the migration.