### PR TITLE
CORE-510: Process BDB 'next:href' links

### DIFF
--- a/Swift/BRCrypto/common/BRBlockChainDB.swift
+++ b/Swift/BRCrypto/common/BRBlockChainDB.swift
@@ -961,10 +961,9 @@ public class BlockChainDB {
                         switch res {
                         case .success: completion (Result.success(()))
                         case .failure(let error):
-                            // Consider 301 or 404 errors as success - owing to a 'quirk' in
-                            // transaction submission.
+                            // Consider 302 or 404 errors as success - owing to a 'quirk'
                             if case let QueryError.response (status) = error,
-                                (302 == status || 404 == status) {
+                                (201 == status || 302 == status || 404 == status) {
                                 completion (Result.success(()))
                             }
                             else {


### PR DESCRIPTION
Previously, bdbMakeRequest() passed a 'more:Bool' flag to the completion handler; now it passes a 'more:URL?' to indicate if more data remains and the URL should be hit.