### PR TITLE
CORE-511: Rinkeby Updates

### DIFF
--- a/Java/Crypto/src/main/java/com/breadwallet/crypto/blockchaindb/models/bdb/Blockchain.java
+++ b/Java/Crypto/src/main/java/com/breadwallet/crypto/blockchaindb/models/bdb/Blockchain.java
@@ -39,8 +39,6 @@ public class Blockchain {
                     ImmutableList.of(new BlockchainFee("30", "10m", UnsignedLong.valueOf(10 * 60 * 1000)))),
             new Blockchain("ethereum-testnet",     "Ethereum Testnet",  "testnet", false, "eth", UnsignedLong.valueOf(1000000),
                     ImmutableList.of(new BlockchainFee("2000000000", "1m", UnsignedLong.valueOf(60 * 1000)))),
-            new Blockchain("ethereum-rinkeby",     "Ethereum Rinkeby",  "rinkeby", false, "eth", UnsignedLong.valueOf(2000000),
-                    ImmutableList.of(new BlockchainFee("2000000000", "1m", UnsignedLong.valueOf(60 * 1000)))),
             new Blockchain("ripple-testnet",       "Ripple Testnet",    "mainnet", false, "xrp", UnsignedLong.valueOf(25000),
                     ImmutableList.of(new BlockchainFee("20", "1m", UnsignedLong.valueOf(60 * 1000))))
     );

--- a/Java/Crypto/src/main/java/com/breadwallet/crypto/blockchaindb/models/bdb/Currency.java
+++ b/Java/Crypto/src/main/java/com/breadwallet/crypto/blockchaindb/models/bdb/Currency.java
@@ -63,10 +63,6 @@ public class Currency {
             new Currency("BRD Token Testnet", "BRD Token Testnet", "brd", "erc20", "ethereum-testnet", ADDRESS_BRD_TESTNET, true,
                     ImmutableList.of(CurrencyDenomination.BRD_INT, CurrencyDenomination.BRD_BRD)),
 
-            new Currency("Ethereum-Rinkeby", "Ethereum Rinkeby", "eth", "native", "ethereum-rinkeby", null, true,
-                    ImmutableList.of(CurrencyDenomination.ETH_WEI, CurrencyDenomination.ETH_GWEI,
-                            CurrencyDenomination.ETH_ETHER)),
-
             new Currency("Ripple", "Ripple", "xrp", "native", "ripple-testnet", null, true,
                          ImmutableList.of(CurrencyDenomination.XRP_DROP, CurrencyDenomination.XRP_XRP))
     );

--- a/Swift/BRCrypto/common/BRBlockChainDB.swift
+++ b/Swift/BRCrypto/common/BRBlockChainDB.swift
@@ -284,8 +284,6 @@ public class BlockChainDB {
              feeEstimates: [(amount: "30", tier: "10m", confirmationTimeInMilliseconds: 10 * 60 * 1000)]),
             (id: "ethereum-testnet",      name: "Ethereum Testnet",  network: "testnet", isMainnet: false, currency: "eth", blockHeight: 1000000,
              feeEstimates: [(amount: "2000000000", tier: "1m", confirmationTimeInMilliseconds: 1 * 60 * 1000)]),
-            (id: "ethereum-rinkeby",      name: "Ethereum Rinkeby",  network: "rinkeby", isMainnet: false, currency: "eth", blockHeight: 2000000,
-             feeEstimates: [(amount: "2000000000", tier: "1m", confirmationTimeInMilliseconds: 1 * 60 * 1000)]),
             (id: "ripple-testnet",        name: "Ripple Testnet",    network: "testnet", isMainnet: false, currency: "xrp", blockHeight: 25000,
              feeEstimates: [(amount: "20", tier: "1m", confirmationTimeInMilliseconds: 1 * 60 * 1000)]),
         ]
@@ -403,18 +401,10 @@ public class BlockChainDB {
              demoninations: [(name: "BRD_INTEGER",   code: "BRDI",  decimals:  0, symbol: "brdi"),
                              (name: "BRD",           code: "BRD",   decimals: 18, symbol: "brd")]),
 
-            (id: "Ethereum-Rinkeby", name: "Ethereum Rinkeby", code: "eth", type: "native", blockchainID: "ethereum-rinkeby",
-             address: nil, verified: true,
-             demoninations: [(name: "wei",   code: "wei",  decimals:  0, symbol: lookupSymbol ("wei")),
-                             (name: "gwei",  code: "gwei", decimals:  9, symbol: lookupSymbol ("gwei")),
-                             (name: "ether", code: "eth",  decimals: 18, symbol: lookupSymbol ("eth"))]),
-
-
             (id: "Ripple", name: "Ripple", code: "xrp", type: "native", blockchainID: "ripple-testnet",
              address: nil, verified: true,
              demoninations: [(name: "drop", code: "drop", decimals: 0, symbol: "drop"),
                              (name: "xrp",  code: "xrp",  decimals: 6, symbol: "xrp")]),
-
        ]
 
         static internal let addressBRDTestnet = "0x7108ca7c4718efa810457f228305c9c71390931a" // testnet

--- a/ethereum/blockchain/BREthereumBlock.c
+++ b/ethereum/blockchain/BREthereumBlock.c
@@ -1647,7 +1647,7 @@ ethereumTestnetCheckpoints [] = {
 
 static BREthereumBlockCheckpoint
 ethereumRinkebyCheckpoints [] = {
-    {       0, HASH_INIT("6341fd3daf94b748c72ced5a5b26028f2474f5f00d824504e4fa37a75767e177"), { .std = "0x01" },  0x58ee40ba }, //  439 days  6 hrs ago (Apr-12-2017 03:20:50 PM +UTC)
+    {       0, HASH_INIT("6341fd3daf94b748c72ced5a5b26028f2474f5f00d824504e4fa37a75767e177"), { .std = "0x01" },  0 }, //  439 days  6 hrs ago (Apr-12-2017 03:20:50 PM +UTC)
 };
 #define CHECKPOINT_RINKEBY_COUNT      (sizeof (ethereumRinkebyCheckpoints) / sizeof (BREthereumBlockCheckpoint))
 


### PR DESCRIPTION
Set the Rinkeby checkpoint timestamp for the genesis block to 0 - which means an arbitrary time in a checkpoint lookup will find the genesis block.

Axe Rinkeby as a default network (it will *never* be provided by BDB)