### PR TITLE
CORE-512: Handle a BDB blockHeight of `-1` (not supported)

### DIFF
--- a/Java/CoreCrypto/src/androidTest/java/com/breadwallet/corecrypto/AddressAIT.java
+++ b/Java/CoreCrypto/src/androidTest/java/com/breadwallet/corecrypto/AddressAIT.java
@@ -180,7 +180,7 @@ public class AddressAIT {
         NetworkFee fee = NetworkFee.create(UnsignedLong.valueOf(1000), Amount.create(2.0, gwei_eth));
         List<NetworkFee> fees = Collections.singletonList(fee);
 
-        Network network = Network.create("ethereum-testnet", "Ethereum Testnet", false, eth, UnsignedLong.valueOf(100000), associations, fees);
+        Network network = Network.create("ethereum-ropsten", "Ethereum Testnet", false, eth, UnsignedLong.valueOf(100000), associations, fees);
 
         Optional<Address> oe1 = network.addressFor("0xb0F225defEc7625C6B5E43126bdDE398bD90eF62");
         assertTrue(oe1.isPresent());
@@ -299,7 +299,7 @@ public class AddressAIT {
         fee = NetworkFee.create(UnsignedLong.valueOf(1000), Amount.create(2.0, gwei_eth));
         fees = Collections.singletonList(fee);
 
-        Network network_eth = Network.create("ethereum-testnet", "Ethereum Testnet", false, eth, UnsignedLong.valueOf(100000), associations, fees);
+        Network network_eth = Network.create("ethereum-ropsten", "Ethereum Testnet", false, eth, UnsignedLong.valueOf(100000), associations, fees);
 
         Address e1 = network_eth.addressFor("0xb0F225defEc7625C6B5E43126bdDE398bD90eF62").get();
         Address b1 = network_btc.addressFor("mm7DDqVkFd35XcWecFipfTYM5dByBzn7nq").get();

--- a/Java/CoreCrypto/src/main/java/com/breadwallet/corecrypto/NetworkDiscovery.java
+++ b/Java/CoreCrypto/src/main/java/com/breadwallet/corecrypto/NetworkDiscovery.java
@@ -18,7 +18,6 @@ import com.breadwallet.crypto.utility.CompletionHandler;
 import com.google.common.base.Function;
 import com.google.common.base.Optional;
 import com.google.common.primitives.UnsignedInteger;
-import com.google.common.primitives.UnsignedLong;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -27,7 +26,6 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 
 /* package */
@@ -45,7 +43,7 @@ final class NetworkDiscovery {
         List<Network> networks = new ArrayList<>();
         CountUpAndDownLatch latch = new CountUpAndDownLatch(() -> callback.discovered(networks));
 
-        getBlockChains(latch, query, Blockchain.DEFAULT_BLOCKCHAINS, isMainnet, blockchainModels -> {
+        getBlockChains(latch, query, System.DEFAULT_BLOCKCHAINS, isMainnet, blockchainModels -> {
             for (Blockchain blockchainModel : blockchainModels) {
                 if (blockchainModel.isMainnet() != isMainnet) {
                     continue;
@@ -55,7 +53,7 @@ final class NetworkDiscovery {
 
                 final List<com.breadwallet.crypto.blockchaindb.models.bdb.Currency> defaultCurrencies = new ArrayList<>();
                 for (com.breadwallet.crypto.blockchaindb.models.bdb.Currency currency :
-                        com.breadwallet.crypto.blockchaindb.models.bdb.Currency.DEFAULT_CURRENCIES) {
+                        System.DEFAULT_CURRENCIES) {
                     if (currency.getBlockchainId().equals(blockchainModelId)) {
                         defaultCurrencies.add(currency);
                     }

--- a/Java/CoreCrypto/src/main/java/com/breadwallet/corecrypto/System.java
+++ b/Java/CoreCrypto/src/main/java/com/breadwallet/corecrypto/System.java
@@ -44,7 +44,6 @@ import com.breadwallet.crypto.blockchaindb.BlockchainDb;
 import com.breadwallet.crypto.blockchaindb.errors.QueryError;
 import com.breadwallet.crypto.blockchaindb.models.bdb.Blockchain;
 import com.breadwallet.crypto.blockchaindb.models.bdb.BlockchainFee;
-import com.breadwallet.crypto.blockchaindb.models.bdb.Currency;
 import com.breadwallet.crypto.blockchaindb.models.bdb.CurrencyDenomination;
 import com.breadwallet.crypto.blockchaindb.models.bdb.Transaction;
 import com.breadwallet.crypto.blockchaindb.models.brd.EthLog;
@@ -97,7 +96,6 @@ import com.sun.jna.Pointer;
 import java.lang.ref.WeakReference;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collection;
 import java.util.Collections;
 import java.util.Date;
 import java.util.List;
@@ -112,8 +110,6 @@ import java.util.concurrent.locks.ReadWriteLock;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 
 import static com.breadwallet.crypto.blockchaindb.models.bdb.Currency.ADDRESS_BRD_MAINNET;
-import static com.breadwallet.crypto.blockchaindb.models.bdb.Currency.ADDRESS_BRD_TESTNET;
-import static com.breadwallet.crypto.blockchaindb.models.bdb.Currency.ADDRESS_EOS_MAINNET;
 
 /* package */
 final class System implements com.breadwallet.crypto.System {
@@ -129,63 +125,48 @@ final class System implements com.breadwallet.crypto.System {
     /* package */
     static List<Blockchain> DEFAULT_BLOCKCHAINS = ImmutableList.of(
             // Mainnet
-            new Blockchain("bitcoin-mainnet",      "Bitcoin",      "mainnet", true, "btc", UnsignedLong.ZERO,
+            new Blockchain("bitcoin-mainnet",      "Bitcoin",      "mainnet", true, "bitcoin-mainnet:__native__", UnsignedLong.ZERO,
                     ImmutableList.of(new BlockchainFee("30", "10m", UnsignedLong.valueOf(10 * 60 * 1000)))),
-            new Blockchain("bitcoin-cash-mainnet", "Bitcoin Cash", "mainnet", true, "bch", UnsignedLong.ZERO,
+            new Blockchain("bitcoincash-mainnet", "Bitcoin Cash", "mainnet", true, "bitcoincash-mainnet:__native__", UnsignedLong.ZERO,
                     ImmutableList.of(new BlockchainFee("30", "10m", UnsignedLong.valueOf(10 * 60 * 1000)))),
-            new Blockchain("ethereum-mainnet",     "Ethereum",     "mainnet", true, "eth", UnsignedLong.ZERO,
+            new Blockchain("ethereum-mainnet",     "Ethereum",     "mainnet", true, "ethereum-mainnet:__native__", UnsignedLong.ZERO,
                     ImmutableList.of(new BlockchainFee("2000000000", "1m", UnsignedLong.valueOf(60 * 1000)))),
-            new Blockchain("ripple-mainnet",       "Ripple",       "mainnet", true, "xrp", null,
-                    ImmutableList.of(new BlockchainFee("20", "1m", UnsignedLong.valueOf(60 * 1000)))),
 
             // Testnet
-            new Blockchain("bitcoin-testnet",      "Bitcoin Test",      "testnet", false, "btc", UnsignedLong.ZERO,
+            new Blockchain("bitcoin-testnet",      "Bitcoin Testnet",      "testnet", false, "bitcoin-testnet:__native__", UnsignedLong.ZERO,
                     ImmutableList.of(new BlockchainFee("30", "10m", UnsignedLong.valueOf(10 * 60 * 1000)))),
-            new Blockchain("bitcoin-cash-testnet", "Bitcoin Cash Test", "testnet", false, "bch", UnsignedLong.ZERO,
+            new Blockchain("bitcoincash-testnet", "Bitcoin Cash Testnet", "testnet", false, "bitcoincash-testnet:__native__", UnsignedLong.ZERO,
                     ImmutableList.of(new BlockchainFee("30", "10m", UnsignedLong.valueOf(10 * 60 * 1000)))),
-            new Blockchain("ethereum-ropsten",     "Ethereum Testnet",  "testnet", false, "eth", UnsignedLong.ZERO,
-                    ImmutableList.of(new BlockchainFee("2000000000", "1m", UnsignedLong.valueOf(60 * 1000)))),
-            new Blockchain("ripple-testnet",       "Ripple Testnet",    "testnet", false, "xrp", null,
-                    ImmutableList.of(new BlockchainFee("20", "1m", UnsignedLong.valueOf(60 * 1000))))
+            new Blockchain("ethereum-ropsten",     "Ethereum Ropsten",  "testnet", false, "ethereum-ropsten:__native__", UnsignedLong.ZERO,
+                    ImmutableList.of(new BlockchainFee("2000000000", "1m", UnsignedLong.valueOf(60 * 1000))))
     );
 
-    public static final List<com.breadwallet.crypto.blockchaindb.models.bdb.Currency> DEFAULT_CURRENCIES = ImmutableList.of(
+    /* package */
+    static final List<com.breadwallet.crypto.blockchaindb.models.bdb.Currency> DEFAULT_CURRENCIES = ImmutableList.of(
             // Mainnet
-            new com.breadwallet.crypto.blockchaindb.models.bdb.Currency("Bitcoin", "Bitcoin", "btc", "native", "bitcoin-mainnet", null, true,
-                    ImmutableList.of(CurrencyDenomination.BTC_SATOSHI, CurrencyDenomination.BTC_BITCOIN)),
+            new com.breadwallet.crypto.blockchaindb.models.bdb.Currency("bitcoin-mainnet:__native__", "Bitcoin", "btc", "native", "bitcoin-mainnet", null, true,
+                    ImmutableList.of(CurrencyDenomination.SATOSHI, CurrencyDenomination.BTC_BITCOIN)),
 
-            new com.breadwallet.crypto.blockchaindb.models.bdb.Currency("Bitcoin-Cash", "Bitcoin Cash", "bch", "native", "bitcoin-cash-mainnet", null, true,
-                    ImmutableList.of(CurrencyDenomination.BTC_SATOSHI, CurrencyDenomination.BCH_BITCOIN)),
+            new com.breadwallet.crypto.blockchaindb.models.bdb.Currency("bitcoincash-mainnet:__native__", "Bitcoin Cash", "bch", "native", "bitcoincash-mainnet", null, true,
+                    ImmutableList.of(CurrencyDenomination.SATOSHI, CurrencyDenomination.BCH_BITCOIN)),
 
-            new com.breadwallet.crypto.blockchaindb.models.bdb.Currency("Ethereum", "Ethereum", "eth", "native", "ethereum-mainnet", null, true,
+            new com.breadwallet.crypto.blockchaindb.models.bdb.Currency("ethereum-mainnet:__native__", "Ethereum", "eth", "native", "ethereum-mainnet", null, true,
                     ImmutableList.of(CurrencyDenomination.ETH_WEI, CurrencyDenomination.ETH_GWEI,
                             CurrencyDenomination.ETH_ETHER)),
 
-            new com.breadwallet.crypto.blockchaindb.models.bdb.Currency("BRD Token", "BRD Token", "brd", "erc20", "ethereum-mainnet", ADDRESS_BRD_MAINNET, true,
+            new com.breadwallet.crypto.blockchaindb.models.bdb.Currency("ethereum-mainnet:0x558ec3152e2eb2174905cd19aea4e34a23de9ad6", "BRD Token", "BRD", "erc20", "ethereum-mainnet", ADDRESS_BRD_MAINNET, true,
                     ImmutableList.of(CurrencyDenomination.BRD_INT, CurrencyDenomination.BRD_BRD)),
-
-            new com.breadwallet.crypto.blockchaindb.models.bdb.Currency("EOS Token", "EOS Token", "eos", "erc20", "ethereum-mainnet", ADDRESS_EOS_MAINNET, true,
-                    ImmutableList.of(CurrencyDenomination.EOS_INT, CurrencyDenomination.EOS_EOS)),
-
-            new com.breadwallet.crypto.blockchaindb.models.bdb.Currency("Ripple", "Ripple", "xrp", "native", "ripple-mainnet", null, true,
-                    ImmutableList.of(CurrencyDenomination.XRP_DROP, CurrencyDenomination.XRP_XRP)),
 
             // Testnet
-            new com.breadwallet.crypto.blockchaindb.models.bdb.Currency("Bitcoin-Testnet", "Bitcoin Test", "btc", "native", "bitcoin-testnet", null, true,
-                    ImmutableList.of(CurrencyDenomination.BTC_SATOSHI, CurrencyDenomination.BTC_BITCOIN)),
+            new com.breadwallet.crypto.blockchaindb.models.bdb.Currency("bitcoin-testnet:__native__", "Bitcoin Test", "btc", "native", "bitcoin-testnet", null, true,
+                    ImmutableList.of(CurrencyDenomination.SATOSHI, CurrencyDenomination.BTC_BITCOIN_TESTNET)),
 
-            new com.breadwallet.crypto.blockchaindb.models.bdb.Currency("Bitcoin-Cash-Testnet", "Bitcoin Cash Test", "bch", "native", "bitcoin-cash-testnet", null, true,
-                    ImmutableList.of(CurrencyDenomination.BTC_SATOSHI, CurrencyDenomination.BCH_BITCOIN)),
+            new com.breadwallet.crypto.blockchaindb.models.bdb.Currency("Bitcoin-Cash-Testnet", "Bitcoin Cash Test", "bch", "native", "bitcoincash-testnet", null, true,
+                    ImmutableList.of(CurrencyDenomination.SATOSHI, CurrencyDenomination.BCH_BITCOIN_TESTNET)),
 
-            new com.breadwallet.crypto.blockchaindb.models.bdb.Currency("Ethereum-Testnet", "Ethereum Testnet", "eth", "native", "ethereum-ropsten", null, true,
+            new com.breadwallet.crypto.blockchaindb.models.bdb.Currency("ethereum-ropsten:__native__", "Ethereum Testnet", "eth", "native", "ethereum-ropsten", null, true,
                     ImmutableList.of(CurrencyDenomination.ETH_WEI, CurrencyDenomination.ETH_GWEI,
-                            CurrencyDenomination.ETH_ETHER)),
-
-            new com.breadwallet.crypto.blockchaindb.models.bdb.Currency("BRD Token Testnet", "BRD Token Testnet", "brd", "erc20", "ethereum-ropsten", ADDRESS_BRD_TESTNET, true,
-                    ImmutableList.of(CurrencyDenomination.BRD_INT, CurrencyDenomination.BRD_BRD)),
-
-            new Currency("Ripple", "Ripple", "xrp", "native", "ripple-testnet", null, true,
-                    ImmutableList.of(CurrencyDenomination.XRP_DROP, CurrencyDenomination.XRP_XRP))
+                            CurrencyDenomination.ETH_ETHER))
     );
 
     ///
@@ -198,13 +179,13 @@ final class System implements com.breadwallet.crypto.System {
         ImmutableMultimap.Builder<String, AddressScheme> builder = new ImmutableMultimap.Builder<>();
         builder.put("bitcoin-mainnet", AddressScheme.BTC_SEGWIT);
         builder.put("bitcoin-mainnet", AddressScheme.BTC_LEGACY);
-        builder.put("bitcoin-cash-mainnet", AddressScheme.BTC_LEGACY);
+        builder.put("bitcoincash-mainnet", AddressScheme.BTC_LEGACY);
         builder.put("ethereum-mainnet", AddressScheme.ETH_DEFAULT);
         builder.put("ripple-mainnet", AddressScheme.GEN_DEFAULT);
 
         builder.put("bitcoin-testnet", AddressScheme.BTC_SEGWIT);
         builder.put("bitcoin-testnet", AddressScheme.BTC_LEGACY);
-        builder.put("bitcoin-cash-testnet", AddressScheme.BTC_LEGACY);
+        builder.put("bitcoincash-testnet", AddressScheme.BTC_LEGACY);
         builder.put("ethereum-ropsten", AddressScheme.ETH_DEFAULT);
         builder.put("ripple-testnet", AddressScheme.GEN_DEFAULT);
         SUPPORTED_ADDRESS_SCHEMES = builder.build();
@@ -215,12 +196,12 @@ final class System implements com.breadwallet.crypto.System {
     static {
         ImmutableMap.Builder<String, AddressScheme> builder = new ImmutableMap.Builder<>();
         builder.put("bitcoin-mainnet", AddressScheme.BTC_SEGWIT);
-        builder.put("bitcoin-cash-mainnet", AddressScheme.BTC_LEGACY);
+        builder.put("bitcoincash-mainnet", AddressScheme.BTC_LEGACY);
         builder.put("ethereum-mainnet", AddressScheme.ETH_DEFAULT);
         builder.put("ripple-mainnet", AddressScheme.GEN_DEFAULT);
 
         builder.put("bitcoin-testnet", AddressScheme.BTC_SEGWIT);
-        builder.put("bitcoin-cash-testnet", AddressScheme.BTC_LEGACY);
+        builder.put("bitcoincash-testnet", AddressScheme.BTC_LEGACY);
         builder.put("ethereum-ropsten", AddressScheme.ETH_DEFAULT);
         builder.put("ripple-testnet", AddressScheme.GEN_DEFAULT);
         DEFAULT_ADDRESS_SCHEMES = builder.build();
@@ -235,13 +216,15 @@ final class System implements com.breadwallet.crypto.System {
     static {
         ImmutableMultimap.Builder<String, WalletManagerMode> builder = new ImmutableMultimap.Builder<>();
         builder.put("bitcoin-mainnet", WalletManagerMode.P2P_ONLY);
-        builder.put("bitcoin-cash-mainnet", WalletManagerMode.P2P_ONLY);
+        builder.put("bitcoin-mainnet", WalletManagerMode.API_ONLY);
+        builder.put("bitcoincash-mainnet", WalletManagerMode.P2P_ONLY);
         builder.put("ethereum-mainnet", WalletManagerMode.API_ONLY);
         builder.put("ethereum-mainnet", WalletManagerMode.API_WITH_P2P_SUBMIT);
         builder.put("ethereum-mainnet", WalletManagerMode.P2P_ONLY);
 
         builder.put("bitcoin-testnet", WalletManagerMode.P2P_ONLY);
-        builder.put("bitcoin-cash-testnet", WalletManagerMode.P2P_ONLY);
+        builder.put("bitcoin-testnet", WalletManagerMode.API_ONLY);
+        builder.put("bitcoincash-testnet", WalletManagerMode.P2P_ONLY);
         builder.put("ethereum-ropsten", WalletManagerMode.API_ONLY);
         builder.put("ethereum-ropsten", WalletManagerMode.API_WITH_P2P_SUBMIT);
         builder.put("ethereum-ropsten", WalletManagerMode.P2P_ONLY);
@@ -1424,9 +1407,15 @@ final class System implements com.breadwallet.crypto.System {
             optSystem.get().query.getBlockchain(coreWalletManager.getNetwork().getUids(), new CompletionHandler<Blockchain, QueryError>() {
                 @Override
                 public void handleData(Blockchain blockchain) {
-                    UnsignedLong blockchainHeight = blockchain.getBlockHeight();
-                    Log.d(TAG, String.format("BRCryptoCWMBtcGetBlockNumberCallback: succeeded (%s)", blockchainHeight));
-                    coreWalletManager.announceGetBlockNumberSuccess(callbackState, blockchainHeight);
+                    Optional<UnsignedLong> maybeBlockHeight = blockchain.getBlockHeight();
+                    if (maybeBlockHeight.isPresent()) {
+                        UnsignedLong blockchainHeight = maybeBlockHeight.get();
+                        Log.d(TAG, String.format("BRCryptoCWMBtcGetBlockNumberCallback: succeeded (%s)", blockchainHeight));
+                        coreWalletManager.announceGetBlockNumberSuccess(callbackState, blockchainHeight);
+                    } else  {
+                        Log.e(TAG, "BRCryptoCWMBtcGetBlockNumberCallback: failed with missing block height");
+                        coreWalletManager.announceGetBlockNumberFailure(callbackState);
+                    }
                 }
 
                 @Override
@@ -1899,9 +1888,15 @@ final class System implements com.breadwallet.crypto.System {
             optSystem.get().query.getBlockchain(coreWalletManager.getNetwork().getUids(), new CompletionHandler<Blockchain, QueryError>() {
                 @Override
                 public void handleData(Blockchain blockchain) {
-                    UnsignedLong blockchainHeight = blockchain.getBlockHeight();
-                    Log.d(TAG, String.format("BRCryptoCWMGenGetBlockNumberCallback: succeeded (%s)", blockchainHeight));
-                    coreWalletManager.announceGetBlockNumberSuccess(callbackState, blockchainHeight);
+                    Optional<UnsignedLong> maybeBlockHeight = blockchain.getBlockHeight();
+                    if (maybeBlockHeight.isPresent()) {
+                        UnsignedLong blockchainHeight = maybeBlockHeight.get();
+                        Log.d(TAG, String.format("BRCryptoCWMGenGetBlockNumberCallback: succeeded (%s)", blockchainHeight));
+                        coreWalletManager.announceGetBlockNumberSuccess(callbackState, blockchainHeight);
+                    } else  {
+                        Log.e(TAG, "BRCryptoCWMGenGetBlockNumberCallback: failed with missing block height");
+                        coreWalletManager.announceGetBlockNumberFailure(callbackState);
+                    }
                 }
 
                 @Override

--- a/Java/Crypto/src/main/java/com/breadwallet/crypto/blockchaindb/models/bdb/Blockchain.java
+++ b/Java/Crypto/src/main/java/com/breadwallet/crypto/blockchaindb/models/bdb/Blockchain.java
@@ -7,6 +7,8 @@
  */
 package com.breadwallet.crypto.blockchaindb.models.bdb;
 
+import android.support.annotation.Nullable;
+
 import com.breadwallet.crypto.blockchaindb.models.Utilities;
 import com.google.common.base.Optional;
 import com.google.common.primitives.UnsignedLong;
@@ -20,6 +22,8 @@ import java.util.List;
 
 public class Blockchain {
 
+    private static long BLOCK_HEIGHT_INTERNAL = -1;
+
     public static Optional<Blockchain> asBlockchain(JSONObject json) {
         try {
             String id = json.getString("id");
@@ -27,7 +31,10 @@ public class Blockchain {
             String network = json.getString("network");
             boolean isMainnet = json.getBoolean("is_mainnet");
             String currency = json.getString("native_currency_id");
-            UnsignedLong blockHeight = Utilities.getUnsignedLongFromString(json, "block_height");
+
+            long blockHeightLong = json.getLong("block_height");
+            UnsignedLong blockHeight = BLOCK_HEIGHT_INTERNAL == blockHeightLong ?
+                    null : UnsignedLong.valueOf(blockHeightLong);
 
             JSONArray feeEstimatesJson = json.getJSONArray("fee_estimates");
             Optional<List<BlockchainFee>> feeEstimatesOption = BlockchainFee.asBlockchainFees(feeEstimatesJson);
@@ -40,6 +47,7 @@ public class Blockchain {
             return Optional.absent();
         }
     }
+
 
     public static Optional<List<Blockchain>> asBlockchains(JSONArray json) {
         List<Blockchain> blockchains = new ArrayList<>();
@@ -64,10 +72,12 @@ public class Blockchain {
     private final String network;
     private final boolean isMainnet;
     private final String currency;
-    private final UnsignedLong blockHeight;
     private final List<BlockchainFee> feeEstimates;
 
-    public Blockchain(String id, String name, String network, boolean isMainnet, String currency, UnsignedLong blockHeight,
+    @Nullable
+    private final UnsignedLong blockHeight;
+
+    public Blockchain(String id, String name, String network, boolean isMainnet, String currency, @Nullable UnsignedLong blockHeight,
                       List<BlockchainFee> feeEstimates) {
         this.id = id;
         this.name = name;
@@ -98,8 +108,8 @@ public class Blockchain {
         return currency;
     }
 
-    public UnsignedLong getBlockHeight() {
-        return blockHeight;
+    public Optional<UnsignedLong> getBlockHeight() {
+        return Optional.fromNullable(blockHeight);
     }
 
     public List<BlockchainFee> getFeeEstimates() {

--- a/Java/Crypto/src/main/java/com/breadwallet/crypto/blockchaindb/models/bdb/Blockchain.java
+++ b/Java/Crypto/src/main/java/com/breadwallet/crypto/blockchaindb/models/bdb/Blockchain.java
@@ -9,7 +9,6 @@ package com.breadwallet.crypto.blockchaindb.models.bdb;
 
 import com.breadwallet.crypto.blockchaindb.models.Utilities;
 import com.google.common.base.Optional;
-import com.google.common.collect.ImmutableList;
 import com.google.common.primitives.UnsignedLong;
 
 import org.json.JSONArray;
@@ -20,28 +19,6 @@ import java.util.ArrayList;
 import java.util.List;
 
 public class Blockchain {
-
-    public static List<Blockchain> DEFAULT_BLOCKCHAINS = ImmutableList.of(
-            // Mainnet
-            new Blockchain("bitcoin-mainnet",      "Bitcoin",      "mainnet", true, "btc", UnsignedLong.valueOf(654321),
-                    ImmutableList.of(new BlockchainFee("30", "10m", UnsignedLong.valueOf(10 * 60 * 1000)))),
-            new Blockchain("bitcoin-cash-mainnet", "Bitcoin Cash", "mainnet", true, "bch", UnsignedLong.valueOf(1000000),
-                    ImmutableList.of(new BlockchainFee("30", "10m", UnsignedLong.valueOf(10 * 60 * 1000)))),
-            new Blockchain("ethereum-mainnet",     "Ethereum",     "mainnet", true, "eth", UnsignedLong.valueOf(8000000),
-                    ImmutableList.of(new BlockchainFee("2000000000", "1m", UnsignedLong.valueOf(60 * 1000)))),
-            new Blockchain("ripple-mainnet",       "Ripple",       "mainnet", true, "xrp", UnsignedLong.valueOf(5000000),
-                    ImmutableList.of(new BlockchainFee("20", "1m", UnsignedLong.valueOf(60 * 1000)))),
-
-            // Testnet
-            new Blockchain("bitcoin-testnet",      "Bitcoin Test",      "testnet", false, "btc", UnsignedLong.valueOf(900000),
-                    ImmutableList.of(new BlockchainFee("30", "10m", UnsignedLong.valueOf(10 * 60 * 1000)))),
-            new Blockchain("bitcoin-cash-testnet", "Bitcoin Cash Test", "testnet", false, "bch", UnsignedLong.valueOf(1200000),
-                    ImmutableList.of(new BlockchainFee("30", "10m", UnsignedLong.valueOf(10 * 60 * 1000)))),
-            new Blockchain("ethereum-testnet",     "Ethereum Testnet",  "testnet", false, "eth", UnsignedLong.valueOf(1000000),
-                    ImmutableList.of(new BlockchainFee("2000000000", "1m", UnsignedLong.valueOf(60 * 1000)))),
-            new Blockchain("ripple-testnet",       "Ripple Testnet",    "mainnet", false, "xrp", UnsignedLong.valueOf(25000),
-                    ImmutableList.of(new BlockchainFee("20", "1m", UnsignedLong.valueOf(60 * 1000))))
-    );
 
     public static Optional<Blockchain> asBlockchain(JSONObject json) {
         try {

--- a/Java/Crypto/src/main/java/com/breadwallet/crypto/blockchaindb/models/bdb/BlockchainFee.java
+++ b/Java/Crypto/src/main/java/com/breadwallet/crypto/blockchaindb/models/bdb/BlockchainFee.java
@@ -22,10 +22,8 @@ import java.util.List;
 public class BlockchainFee {
 
     public static Optional<BlockchainFee> asBlockchainFee(JSONObject json) {
-        String value = json.optString("value", "1");
-
         try {
-            json.getString("currency_id");
+            json.getJSONObject("fee").getString("currency_id");
             String amount = json.getJSONObject("fee").getString("amount");
             String tier = json.getString("tier");
             UnsignedLong confirmationTime = Utilities.getUnsignedLongFromString(json, "estimated_confirmation_in");

--- a/Java/Crypto/src/main/java/com/breadwallet/crypto/blockchaindb/models/bdb/Currency.java
+++ b/Java/Crypto/src/main/java/com/breadwallet/crypto/blockchaindb/models/bdb/Currency.java
@@ -23,54 +23,15 @@ public class Currency {
 
     private static final String ADDRESS_INTERNAL = "__native__";
 
-    private static final String ADDRESS_BRD_MAINNET = "0x558ec3152e2eb2174905cd19aea4e34a23de9ad6";
-    private static final String ADDRESS_BRD_TESTNET = "0x7108ca7c4718efa810457f228305c9c71390931a";
+    public static final String ADDRESS_BRD_MAINNET = "0x558ec3152e2eb2174905cd19aea4e34a23de9ad6";
+    public static final String ADDRESS_BRD_TESTNET = "0x7108ca7c4718efa810457f228305c9c71390931a";
 
-    private static final String ADDRESS_EOS_MAINNET = "0x86fa049857e0209aa7d9e616f7eb3b3b78ecfdb0";
-
-    public static final List<Currency> DEFAULT_CURRENCIES = ImmutableList.of(
-            // Mainnet
-            new Currency("Bitcoin", "Bitcoin", "btc", "native", "bitcoin-mainnet", null, true,
-                    ImmutableList.of(CurrencyDenomination.BTC_SATOSHI, CurrencyDenomination.BTC_BITCOIN)),
-
-            new Currency("Bitcoin-Cash", "Bitcoin Cash", "bch", "native", "bitcoin-cash-mainnet", null, true,
-                    ImmutableList.of(CurrencyDenomination.BTC_SATOSHI, CurrencyDenomination.BCH_BITCOIN)),
-
-            new Currency("Ethereum", "Ethereum", "eth", "native", "ethereum-mainnet", null, true,
-                    ImmutableList.of(CurrencyDenomination.ETH_WEI, CurrencyDenomination.ETH_GWEI,
-                            CurrencyDenomination.ETH_ETHER)),
-
-            new Currency("BRD Token", "BRD Token", "brd", "erc20", "ethereum-mainnet", ADDRESS_BRD_MAINNET, true,
-                    ImmutableList.of(CurrencyDenomination.BRD_INT, CurrencyDenomination.BRD_BRD)),
-
-            new Currency("EOS Token", "EOS Token", "eos", "erc20", "ethereum-mainnet", ADDRESS_EOS_MAINNET, true,
-                    ImmutableList.of(CurrencyDenomination.EOS_INT, CurrencyDenomination.EOS_EOS)),
-
-            new Currency("Ripple", "Ripple", "xrp", "native", "ripple-mainnet", null, true,
-                    ImmutableList.of(CurrencyDenomination.XRP_DROP, CurrencyDenomination.XRP_XRP)),
-
-            // Testnet
-            new Currency("Bitcoin-Testnet", "Bitcoin Test", "btc", "native", "bitcoin-testnet", null, true,
-                    ImmutableList.of(CurrencyDenomination.BTC_SATOSHI, CurrencyDenomination.BTC_BITCOIN)),
-
-            new Currency("Bitcoin-Cash-Testnet", "Bitcoin Cash Test", "bch", "native", "bitcoin-cash-testnet", null, true,
-                    ImmutableList.of(CurrencyDenomination.BTC_SATOSHI, CurrencyDenomination.BCH_BITCOIN)),
-
-            new Currency("Ethereum-Testnet", "Ethereum Testnet", "eth", "native", "ethereum-testnet", null, true,
-                    ImmutableList.of(CurrencyDenomination.ETH_WEI, CurrencyDenomination.ETH_GWEI,
-                            CurrencyDenomination.ETH_ETHER)),
-
-            new Currency("BRD Token Testnet", "BRD Token Testnet", "brd", "erc20", "ethereum-testnet", ADDRESS_BRD_TESTNET, true,
-                    ImmutableList.of(CurrencyDenomination.BRD_INT, CurrencyDenomination.BRD_BRD)),
-
-            new Currency("Ripple", "Ripple", "xrp", "native", "ripple-testnet", null, true,
-                         ImmutableList.of(CurrencyDenomination.XRP_DROP, CurrencyDenomination.XRP_XRP))
-    );
+    public static final String ADDRESS_EOS_MAINNET = "0x86fa049857e0209aa7d9e616f7eb3b3b78ecfdb0";
 
     public static Optional<Currency> asCurrency(JSONObject json) {
         // optional
         String address = json.optString("address", null);
-        if (address.equals(ADDRESS_INTERNAL)) address = null;
+        if (ADDRESS_INTERNAL.equals(address)) address = null;
 
         // required
         try {

--- a/Java/Crypto/src/main/java/com/breadwallet/crypto/blockchaindb/models/bdb/CurrencyDenomination.java
+++ b/Java/Crypto/src/main/java/com/breadwallet/crypto/blockchaindb/models/bdb/CurrencyDenomination.java
@@ -26,32 +26,40 @@ public class CurrencyDenomination {
             "eth", "Ξ"
     );
 
-    public static CurrencyDenomination BTC_SATOSHI = new CurrencyDenomination(
-            "satoshi", "sat", UnsignedInteger.valueOf(0), lookupSymbol("sat"));
+
+    public static CurrencyDenomination SATOSHI = new CurrencyDenomination(
+            "Satoshi", "sat", UnsignedInteger.valueOf(0), lookupSymbol("sat"));
+
 
     public static CurrencyDenomination BTC_BITCOIN = new CurrencyDenomination(
-            "bitcoin", "btc", UnsignedInteger.valueOf(8), lookupSymbol("btc"));
+            "Bitcoin", "btc", UnsignedInteger.valueOf(8), lookupSymbol("btc"));
+
+    public static CurrencyDenomination BTC_BITCOIN_TESTNET = new CurrencyDenomination(
+            "Bitcoin Testnet", "btc", UnsignedInteger.valueOf(8), lookupSymbol("btc"));
 
 
     public static CurrencyDenomination BCH_BITCOIN = new CurrencyDenomination(
-            "bitcoin cash", "bch", UnsignedInteger.valueOf(8), lookupSymbol("bch"));
+            "Bitcoin Cash", "bch", UnsignedInteger.valueOf(8), lookupSymbol("bch"));
+
+    public static CurrencyDenomination BCH_BITCOIN_TESTNET = new CurrencyDenomination(
+            "Bitcoin Cash Testnet", "bch", UnsignedInteger.valueOf(8), lookupSymbol("bch"));
 
 
     public static CurrencyDenomination ETH_WEI = new CurrencyDenomination(
-            "wei", "wei", UnsignedInteger.valueOf(0), lookupSymbol("wei"));
+            "Wei", "wei", UnsignedInteger.valueOf(0), lookupSymbol("wei"));
 
     public static CurrencyDenomination ETH_GWEI = new CurrencyDenomination(
-            "gwei", "gwei", UnsignedInteger.valueOf(9), lookupSymbol("gwei"));
+            "Gwei", "gwei", UnsignedInteger.valueOf(9), lookupSymbol("gwei"));
 
     public static CurrencyDenomination ETH_ETHER = new CurrencyDenomination(
-            "ether", "eth", UnsignedInteger.valueOf(18), lookupSymbol("eth"));
+            "Ether", "eth", UnsignedInteger.valueOf(18), lookupSymbol("eth"));
 
 
     public static CurrencyDenomination BRD_INT = new CurrencyDenomination(
-            "BRD_INTEGER", "BRDI", UnsignedInteger.valueOf(0), lookupSymbol("brdi"));
+            "BRD Token INT", "BRDI", UnsignedInteger.valueOf(0), lookupSymbol("brdi"));
 
     public static CurrencyDenomination BRD_BRD = new CurrencyDenomination(
-            "BRD", "BRD", UnsignedInteger.valueOf(18), lookupSymbol("brd"));
+            "BRD Token", "BRD", UnsignedInteger.valueOf(18), lookupSymbol("brd"));
 
 
     public static CurrencyDenomination EOS_INT = new CurrencyDenomination(

--- a/Swift/BRCrypto/BRCryptoSystem.swift
+++ b/Swift/BRCrypto/BRCryptoSystem.swift
@@ -38,6 +38,118 @@ public final class System {
 
     internal let callbackCoordinator: SystemCallbackCoordinator
 
+    /// We define default blockchains but these are wholly insufficient given that the
+    /// specfication includes `blockHeight` (which can never be correct).
+
+    static let defaultBlockchains: [BlockChainDB.Model.Blockchain] = [
+        // Mainnet
+        (id: "bitcoin-mainnet",       name: "Bitcoin",       network: "mainnet", isMainnet: true,  currency: "btc", blockHeight: 0,
+         feeEstimates: [(amount: "30", tier: "10m", confirmationTimeInMilliseconds: 10 * 60 * 1000)]),
+        (id: "bitcoin-cash-mainnet",  name: "Bitcoin Cash",  network: "mainnet", isMainnet: true,  currency: "bch", blockHeight: 0,
+         feeEstimates: [(amount: "30", tier: "10m", confirmationTimeInMilliseconds: 10 * 60 * 1000)]),
+        (id: "ethereum-mainnet",      name: "Ethereum",      network: "mainnet", isMainnet: true,  currency: "eth", blockHeight: 0,
+         feeEstimates: [(amount: "2000000000", tier: "1m", confirmationTimeInMilliseconds: 1 * 60 * 1000)]),
+        (id: "ripple-mainnet",        name: "Ripple",        network: "mainnet", isMainnet: true,  currency: "xrp", blockHeight: nil,
+         feeEstimates: [(amount: "20", tier: "1m", confirmationTimeInMilliseconds: 1 * 60 * 1000)]),
+
+        // Testnet
+        (id: "bitcoin-testnet",       name: "Bitcoin Test",      network: "testnet", isMainnet: false, currency: "btc", blockHeight: 0,
+         feeEstimates: [(amount: "30", tier: "10m", confirmationTimeInMilliseconds: 10 * 60 * 1000)]),
+        (id: "bitcoin-cash-testnet",  name: "Bitcoin Cash Test", network: "testnet", isMainnet: false, currency: "bch", blockHeight: 0,
+         feeEstimates: [(amount: "30", tier: "10m", confirmationTimeInMilliseconds: 10 * 60 * 1000)]),
+        (id: "ethereum-ropsten",      name: "Ethereum Testnet",  network: "testnet", isMainnet: false, currency: "eth", blockHeight: 0,
+         feeEstimates: [(amount: "2000000000", tier: "1m", confirmationTimeInMilliseconds: 1 * 60 * 1000)]),
+        (id: "ripple-testnet",        name: "Ripple Testnet",    network: "testnet", isMainnet: false, currency: "xrp", blockHeight: nil,
+         feeEstimates: [(amount: "20", tier: "1m", confirmationTimeInMilliseconds: 1 * 60 * 1000)]),
+    ]
+
+    static let defaultCurrencies: [BlockChainDB.Model.Currency] = [
+        // Mainnet
+        (id: "Bitcoin", name: "Bitcoin", code: "btc", type: "native", blockchainID: "bitcoin-mainnet",
+         address: nil, verified: true,
+         demoninations: [(name: "satoshi", code: "sat", decimals: 0, symbol: BlockChainDB.Model.lookupSymbol ("sat")),
+                         (name: "bitcoin", code: "btc", decimals: 8, symbol: BlockChainDB.Model.lookupSymbol ("btc"))]),
+
+        (id: "Bitcoin-Cash", name: "Bitcoin Cash", code: "bch", type: "native", blockchainID: "bitcoin-cash-mainnet",
+         address: nil, verified: true,
+         demoninations: [(name: "satoshi",      code: "sat", decimals: 0, symbol: BlockChainDB.Model.lookupSymbol ("sat")),
+                         (name: "bitcoin cash", code: "bch", decimals: 8, symbol: BlockChainDB.Model.lookupSymbol ("bch"))]),
+
+        (id: "Ethereum", name: "Ethereum", code: "eth", type: "native", blockchainID: "ethereum-mainnet",
+         address: nil, verified: true,
+         demoninations: [(name: "wei",   code: "wei",  decimals:  0, symbol: BlockChainDB.Model.lookupSymbol ("wei")),
+                         (name: "gwei",  code: "gwei", decimals:  9, symbol: BlockChainDB.Model.lookupSymbol ("gwei")),
+                         (name: "ether", code: "eth",  decimals: 18, symbol: BlockChainDB.Model.lookupSymbol ("eth"))]),
+
+        (id: "BRD Token", name: "BRD Token", code: "brd", type: "erc20", blockchainID: "ethereum-mainnet",
+         address: BlockChainDB.Model.addressBRDMainnet, verified: true,
+         demoninations: [(name: "BRD_INTEGER",   code: "BRDI",  decimals:  0, symbol: "brdi"),
+                         (name: "BRD",           code: "BRD",   decimals: 18, symbol: "brd")]),
+
+        (id: "EOS Token", name: "EOS Token", code: "eos", type: "erc20", blockchainID: "ethereum-mainnet",
+         address: "0x86fa049857e0209aa7d9e616f7eb3b3b78ecfdb0", verified: true,
+         demoninations: [(name: "EOS_INTEGER",   code: "EOSI",  decimals:  0, symbol: "eosi"),
+                         (name: "EOS",           code: "EOS",   decimals: 18, symbol: "eos")]),
+
+        (id: "Ripple", name: "Ripple", code: "xrp", type: "native", blockchainID: "ripple-mainnet",
+         address: nil, verified: true,
+         demoninations: [(name: "drop", code: "drop", decimals: 0, symbol: "drop"),
+                         (name: "xrp",  code: "xrp",  decimals: 6, symbol: "xrp")]),
+
+        // Testnet
+        (id: "Bitcoin-Testnet", name: "Bitcoin", code: "btc", type: "native", blockchainID: "bitcoin-testnet",
+         address: nil, verified: true,
+         demoninations: [(name: "satoshi", code: "sat", decimals: 0, symbol: BlockChainDB.Model.lookupSymbol ("sat")),
+                         (name: "bitcoin", code: "btc", decimals: 8, symbol: BlockChainDB.Model.lookupSymbol ("btc"))]),
+
+        (id: "Bitcoin-Cash-Testnet", name: "Bitcoin Cash Test", code: "bch", type: "native", blockchainID: "bitcoin-cash-testnet",
+         address: nil, verified: true,
+         demoninations: [(name: "satoshi",           code: "sat", decimals: 0, symbol: BlockChainDB.Model.lookupSymbol ("sat")),
+                         (name: "bitcoin cash test", code: "bch", decimals: 8, symbol: BlockChainDB.Model.lookupSymbol ("bch"))]),
+
+        (id: "Ethereum-Testnet", name: "Ethereum", code: "eth", type: "native", blockchainID: "ethereum-ropsten",
+         address: nil, verified: true,
+         demoninations: [(name: "wei",   code: "wei",  decimals:  0, symbol: BlockChainDB.Model.lookupSymbol ("wei")),
+                         (name: "gwei",  code: "gwei", decimals:  9, symbol: BlockChainDB.Model.lookupSymbol ("gwei")),
+                         (name: "ether", code: "eth",  decimals: 18, symbol: BlockChainDB.Model.lookupSymbol ("eth"))]),
+
+        (id: "BRD Token Testnet", name: "BRD Token", code: "brd", type: "erc20", blockchainID: "ethereum-ropsten",
+         address: BlockChainDB.Model.addressBRDTestnet, verified: true,
+         demoninations: [(name: "BRD_INTEGER",   code: "BRDI",  decimals:  0, symbol: "brdi"),
+                         (name: "BRD",           code: "BRD",   decimals: 18, symbol: "brd")]),
+
+        (id: "Ripple", name: "Ripple", code: "xrp", type: "native", blockchainID: "ripple-testnet",
+         address: nil, verified: true,
+         demoninations: [(name: "drop", code: "drop", decimals: 0, symbol: "drop"),
+                         (name: "xrp",  code: "xrp",  decimals: 6, symbol: "xrp")]),
+    ]
+
+    ///
+    /// Address Scheme
+    ///
+
+    var supportedAddressSchemesMap: [String:[AddressScheme]] = [
+        "bitcoin-mainnet":      [.btcSegwit, .btcLegacy],
+        "bitcoin-cash-mainnet": [.btcLegacy],
+        "ethereum-mainnet":     [.ethDefault],
+        "ripple-mainnet":       [.genDefault],
+        "bitcoin-testnet":      [.btcSegwit, .btcLegacy],
+        "bitcoin-cash-testnet": [.btcLegacy],
+        "ethereum-ropsten":     [.ethDefault],
+        "ripple-testnet":       [.genDefault]
+    ]
+
+    var defaultAddressSchemeMap: [String:AddressScheme] = [
+        "bitcoin-mainnet":      .btcSegwit,
+        "bitcoin-cash-mainnet": .btcLegacy,
+        "ethereum-mainnet":     .ethDefault,
+        "ripple-mainnet":       .genDefault,
+        "bitcoin-testnet":      .btcSegwit,
+        "bitcoin-cash-testnet": .btcLegacy,
+        "ethereum-ropsten":     .ethDefault,
+        "ripple-testnet":       .genDefault
+    ]
+
     ///
     /// Return the AddressSchemes support for `network`
     ///
@@ -46,13 +158,7 @@ public final class System {
     /// - Returns: An array of AddressScheme
     ///
     public func supportedAddressSchemes (network: Network) -> [AddressScheme] {
-        switch network.currency.code {
-        case Currency.codeAsBTC: return [AddressScheme (core: CRYPTO_ADDRESS_SCHEME_BTC_SEGWIT),
-                                         AddressScheme (core: CRYPTO_ADDRESS_SCHEME_BTC_LEGACY)]
-        case Currency.codeAsBCH: return [AddressScheme (core: CRYPTO_ADDRESS_SCHEME_BTC_LEGACY)]
-        case Currency.codeAsETH: return [AddressScheme (core: CRYPTO_ADDRESS_SCHEME_ETH_DEFAULT)]
-        default: return [AddressScheme (core: CRYPTO_ADDRESS_SCHEME_GEN_DEFAULT)]
-        }
+        return supportedAddressSchemesMap[network.uids] ?? [.genDefault]
     }
 
     ///
@@ -76,15 +182,36 @@ public final class System {
     /// - Returns: The default AddressScheme
     ///
     public func defaultAddressScheme (network: Network) -> AddressScheme {
-        switch network.currency.code {
-        case Currency.codeAsBTC: return AddressScheme (core: CRYPTO_ADDRESS_SCHEME_BTC_SEGWIT)
-        case Currency.codeAsBCH: return AddressScheme (core: CRYPTO_ADDRESS_SCHEME_BTC_LEGACY)
-        case Currency.codeAsETH: return AddressScheme (core: CRYPTO_ADDRESS_SCHEME_ETH_DEFAULT)
-        default: return AddressScheme (core: CRYPTO_ADDRESS_SCHEME_GEN_DEFAULT)
-        }
+        return defaultAddressSchemeMap[network.uids] ?? .genDefault
     }
 
     ///
+    /// Wallet Manager Modes
+    ///
+
+    var supportedModesMap: [String:[WalletManagerMode]] = [
+        "bitcoin-mainnet":      [.p2p_only],
+        "bitcoin-cash-mainnet": [.p2p_only],
+        "ethereum-mainnet":     [.api_only, .api_with_p2p_submit, .p2p_only],
+//        "ripple-mainnet":       [],
+        "bitcoin-testnet":      [.p2p_only],
+        "bitcoin-cash-testnet": [.p2p_only],
+        "ethereum-ropsten":     [.api_only, .api_with_p2p_submit, .p2p_only],
+//        "ripple-testnet":       []
+    ]
+
+    var defaultModesMap: [String:WalletManagerMode] = [
+        "bitcoin-mainnet":      .p2p_only,
+        "bitcoin-cash-mainnet": .p2p_only,
+        "ethereum-mainnet":     .api_only,
+//        "ripple-mainnet":       [],
+        "bitcoin-testnet":      .p2p_only,
+        "bitcoin-cash-testnet": .p2p_only,
+        "ethereum-ropsten":     .api_only,
+//        "ripple-testnet":       []
+    ]
+
+
     /// Return the WalletManagerModes supported by `network`
     ///
     /// - Parameter network: the network
@@ -92,14 +219,7 @@ public final class System {
     /// - Returns: an aray of WalletManagerMode
     ///
     public func supportedModes (network: Network) -> [WalletManagerMode] {
-        switch network.currency.code {
-        case Currency.codeAsBTC: return [WalletManagerMode.api_only,
-                                         WalletManagerMode.p2p_only]
-        case Currency.codeAsBCH: return [WalletManagerMode.p2p_only]
-        case Currency.codeAsETH: return [WalletManagerMode.api_only,
-                                         WalletManagerMode.api_with_p2p_submit]
-        default: return [WalletManagerMode.api_only]
-        }
+        return supportedModesMap[network.uids] ?? [.api_only]
     }
 
     ///
@@ -123,12 +243,7 @@ public final class System {
     /// - Returns: the default mode
     ///
     public func defaultMode (network: Network) -> WalletManagerMode {
-        switch network.currency.code {
-        case Currency.codeAsBTC: return WalletManagerMode.p2p_only
-        case Currency.codeAsBCH: return WalletManagerMode.p2p_only
-        case Currency.codeAsETH: return WalletManagerMode.api_only
-        default: return WalletManagerMode.api_only
-        }
+        return defaultModesMap[network.uids] ?? .api_only
     }
 
     ///
@@ -325,6 +440,30 @@ public final class System {
         managers.forEach { $0.disconnect() }
     }
 
+    public func configureMergeBlockchains (builtin: [BlockChainDB.Model.Blockchain],
+                                           remote:  [BlockChainDB.Model.Blockchain]) -> [BlockChainDB.Model.Blockchain] {
+        // Both `builtin` and `remote` have a non-null blockHeight -> supported.
+
+        // For existing remotes:
+        remote.forEach { (blockchain: BlockChainDB.Model.Blockchain) in
+            // 1) api_only is a supported mode
+            let modes = supportedModesMap[blockchain.id]
+            supportedModesMap[blockchain.id] = (nil == modes
+                ? [.api_only]
+                : (modes!.contains (.api_only)
+                    ? modes!
+                    : ([.api_only] + modes!)))
+
+            // 2) api_only is a default mode if a default doesn't exist
+            if nil == defaultModesMap[blockchain.id] {
+                defaultModesMap[blockchain.id] = .api_only
+            }
+        }
+
+        // Merge builtin into remote
+        return remote.unionOf(builtin) { $0.id }
+    }
+
     ///
     /// Configure the system.  This will query various BRD services, notably the BlockChainDB, to
     /// establish the available networks (aka blockchains) and their currencies.  For each
@@ -353,22 +492,25 @@ public final class System {
 
         // query blockchains
         self.query.getBlockchains (mainnet: self.onMainnet) { (blockchainResult: Result<[BlockChainDB.Model.Blockchain],BlockChainDB.QueryError>) in
-            let blockChainModels = try! blockchainResult
-                // On success, always merge `defaultBlockchains`
-                .map { $0.unionOf (BlockChainDB.Model.defaultBlockchains) { $0.id } }
-                // On error, use defaultBlockchains
-                .recover { (error: BlockChainDB.QueryError) -> [BlockChainDB.Model.Blockchain] in
-                    return BlockChainDB.Model.defaultBlockchains
-                }.get()
+            // Filter our defaults to be `self.onMainnet` and supported (non-nil blockHeight)
+            let blockChainModelsDefaults = System.defaultBlockchains
+                .filter { $0.isMainnet == self.onMainnet && nil != $0.blockHeight }
 
-            blockChainModels
-                .filter { self.onMainnet == $0.isMainnet }
+            let blockChainModels = blockchainResult
+                // Only supported blockchains, but we'll merge in the defaults to handle
+                // blockchains not supported by BDB.
+                .map { $0.filter { nil != $0.blockHeight } }
+                // On error, return [] - we'll use defaults
+                .getWithRecovery { (ignore) in return [] }
+
+            self.configureMergeBlockchains (builtin: blockChainModelsDefaults,
+                                            remote: blockChainModels)
                 .forEach { (blockchainModel: BlockChainDB.Model.Blockchain) in
 
                     // query currencies
                     self.query.getCurrencies (blockchainId: blockchainModel.id) { (currencyResult: Result<[BlockChainDB.Model.Currency],BlockChainDB.QueryError>) in
                         // Find applicable defaults by `blockchainID`
-                        let defaults = BlockChainDB.Model.defaultCurrencies
+                        let defaults = System.defaultCurrencies
                             .filter { $0.blockchainID == blockchainModel.id }
 
                         let currencyModels = try! currencyResult
@@ -436,7 +578,7 @@ public final class System {
                                                name: blockchainModel.name,
                                                isMainnet: blockchainModel.isMainnet,
                                                currency: currency,
-                                               height: blockchainModel.blockHeight,
+                                               height: blockchainModel.blockHeight!,
                                                associations: associations,
                                                fees: fees)
 
@@ -818,7 +960,7 @@ extension System {
                 manager.query.getBlockchain (blockchainId: manager.network.uids) { (res: Result<BlockChainDB.Model.Blockchain, BlockChainDB.QueryError>) in
                     defer { cryptoWalletManagerGive (cwm!) }
                     res.resolve (
-                        success: { cwmAnnounceGetBlockNumberSuccessAsInteger (manager.core, sid, $0.blockHeight) },
+                        success: { cwmAnnounceGetBlockNumberSuccessAsInteger (manager.core, sid, $0.blockHeight!) },
                         failure: { (_) in cwmAnnounceGetBlockNumberFailure (manager.core, sid) })
                 }},
 
@@ -1172,7 +1314,7 @@ extension System {
                     (res: Result<BlockChainDB.Model.Blockchain, BlockChainDB.QueryError>) in
                     defer { cryptoWalletManagerGive(cwm) }
                     res.resolve (
-                        success: { cwmAnnounceGetBlockNumberSuccessAsInteger (cwm, sid, $0.blockHeight) },
+                        success: { cwmAnnounceGetBlockNumberSuccessAsInteger (cwm, sid, $0.blockHeight!) },
                         failure: { (_) in cwmAnnounceGetBlockNumberFailure (cwm, sid) })
                 }},
 

--- a/Swift/BRCrypto/common/BRBlockChainDB.swift
+++ b/Swift/BRCrypto/common/BRBlockChainDB.swift
@@ -232,7 +232,7 @@ public class BlockChainDB {
             network: String,
             isMainnet: Bool,
             currency: String,
-            blockHeight: UInt64,
+            blockHeight: UInt64?,
             feeEstimates: [BlockchainFee])
 
         static internal func asBlockchainFee (json: JSON) -> Model.BlockchainFee? {
@@ -251,7 +251,7 @@ public class BlockChainDB {
                 let network = json.asString (name: "network"),
                 let isMainnet = json.asBool (name: "is_mainnet"),
                 let currency = json.asString (name: "native_currency_id"),
-                let blockHeight = json.asUInt64 (name: "block_height")
+                let blockHeight = json.asInt64 (name: "block_height")
                 else { return nil }
 
             guard let feeEstimates = json.asArray(name: "fee_estimates")?
@@ -260,33 +260,10 @@ public class BlockChainDB {
             else { return nil }
 
             return (id: id, name: name, network: network, isMainnet: isMainnet, currency: currency,
-                    blockHeight: blockHeight,
+                    blockHeight: (-1 == blockHeight ? nil : UInt64 (blockHeight)),
                     feeEstimates: feeEstimates)
         }
 
-        /// We define default blockchains but these are wholly insufficient given that the
-        /// specfication includes `blockHeight` (which can never be correct).
-        static public let defaultBlockchains: [Blockchain] = [
-            // Mainnet
-            (id: "bitcoin-mainnet",       name: "Bitcoin",       network: "mainnet", isMainnet: true,  currency: "btc", blockHeight:  654321,
-             feeEstimates: [(amount: "30", tier: "10m", confirmationTimeInMilliseconds: 10 * 60 * 1000)]),
-            (id: "bitcoin-cash-mainnet",  name: "Bitcoin Cash",  network: "mainnet", isMainnet: true,  currency: "bch", blockHeight: 1000000,
-             feeEstimates: [(amount: "30", tier: "10m", confirmationTimeInMilliseconds: 10 * 60 * 1000)]),
-            (id: "ethereum-mainnet",      name: "Ethereum",      network: "mainnet", isMainnet: true,  currency: "eth", blockHeight: 8000000,
-             feeEstimates: [(amount: "2000000000", tier: "1m", confirmationTimeInMilliseconds: 1 * 60 * 1000)]),
-            (id: "ripple-mainnet",        name: "Ripple",        network: "mainnet", isMainnet: true,  currency: "xrp", blockHeight: 5000000,
-            feeEstimates: [(amount: "20", tier: "1m", confirmationTimeInMilliseconds: 1 * 60 * 1000)]),
-
-            // Testnet
-            (id: "bitcoin-testnet",       name: "Bitcoin Test",      network: "testnet", isMainnet: false, currency: "btc", blockHeight:  900000,
-             feeEstimates: [(amount: "30", tier: "10m", confirmationTimeInMilliseconds: 10 * 60 * 1000)]),
-            (id: "bitcoin-cash-testnet",  name: "Bitcoin Cash Test", network: "testnet", isMainnet: false, currency: "bch", blockHeight: 1200000,
-             feeEstimates: [(amount: "30", tier: "10m", confirmationTimeInMilliseconds: 10 * 60 * 1000)]),
-            (id: "ethereum-testnet",      name: "Ethereum Testnet",  network: "testnet", isMainnet: false, currency: "eth", blockHeight: 1000000,
-             feeEstimates: [(amount: "2000000000", tier: "1m", confirmationTimeInMilliseconds: 1 * 60 * 1000)]),
-            (id: "ripple-testnet",        name: "Ripple Testnet",    network: "testnet", isMainnet: false, currency: "xrp", blockHeight: 25000,
-             feeEstimates: [(amount: "20", tier: "1m", confirmationTimeInMilliseconds: 1 * 60 * 1000)]),
-        ]
 
         /// Currency & CurrencyDenomination
 
@@ -344,68 +321,6 @@ public class BlockChainDB {
                     verified: verified,
                     demoninations: demoninations)
         }
-
-        static public let defaultCurrencies: [Currency] = [
-
-            // Mainnet
-            (id: "Bitcoin", name: "Bitcoin", code: "btc", type: "native", blockchainID: "bitcoin-mainnet",
-             address: nil, verified: true,
-             demoninations: [(name: "satoshi", code: "sat", decimals: 0, symbol: lookupSymbol ("sat")),
-                             (name: "bitcoin", code: "btc", decimals: 8, symbol: lookupSymbol ("btc"))]),
-
-            (id: "Bitcoin-Cash", name: "Bitcoin Cash", code: "bch", type: "native", blockchainID: "bitcoin-cash-mainnet",
-             address: nil, verified: true,
-             demoninations: [(name: "satoshi",      code: "sat", decimals: 0, symbol: lookupSymbol ("sat")),
-                             (name: "bitcoin cash", code: "bch", decimals: 8, symbol: lookupSymbol ("bch"))]),
-
-            (id: "Ethereum", name: "Ethereum", code: "eth", type: "native", blockchainID: "ethereum-mainnet",
-             address: nil, verified: true,
-             demoninations: [(name: "wei",   code: "wei",  decimals:  0, symbol: lookupSymbol ("wei")),
-                             (name: "gwei",  code: "gwei", decimals:  9, symbol: lookupSymbol ("gwei")),
-                             (name: "ether", code: "eth",  decimals: 18, symbol: lookupSymbol ("eth"))]),
-
-            (id: "BRD Token", name: "BRD Token", code: "brd", type: "erc20", blockchainID: "ethereum-mainnet",
-             address: addressBRDMainnet, verified: true,
-             demoninations: [(name: "BRD_INTEGER",   code: "BRDI",  decimals:  0, symbol: "brdi"),
-                             (name: "BRD",           code: "BRD",   decimals: 18, symbol: "brd")]),
-
-            (id: "EOS Token", name: "EOS Token", code: "eos", type: "erc20", blockchainID: "ethereum-mainnet",
-             address: "0x86fa049857e0209aa7d9e616f7eb3b3b78ecfdb0", verified: true,
-             demoninations: [(name: "EOS_INTEGER",   code: "EOSI",  decimals:  0, symbol: "eosi"),
-                             (name: "EOS",           code: "EOS",   decimals: 18, symbol: "eos")]),
-
-            (id: "Ripple", name: "Ripple", code: "xrp", type: "native", blockchainID: "ripple-mainnet",
-             address: nil, verified: true,
-             demoninations: [(name: "drop", code: "drop", decimals: 0, symbol: "drop"),
-                             (name: "xrp",  code: "xrp",  decimals: 6, symbol: "xrp")]),
-
-            // Testnet
-            (id: "Bitcoin-Testnet", name: "Bitcoin", code: "btc", type: "native", blockchainID: "bitcoin-testnet",
-             address: nil, verified: true,
-             demoninations: [(name: "satoshi", code: "sat", decimals: 0, symbol: lookupSymbol ("sat")),
-                             (name: "bitcoin", code: "btc", decimals: 8, symbol: lookupSymbol ("btc"))]),
-
-            (id: "Bitcoin-Cash-Testnet", name: "Bitcoin Cash Test", code: "bch", type: "native", blockchainID: "bitcoin-cash-testnet",
-             address: nil, verified: true,
-             demoninations: [(name: "satoshi",           code: "sat", decimals: 0, symbol: lookupSymbol ("sat")),
-                             (name: "bitcoin cash test", code: "bch", decimals: 8, symbol: lookupSymbol ("bch"))]),
-
-            (id: "Ethereum-Testnet", name: "Ethereum", code: "eth", type: "native", blockchainID: "ethereum-testnet",
-             address: nil, verified: true,
-             demoninations: [(name: "wei",   code: "wei",  decimals:  0, symbol: lookupSymbol ("wei")),
-                             (name: "gwei",  code: "gwei", decimals:  9, symbol: lookupSymbol ("gwei")),
-                             (name: "ether", code: "eth",  decimals: 18, symbol: lookupSymbol ("eth"))]),
-
-            (id: "BRD Token Testnet", name: "BRD Token", code: "brd", type: "erc20", blockchainID: "ethereum-testnet",
-             address: addressBRDTestnet, verified: true,
-             demoninations: [(name: "BRD_INTEGER",   code: "BRDI",  decimals:  0, symbol: "brdi"),
-                             (name: "BRD",           code: "BRD",   decimals: 18, symbol: "brd")]),
-
-            (id: "Ripple", name: "Ripple", code: "xrp", type: "native", blockchainID: "ripple-testnet",
-             address: nil, verified: true,
-             demoninations: [(name: "drop", code: "drop", decimals: 0, symbol: "drop"),
-                             (name: "xrp",  code: "xrp",  decimals: 6, symbol: "xrp")]),
-       ]
 
         static internal let addressBRDTestnet = "0x7108ca7c4718efa810457f228305c9c71390931a" // testnet
         static internal let addressBRDMainnet = "0x558ec3152e2eb2174905cd19aea4e34a23de9ad6" // mainnet
@@ -1456,6 +1371,11 @@ public class BlockChainDB {
             return dict[name] as? Bool
         }
 
+        internal func asInt64 (name: String) -> Int64? {
+            return (dict[name] as? NSNumber)
+                .flatMap { Int64 (exactly: $0)}
+        }
+
         internal func asUInt64 (name: String) -> UInt64? {
             return (dict[name] as? NSNumber)
                 .flatMap { UInt64 (exactly: $0)}
@@ -1486,6 +1406,10 @@ public class BlockChainDB {
 
         internal func asStringArray (name: String) -> [String]? {
             return dict[name] as? [String]
+        }
+
+        internal func asJSON (name: String) -> JSON? {
+            return asDict(name: name).map { JSON (dict: $0) }
         }
     }
 

--- a/Swift/BRCrypto/common/BRSupport.swift
+++ b/Swift/BRCrypto/common/BRSupport.swift
@@ -172,6 +172,13 @@ extension Result {
         case let .failure (error): failure(error)
         }
     }
+
+    public func getWithRecovery (_ transform: (Failure) -> Success) -> Success {
+        switch self {
+        case let .success(success): return success
+        case let .failure(failure): return transform (failure)
+        }
+    }
 }
 
 extension Array {

--- a/Swift/BRCryptoDemo/SummaryViewController.swift
+++ b/Swift/BRCryptoDemo/SummaryViewController.swift
@@ -167,8 +167,9 @@ class SummaryViewController: UITableViewController, WalletListener {
             case .balanceUpdated:
                 if let index = self.wallets.firstIndex (of: wallet) {
                     let path = IndexPath (row: index, section: 0)
-                    let cell = self.tableView.cellForRow(at: path) as! WalletTableViewCell
-                    cell.updateView ()
+                    if let cell = self.tableView.cellForRow(at: path) as? WalletTableViewCell {
+                        cell.updateView ()
+                    }
                 }
 
             case .deleted:


### PR DESCRIPTION
Java changes pending.  Note: in the blockchain+currencies declarations 'ethereum-testnet' changed to 'ethereum-ropsten' to be consistent with BDB.