### PR TITLE
CORE-531: Produce a SystemEvent When All Networks are Discovered

### DIFF
--- a/Java/CoreCrypto/src/main/java/com/breadwallet/corecrypto/NetworkDiscovery.java
+++ b/Java/CoreCrypto/src/main/java/com/breadwallet/corecrypto/NetworkDiscovery.java
@@ -39,26 +39,22 @@ final class NetworkDiscovery {
 
     /* package */
     interface Callback {
-        void discovered(List<Network> networks,
-                        ImmutableMultimap<String, WalletManagerMode> updatedSupportedModes,
-                        ImmutableMap<String, WalletManagerMode> updatedDefaultModes);
+        void update(ImmutableMultimap<String, WalletManagerMode> updatedSupportedModes,
+                    ImmutableMap<String, WalletManagerMode> updatedDefaultModes);
+        void discovered(Network network);
+        void complete(List<com.breadwallet.crypto.Network> networks);
     }
 
     /* package */
     static void discoverNetworks(BlockchainDb query,
                                  boolean isMainnet,
+                                 List<com.breadwallet.crypto.blockchaindb.models.bdb.Currency> appCurrencies,
                                  ImmutableMultimap<String, WalletManagerMode> supportedModes,
                                  ImmutableMap<String, WalletManagerMode> defaultModes,
                                  Callback callback) {
-        List<Network> networks = new ArrayList<>();
+        List<com.breadwallet.crypto.Network> networks = new ArrayList<>();
 
-        ImmutableMultimap.Builder<String, WalletManagerMode> supportedModesBuilder = new ImmutableMultimap.Builder<>();
-        supportedModesBuilder.putAll(supportedModes);
-
-        ImmutableMap.Builder<String, WalletManagerMode> defaultModesBuilder = new ImmutableMap.Builder<>();
-        defaultModesBuilder.putAll(defaultModes);
-
-        CountUpAndDownLatch latch = new CountUpAndDownLatch(() -> callback.discovered(networks, supportedModesBuilder.build(), defaultModesBuilder.build()));
+        CountUpAndDownLatch latch = new CountUpAndDownLatch(() -> callback.complete(networks));
 
         getBlockChains(latch, query, isMainnet, blockchainModels -> {
             // Filter our defaults to be `self.onMainnet` and supported (non-nil blockHeight)
@@ -70,15 +66,24 @@ final class NetworkDiscovery {
             }
 
             blockchainModels = filterBlockchains(supportedBlockchains, blockchainModels);
-            updateSupportedModes(blockchainModels, supportedModes, supportedModesBuilder);
-            updateDefaultModes(blockchainModels, defaultModes, defaultModesBuilder);
+            ImmutableMultimap<String, WalletManagerMode> updatedSupportedModes = getUpdateSupportedModes(blockchainModels, supportedModes);
+            ImmutableMap<String, WalletManagerMode> updatedDefaultModes = getUpdatedDefaultModes(blockchainModels, defaultModes);
             blockchainModels = mergeBlockchains(supportedBlockchains, blockchainModels);
+
+            callback.update(updatedSupportedModes, updatedDefaultModes);
 
             for (Blockchain blockchainModel : blockchainModels) {
                 String blockchainModelId = blockchainModel.getId();
 
                 @SuppressWarnings("OptionalGetWithoutIsPresent")
                 UnsignedLong blockHeight = blockchainModel.getBlockHeight().get();
+
+                final List<com.breadwallet.crypto.blockchaindb.models.bdb.Currency> applicationCurrencies = new ArrayList<>();
+                for (com.breadwallet.crypto.blockchaindb.models.bdb.Currency currency: appCurrencies) {
+                    if (currency.getBlockchainId().equals(blockchainModelId)) {
+                        applicationCurrencies .add(currency);
+                    }
+                }
 
                 final List<com.breadwallet.crypto.blockchaindb.models.bdb.Currency> defaultCurrencies = new ArrayList<>();
                 for (com.breadwallet.crypto.blockchaindb.models.bdb.Currency currency: System.DEFAULT_CURRENCIES) {
@@ -89,7 +94,7 @@ final class NetworkDiscovery {
 
                 Map<Currency, NetworkAssociation> associations = new HashMap<>();
 
-                getCurrencies(latch, query, blockchainModelId, defaultCurrencies, currencyModels -> {
+                getCurrencies(latch, query, blockchainModelId, applicationCurrencies, defaultCurrencies, currencyModels -> {
                     for (com.breadwallet.crypto.blockchaindb.models.bdb.Currency currencyModel : currencyModels) {
                         Currency currency = Currency.create(
                                 currencyModel.getId(),
@@ -142,7 +147,8 @@ final class NetworkDiscovery {
                         return null;
                     }
 
-                    networks.add(Network.create(
+                    // define the network
+                    Network network = Network.create(
                             blockchainModel.getId(),
                             blockchainModel.getName(),
                             blockchainModel.isMainnet(),
@@ -150,7 +156,14 @@ final class NetworkDiscovery {
                             blockHeight,
                             associations,
                             fees,
-                            blockchainModel.getConfirmationsUntilFinal()));
+                            blockchainModel.getConfirmationsUntilFinal()
+                    );
+
+                    // Announce the network
+                    callback.discovered(network);
+
+                    // Keep a running total of discovered networks
+                    networks.add(network);
 
                     return null;
                 });
@@ -194,29 +207,37 @@ final class NetworkDiscovery {
         return mergedMap.values();
     }
 
-    private static void updateSupportedModes(Collection<Blockchain> remotes,
-                                             ImmutableMultimap<String, WalletManagerMode> supportedModes,
-                                             ImmutableMultimap.Builder<String, WalletManagerMode> supportedModesBuilder) {
+    private static ImmutableMultimap<String, WalletManagerMode> getUpdateSupportedModes(Collection<Blockchain> remotes,
+                                                                                        ImmutableMultimap<String, WalletManagerMode> supportedModes) {
+        ImmutableMultimap.Builder<String, WalletManagerMode> builder = new ImmutableMultimap.Builder<>();
+        builder.putAll(supportedModes);
+
         for (Blockchain b: remotes) {
             Collection<WalletManagerMode> modes = supportedModes.get(b.getId());
             if (null == modes || modes.isEmpty()) {
-                supportedModesBuilder.put(b.getId(), WalletManagerMode.API_ONLY);
+                builder.put(b.getId(), WalletManagerMode.API_ONLY);
 
             } else if (!modes.contains(WalletManagerMode.API_ONLY)) {
-                supportedModesBuilder.put(b.getId(), WalletManagerMode.API_ONLY);
+                builder.put(b.getId(), WalletManagerMode.API_ONLY);
             }
         }
+
+        return builder.build();
     }
 
-    private static void updateDefaultModes(Collection<Blockchain> remotes,
-                                           ImmutableMap<String, WalletManagerMode> defaultModes,
-                                           ImmutableMap.Builder<String, WalletManagerMode> defaultModesBuilder) {
+    private static ImmutableMap<String, WalletManagerMode> getUpdatedDefaultModes(Collection<Blockchain> remotes,
+                                                                                  ImmutableMap<String, WalletManagerMode> defaultModes) {
+        ImmutableMap.Builder<String, WalletManagerMode> builder = new ImmutableMap.Builder<>();
+        builder.putAll(defaultModes);
+
         for (Blockchain b: remotes) {
             WalletManagerMode mode = defaultModes.get(b.getId());
             if (null == mode) {
-                defaultModesBuilder.put(b.getId(), WalletManagerMode.API_ONLY);
+                builder.put(b.getId(), WalletManagerMode.API_ONLY);
             }
         }
+
+        return builder.build();
     }
 
     private static void getBlockChains(CountUpAndDownLatch latch,
@@ -254,20 +275,24 @@ final class NetworkDiscovery {
     private static void getCurrencies(CountUpAndDownLatch latch,
                                       BlockchainDb query,
                                       String blockchainId,
+                                      Collection<com.breadwallet.crypto.blockchaindb.models.bdb.Currency> applicationCurrencies,
                                       Collection<com.breadwallet.crypto.blockchaindb.models.bdb.Currency> defaultCurrencies,
                                       Function<Collection<com.breadwallet.crypto.blockchaindb.models.bdb.Currency>, Void> func) {
-        Map<String, com.breadwallet.crypto.blockchaindb.models.bdb.Currency> merged = new HashMap<>();
-        for (com.breadwallet.crypto.blockchaindb.models.bdb.Currency currency : defaultCurrencies) {
-            if (currency.getBlockchainId().equals(blockchainId) && currency.getVerified()) {
-                merged.put(currency.getId(), currency);
-            }
-        }
-
         latch.countUp();
         query.getCurrencies(blockchainId, new CompletionHandler<List<com.breadwallet.crypto.blockchaindb.models.bdb.Currency>, QueryError>() {
             @Override
             public void handleData(List<com.breadwallet.crypto.blockchaindb.models.bdb.Currency> newCurrencies) {
                 try {
+                    // On success, always merge `default` INTO the result.  We merge defaultUnit
+                    // into `result` to always bias to the blockchainDB result.
+
+                    Map<String, com.breadwallet.crypto.blockchaindb.models.bdb.Currency> merged = new HashMap<>();
+                    for (com.breadwallet.crypto.blockchaindb.models.bdb.Currency currency : defaultCurrencies) {
+                        if (currency.getBlockchainId().equals(blockchainId) && currency.getVerified()) {
+                            merged.put(currency.getId(), currency);
+                        }
+                    }
+
                     for (com.breadwallet.crypto.blockchaindb.models.bdb.Currency currency : newCurrencies) {
                         if (currency.getBlockchainId().equals(blockchainId) && currency.getVerified()) {
                             merged.put(currency.getId(), currency);
@@ -283,6 +308,22 @@ final class NetworkDiscovery {
             @Override
             public void handleError(QueryError error) {
                 try {
+                    // On error, use `apps` merged INTO defaults.  We merge into `defaults` to ensure that we get
+                    // BTC, BCH, ETH, BRD and that they are correct (don't rely on the App).
+
+                    Map<String, com.breadwallet.crypto.blockchaindb.models.bdb.Currency> merged = new HashMap<>();
+                    for (com.breadwallet.crypto.blockchaindb.models.bdb.Currency currency : applicationCurrencies) {
+                        if (currency.getBlockchainId().equals(blockchainId) && currency.getVerified()) {
+                            merged.put(currency.getId(), currency);
+                        }
+                    }
+
+                    for (com.breadwallet.crypto.blockchaindb.models.bdb.Currency currency : defaultCurrencies) {
+                        if (currency.getBlockchainId().equals(blockchainId) && currency.getVerified()) {
+                            merged.put(currency.getId(), currency);
+                        }
+                    }
+
                     func.apply(merged.values());
                 } finally {
                     latch.countDown();

--- a/Java/Crypto/src/main/java/com/breadwallet/crypto/System.java
+++ b/Java/Crypto/src/main/java/com/breadwallet/crypto/System.java
@@ -10,6 +10,7 @@
 package com.breadwallet.crypto;
 
 import com.breadwallet.crypto.blockchaindb.BlockchainDb;
+import com.breadwallet.crypto.blockchaindb.models.bdb.Currency;
 import com.breadwallet.crypto.events.system.SystemListener;
 
 import java.util.List;
@@ -21,7 +22,7 @@ public interface System {
         return CryptoApi.getProvider().systemProvider().create(executor, listener, account, isMainnet,path, query);
     }
 
-    void configure();
+    void configure(List<Currency> appCurrencies);
 
     void createWalletManager(Network network, WalletManagerMode mode, AddressScheme addressScheme);
 

--- a/Java/Crypto/src/main/java/com/breadwallet/crypto/events/system/DefaultSystemEventVisitor.java
+++ b/Java/Crypto/src/main/java/com/breadwallet/crypto/events/system/DefaultSystemEventVisitor.java
@@ -25,4 +25,9 @@ public abstract class DefaultSystemEventVisitor<T> implements SystemEventVisitor
     public T visit(SystemNetworkAddedEvent event) {
         return null;
     }
+
+    @Nullable
+    public T visit(SystemDiscoveredNetworksEvent event) {
+        return null;
+    }
 }

--- a/Java/Crypto/src/main/java/com/breadwallet/crypto/events/system/SystemDiscoveredNetworksEvent.java
+++ b/Java/Crypto/src/main/java/com/breadwallet/crypto/events/system/SystemDiscoveredNetworksEvent.java
@@ -1,0 +1,24 @@
+package com.breadwallet.crypto.events.system;
+
+import com.breadwallet.crypto.Network;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public final class SystemDiscoveredNetworksEvent implements SystemEvent {
+
+    private final List<Network> networks;
+
+    public SystemDiscoveredNetworksEvent(List<Network> networks) {
+        this.networks = new ArrayList<>(networks);
+    }
+
+    public List<Network> getNetworks() {
+        return new ArrayList<>(networks);
+    }
+
+    @Override
+    public <T> T accept(SystemEventVisitor<T> visitor) {
+        return visitor.visit(this);
+    }
+}

--- a/Java/Crypto/src/main/java/com/breadwallet/crypto/events/system/SystemEventVisitor.java
+++ b/Java/Crypto/src/main/java/com/breadwallet/crypto/events/system/SystemEventVisitor.java
@@ -14,4 +14,6 @@ public interface SystemEventVisitor<T> {
     T visit(SystemManagerAddedEvent event);
 
     T visit(SystemNetworkAddedEvent event);
+
+    T visit(SystemDiscoveredNetworksEvent event);
 }

--- a/Java/CryptoDemo/src/main/java/com/breadwallet/cryptodemo/CoreCryptoApplication.java
+++ b/Java/CryptoDemo/src/main/java/com/breadwallet/cryptodemo/CoreCryptoApplication.java
@@ -17,6 +17,7 @@ import com.breadwallet.crypto.System;
 import java.io.File;
 import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.Date;
 import java.util.List;
 import java.util.UUID;
@@ -82,7 +83,7 @@ public class CoreCryptoApplication extends Application {
 
             CryptoApi.initialize(CryptoApiProvider.getInstance());
 
-            List<String> currencyCodesNeeded = Arrays.asList("btc", "eth", "brd");
+            List<String> currencyCodesNeeded = Arrays.asList("btc", "eth", "bch");
             systemListener = new DispatchingSystemListener();
             systemListener.addSystemListener(new CoreSystemListener(mode, isMainnet, currencyCodesNeeded));
 
@@ -91,7 +92,7 @@ public class CoreCryptoApplication extends Application {
 
             blockchainDb = BlockchainDb.createForTest (new OkHttpClient(), BDB_BASE_URL, BDB_AUTH_TOKEN, API_BASE_URL);
             system = System.create(Executors.newSingleThreadScheduledExecutor(), systemListener, account, isMainnet, storageFile.getAbsolutePath(), blockchainDb);
-            system.configure();
+            system.configure(Collections.emptyList());
         }
     }
 
@@ -108,7 +109,7 @@ public class CoreCryptoApplication extends Application {
                 isMainnet,
                 CoreCryptoApplication.system.getPath(),
                 blockchainDb);
-        CoreCryptoApplication.system.configure();
+        CoreCryptoApplication.system.configure(Collections.emptyList());
     }
 
     public static DispatchingSystemListener getDispatchingSystemListener() {

--- a/Java/CryptoDemo/src/main/java/com/breadwallet/cryptodemo/CoreSystemListener.java
+++ b/Java/CryptoDemo/src/main/java/com/breadwallet/cryptodemo/CoreSystemListener.java
@@ -13,26 +13,20 @@ import com.breadwallet.crypto.WalletManager;
 import com.breadwallet.crypto.WalletManagerMode;
 import com.breadwallet.crypto.events.network.NetworkEvent;
 import com.breadwallet.crypto.events.system.DefaultSystemEventVisitor;
+import com.breadwallet.crypto.events.system.SystemDiscoveredNetworksEvent;
 import com.breadwallet.crypto.events.system.SystemEvent;
 import com.breadwallet.crypto.events.system.SystemListener;
 import com.breadwallet.crypto.events.system.SystemManagerAddedEvent;
 import com.breadwallet.crypto.events.system.SystemNetworkAddedEvent;
 import com.breadwallet.crypto.events.transfer.TranferEvent;
-import com.breadwallet.crypto.events.transfer.TransferListener;
 import com.breadwallet.crypto.events.wallet.DefaultWalletEventVisitor;
 import com.breadwallet.crypto.events.wallet.WalletCreatedEvent;
 import com.breadwallet.crypto.events.wallet.WalletEvent;
-import com.breadwallet.crypto.events.wallet.WalletListener;
 import com.breadwallet.crypto.events.walletmanager.WalletManagerEvent;
-import com.breadwallet.crypto.events.walletmanager.WalletManagerListener;
 import com.google.common.base.Optional;
 
 import java.util.ArrayList;
-import java.util.Collections;
-import java.util.HashSet;
 import java.util.List;
-import java.util.Set;
-import java.util.WeakHashMap;
 
 public class CoreSystemListener implements SystemListener {
 
@@ -80,6 +74,18 @@ public class CoreSystemListener implements SystemListener {
 
                     AddressScheme addressScheme = system.getDefaultAddressScheme(network);
                     system.createWalletManager(event.getNetwork(), wmMode, addressScheme);
+                }
+                return null;
+            }
+
+            @Nullable
+            @Override
+            public Void visit(SystemDiscoveredNetworksEvent event) {
+                Log.d(TAG, String.format("Currencies (Discovered): %s", event));
+                for (Network network: event.getNetworks()) {
+                    for (Currency currency: network.getCurrencies()) {
+                        Log.d(TAG, String.format("    Currency: %s for %s", currency.getCode(), network.getName()));
+                    }
                 }
                 return null;
             }

--- a/Swift/BRCrypto/BRCryptoSystem.swift
+++ b/Swift/BRCrypto/BRCryptoSystem.swift
@@ -585,12 +585,17 @@ public final class System {
                         // save the network
                         self.networks.append (network)
 
-                        // Invoke callbacks.
+                        // Announce NetworkEvent.created...
                         self.listener?.handleNetworkEvent (system: self, network: network, event: NetworkEvent.created)
+
+                        // Announce SystemEvent.networkAdded - this will likely be handled with
+                        // system.createWalletManager(network:...) which will then announce
+                        // numerous events as wallets are created.
                         self.listener?.handleSystemEvent  (system: self, event: SystemEvent.networkAdded(network: network))
                     }
             }
         }
+        self.listener?.handleSystemEvent(system: self, event: SystemEvent.configured)
     }
 
     //
@@ -663,6 +668,9 @@ public enum SystemEvent {
     case created
     case networkAdded (network: Network)
     case managerAdded (manager: WalletManager)
+
+    /// Invoked possibly multiple times - each time System.configure() completes.
+    case configured
 }
 
 ///
@@ -734,6 +742,7 @@ public final class SystemCallbackCoordinator {
 
 extension System {
     internal var cryptoListener: BRCryptoCWMListener {
+        // These methods are invoked direclty on a BWM, EWM, or GWM thread.
         return BRCryptoCWMListener (
             context: systemContext,
 

--- a/Swift/BRCryptoDemo/CoreDemoAppDelegate.swift
+++ b/Swift/BRCryptoDemo/CoreDemoAppDelegate.swift
@@ -125,7 +125,7 @@ class CoreDemoAppDelegate: UIResponder, UIApplicationDelegate, UISplitViewContro
         let subscription = BlockChainDB.Subscription (id: subscriptionId, endpoint: nil);
         self.system.subscribe (using: subscription)
 
-        self.system.configure()
+        self.system.configure(withCurrencyModels: [])
 
         return true
     }
@@ -211,7 +211,7 @@ extension UIApplication {
         
         // Assign and then configure the new system
         app.system = system
-        app.system.configure()
+        app.system.configure(withCurrencyModels: [])
     }
 }
 

--- a/Swift/BRCryptoDemo/CoreDemoListener.swift
+++ b/Swift/BRCryptoDemo/CoreDemoListener.swift
@@ -109,6 +109,8 @@ class CoreDemoListener: SystemListener {
             //TODO: Don't connect here. connect on touch...
             manager.connect()
 
+        case .configured:
+            break;
         }
     }
 

--- a/Swift/BRCryptoDemo/CoreDemoListener.swift
+++ b/Swift/BRCryptoDemo/CoreDemoListener.swift
@@ -109,9 +109,9 @@ class CoreDemoListener: SystemListener {
             //TODO: Don't connect here. connect on touch...
             manager.connect()
 
-        case .configured:
-            let allCurrencies = system.networks.flatMap { $0.currencies }
-            print ("APP: System: Currencies: ")
+        case .discoveredNetworks (let networks):
+            let allCurrencies = networks.flatMap { $0.currencies }
+            print ("APP: System: Currencies (Added): ")
             allCurrencies.forEach { print ("APP: System:    \($0.code)") }
         }
     }

--- a/Swift/BRCryptoDemo/CoreDemoListener.swift
+++ b/Swift/BRCryptoDemo/CoreDemoListener.swift
@@ -110,7 +110,9 @@ class CoreDemoListener: SystemListener {
             manager.connect()
 
         case .configured:
-            break;
+            let allCurrencies = system.networks.flatMap { $0.currencies }
+            print ("APP: System: Currencies: ")
+            allCurrencies.forEach { print ("APP: System:    \($0.code)") }
         }
     }
 

--- a/Swift/BRCryptoTests/BRCryptoBaseTests.swift
+++ b/Swift/BRCryptoTests/BRCryptoBaseTests.swift
@@ -303,6 +303,8 @@ class BRCryptoSystemBaseTests: BRCryptoBaseTests {
     var currencyCodesNeeded = ["btc"]
     var modeMap = ["btc":WalletManagerMode.api_only]
 
+    var currencyModels: [BlockChainDB.Model.Currency] = []
+
     func createDefaultListener() -> CryptoTestSystemListener {
         return CryptoTestSystemListener (currencyCodesNeeded: currencyCodesNeeded, isMainnet: isMainnet, modeMap: modeMap)
     }
@@ -326,7 +328,7 @@ class BRCryptoSystemBaseTests: BRCryptoBaseTests {
         XCTAssertTrue  (self.query === system.query)
         XCTAssertEqual (account.uids, system.account.uids)
 
-        system.configure() // Don't connect
+        system.configure(withCurrencyModels: currencyModels) // Don't connect
         wait (for: [self.listener.networkExpectation], timeout: 5)
         wait (for: [self.listener.managerExpectation], timeout: 5)
         wait (for: [self.listener.walletExpectation ], timeout: 5)

--- a/Swift/BRCryptoTests/BRCryptoWalletManagerTests.swift
+++ b/Swift/BRCryptoTests/BRCryptoWalletManagerTests.swift
@@ -279,7 +279,7 @@ class BRCryptoWalletManagerTests: BRCryptoSystemBaseTests {
 
         // transfers annonced on `configure`
         migrateListener.transferCount = transferBlobs.count
-        migrateSystem.configure()
+        migrateSystem.configure(withCurrencyModels: [])
         wait (for: [migrateListener.migratedManagerExpectation], timeout: 30)
         wait (for: [migrateListener.transferExpectation], timeout: 30)
         XCTAssertFalse (migrateListener.migratedFailed)
@@ -306,7 +306,7 @@ class BRCryptoWalletManagerTests: BRCryptoSystemBaseTests {
                                     query: muckedQuery)
 
         // transfers annonced on `configure`
-        muckedSystem.configure()
+        muckedSystem.configure(withCurrencyModels: [])
         wait (for: [muckedListener.migratedManagerExpectation], timeout: 30)
         XCTAssertTrue (muckedListener.migratedFailed)
     }
@@ -358,6 +358,8 @@ class MigrateSystemListener: SystemListener {
                 migratedManager = manager
                 migratedManagerExpectation.fulfill()
             }
+        case .configured:
+            break
         }
     }
 

--- a/Swift/BRCryptoTests/BRCryptoWalletManagerTests.swift
+++ b/Swift/BRCryptoTests/BRCryptoWalletManagerTests.swift
@@ -327,7 +327,9 @@ class MigrateSystemListener: SystemListener {
 
     func handleSystemEvent(system: System, event: SystemEvent) {
         switch event {
-        case .created: break
+        case .created:
+            break
+
         case .networkAdded(let network):
             // Network of interest
             if system.onMainnet == network.isMainnet
@@ -358,7 +360,8 @@ class MigrateSystemListener: SystemListener {
                 migratedManager = manager
                 migratedManagerExpectation.fulfill()
             }
-        case .configured:
+
+        case .discoveredNetworks:
             break
         }
     }

--- a/crypto/BRCryptoUnit.c
+++ b/crypto/BRCryptoUnit.c
@@ -48,7 +48,7 @@ IMPLEMENT_CRYPTO_GIVE_TAKE (BRCryptoUnit, cryptoUnit)
 static BRCryptoUnit
 cryptoUnitCreateInternal (BRCryptoCurrency currency,
                           const char *uids,
-                         const char *name,
+                          const char *name,
                           const char *symbol) {
     BRCryptoUnit unit = malloc (sizeof (struct BRCryptoUnitRecord));
 

--- a/crypto/BRCryptoWalletManager.c
+++ b/crypto/BRCryptoWalletManager.c
@@ -38,6 +38,9 @@
 static void
 cryptoWalletManagerRelease (BRCryptoWalletManager cwm);
 
+static void
+cryptoWalletManagerInstallWalletsForCurrencies (BRCryptoWalletManager cwm);
+
 IMPLEMENT_CRYPTO_GIVE_TAKE (BRCryptoWalletManager, cryptoWalletManager)
 
 /// =============================================================================================
@@ -173,26 +176,13 @@ cryptoWalletManagerCreate (BRCryptoCWMListener listener,
             // ... and finally start the EWM event handling (with CWM fully in place).
             ewmStart (cwm->u.eth);
 
-            // During the creation of both the BTC and ETH wallet managers, the primary wallet will
-            // be created and will have wallet events generated.  There will be a race on `cwm->wallet` but
-            // that race is resolved in the BTC and ETH event handlers, respectively.
-            //
-            // There are others wallets to create.  Specifically, for the Ethereum network we'll want to
-            // create wallets for each and every ERC20 token of interest.
-            //
-            // TODO: How to decide on tokens-of-interest and when to decide (CORE-291).
-            //
-            // We should pass in 'tokens-of-interest' as List<Currency-Code> and then add the tokens
-            // one-by-one - specifically 'add them' not 'announce them'.  If we 'announce them' then the
-            // install event gets queued until the wallet manager connects.  Or, we could query them,
-            // as we do below, and have the BRD endpoint provide them asynchronously and handled w/
-            // 'announce..
-            //
-            // When a token is announced, we'll create a CRYPTO wallet if-and-only-if the token has
-            // a knonw currency.  EVERY TOKEN SHOULD, eventually - key word being 'eventually'.
-            //
-            // TODO: Only finds MAINNET tokens
-            ewmUpdateTokens(cwm->u.eth);
+            // This will generate EWM wallet events... as EWM is started, the CWM callback of
+            // cwmWalletEventAsETH() will runs, create the CWM wallet and then signal both
+            // CRYPTO_WALLET_EVENT_CREATED and CRYPTO_WALLET_MANAGER_EVENT_WALLET_ADDED.
+            cryptoWalletManagerInstallWalletsForCurrencies(cwm);
+
+            // We finish here with possibly EWM events in the EWM handler queue and/or with
+            // CWM events in the CWM handler queue.
 
             break;
         }
@@ -268,13 +258,7 @@ cryptoWalletManagerCreate (BRCryptoCWMListener listener,
     cryptoUnitGive(unit);
     cryptoCurrencyGive(currency);
 
-    // NOTE: Race on cwm->u.{btc,eth} is resolved in the event handlers
-
-
     free (cwmPath);
-
-    //    listener.walletManagerEventCallback (listener.context, cwm);  // created
-    //    listener.walletEventCallback (listener.context, cwm, cwm->wallet);
 
     return cwm;
 }
@@ -457,6 +441,57 @@ cryptoWalletManagerRemWallet (BRCryptoWalletManager cwm,
 
     // drop reference outside of lock to avoid potential case where release function runs
     if (NULL != managerWallet) cryptoWalletGive (managerWallet);
+}
+
+static void
+cryptoWalletManagerInstallWalletsForCurrencies (BRCryptoWalletManager cwm) {
+    BRCryptoNetwork  network    = cryptoNetworkTake (cwm->network);
+    BRCryptoCurrency currency   = cryptoNetworkGetCurrency(network);
+    BRCryptoUnit     unitForFee = cryptoNetworkGetUnitAsBase (network, currency);
+
+    size_t currencyCount = cryptoNetworkGetCurrencyCount (network);
+    for (size_t index = 0; index < currencyCount; index++) {
+        BRCryptoCurrency c = cryptoNetworkGetCurrencyAt (network, index);
+        if (c != currency) {
+            BRCryptoUnit unitDefault = cryptoNetworkGetUnitAsDefault (network, c);
+
+            switch (cwm->type) {
+                case BLOCK_CHAIN_TYPE_BTC:
+                    break;
+                case BLOCK_CHAIN_TYPE_ETH: {
+                    const char *address = cryptoCurrencyGetIssuer(c);
+                    if (NULL != address) {
+                        BREthereumGas      ethGasLimit = gasCreate(TOKEN_BRD_DEFAULT_GAS_LIMIT);
+                        BREthereumGasPrice ethGasPrice = gasPriceCreate(etherCreate(createUInt256(TOKEN_BRD_DEFAULT_GAS_PRICE_IN_WEI_UINT64)));
+
+                        tokenInstall (address,
+                                      cryptoCurrencyGetCode (c),
+                                      cryptoCurrencyGetName(c),
+                                      cryptoCurrencyGetUids(c), // description
+                                      cryptoUnitGetBaseDecimalOffset(unitDefault),
+                                      ethGasLimit,
+                                      ethGasPrice);
+
+                        BREthereumToken ethToken = tokenLookup(cryptoCurrencyGetIssuer(c));
+                        if (NULL != ethToken) {
+                            // The following generates an EWM event of WALLET_EVENT_CREATED.  Which flows
+                            // to CWM and is handled in cwmWalletEventAsETH where a BRCrytoWallet is
+                            // created and then signalled on up.
+                            ewmGetWalletHoldingToken (cwm->u.eth, ethToken);
+                        }
+                    }
+                    break;
+                }
+                case BLOCK_CHAIN_TYPE_GEN:
+                    break;
+            }
+            cryptoUnitGive(unitDefault);
+        }
+        cryptoCurrencyGive(c);
+    }
+    cryptoUnitGive(unitForFee);
+    cryptoCurrencyGive(currency);
+    cryptoNetworkGive(network);
 }
 
 /// MARK: - Connect/Disconnect/Sync

--- a/crypto/BRCryptoWalletManagerClient.c
+++ b/crypto/BRCryptoWalletManagerClient.c
@@ -952,6 +952,7 @@ cwmWalletEventAsETH (BREthereumClientContext context,
                 cryptoUnitGive (unit);
                 cryptoCurrencyGive (currency);
 
+                // This is invoked directly on an EWM thread. (as is all this function's code).
                 cwm->listener.walletEventCallback (cwm->listener.context,
                                                    cryptoWalletManagerTake (cwm),
                                                    cryptoWalletTake (wallet),
@@ -1689,6 +1690,7 @@ cryptoWalletManagerClientCreateBTCClient (OwnershipKept BRCryptoWalletManager cw
 
 extern BREthereumClient
 cryptoWalletManagerClientCreateETHClient (OwnershipKept BRCryptoWalletManager cwm) {
+    // All these client callbacks are invoked directly on an ETH thread.
     return (BREthereumClient) {
         cwm,
         cwmGetBalanceAsETH,


### PR DESCRIPTION
This PR is 'double drafty'.

Probably the most important change is in BRCryptoWalletManager in the `create()` function (for ETH).  No longer is the ETH callback getTokens invoked; instead the network currencies (and the corresponding default unit) are used to a) create an ETH token and b) create an ETH wallet for that token.  The creation of the ETH wallet 'flows through the callbacks' to a) create an CWM wallet, and b) get announced via Swift/Java WalletManager and Wallet events.  [It may be that this change **is not** needed - it was originally made expecting (hoping) that the wallets would get announced immediately - that didn't happen]

Another change is to perform the system.configure action on the system.queue and to have that queue wait until all blockshains+currencies have produced their network.