### PR TITLE
CORE-527: Support `.api_only` for all blockchains.

### DIFF
--- a/Java/CoreCrypto/src/main/java/com/breadwallet/corecrypto/System.java
+++ b/Java/CoreCrypto/src/main/java/com/breadwallet/corecrypto/System.java
@@ -211,18 +211,30 @@ final class System implements com.breadwallet.crypto.System {
     /// Wallet Manager Modes
     ///
 
+    /// Every blockchain supports `API_ONLY`; blockchains with built-in P2P support (BTC, BCH,
+    /// and ETH) may support `P2P_ONLY`.  Intermediate modes (API_WITH_P2P_SUBMIT,
+    /// P2P_WITH_API_SYNC) are suppored on a case-by-case basis.
+    ///
+    /// It is possible that the `API_ONLY` mode does not work - for exmaple, the BDB is down.  In
+    /// that case it is an App issue to report and resolve the issue by: waiting out the outage;
+    /// selecting another mode if available.
+
     private static final ImmutableMultimap<String, WalletManagerMode> SUPPORTED_MODES;
 
     static {
         ImmutableMultimap.Builder<String, WalletManagerMode> builder = new ImmutableMultimap.Builder<>();
         builder.put("bitcoin-mainnet", WalletManagerMode.P2P_ONLY);
+        builder.put("bitcoin-mainnet", WalletManagerMode.API_ONLY);
         builder.put("bitcoincash-mainnet", WalletManagerMode.P2P_ONLY);
+        builder.put("bitcoincash-mainnet", WalletManagerMode.API_ONLY);
         builder.put("ethereum-mainnet", WalletManagerMode.API_ONLY);
         builder.put("ethereum-mainnet", WalletManagerMode.API_WITH_P2P_SUBMIT);
         builder.put("ethereum-mainnet", WalletManagerMode.P2P_ONLY);
 
         builder.put("bitcoin-testnet", WalletManagerMode.P2P_ONLY);
+        builder.put("bitcoin-testnet", WalletManagerMode.API_ONLY);
         builder.put("bitcoincash-testnet", WalletManagerMode.P2P_ONLY);
+        builder.put("bitcoincash-testnet", WalletManagerMode.API_ONLY);
         builder.put("ethereum-ropsten", WalletManagerMode.API_ONLY);
         builder.put("ethereum-ropsten", WalletManagerMode.API_WITH_P2P_SUBMIT);
         builder.put("ethereum-ropsten", WalletManagerMode.P2P_ONLY);

--- a/Swift/BRCrypto/BRCryptoSystem.swift
+++ b/Swift/BRCrypto/BRCryptoSystem.swift
@@ -199,14 +199,21 @@ public final class System {
     ///
     /// Wallet Manager Modes
     ///
-
+    /// Every blockchain supports `.api_only`; blockchains with built-in P2P support (BTC, BCH,
+    /// and ETH) may support `.p2p_only`.  Intermediate modes (.api_with_p2p_submit,
+    /// .p2p_with_api_sync) are suppored on a case-by-case basis.
+    ///
+    /// It is possible that the `.api_only` mode does not work - for exmaple, the BDB is down.  In
+    /// that case it is an App issue to report and resolve the issue by: waiting out the outage;
+    /// selecting another mode if available.
+    ///
     var supportedModesMap: [String:[WalletManagerMode]] = [
-        "bitcoin-mainnet":      [.p2p_only],
-        "bitcoincash-mainnet":  [.p2p_only],
+        "bitcoin-mainnet":      [.api_only, .p2p_only],
+        "bitcoincash-mainnet":  [.api_only, .p2p_only],
         "ethereum-mainnet":     [.api_only, .api_with_p2p_submit, .p2p_only],
 //        "ripple-mainnet":       [],
-        "bitcoin-testnet":      [.p2p_only],
-        "bitcoincash-testnet":  [.p2p_only],
+        "bitcoin-testnet":      [.api_only, .p2p_only],
+        "bitcoincash-testnet":  [.api_only, .p2p_only],
         "ethereum-ropsten":     [.api_only, .api_with_p2p_submit, .p2p_only],
 //        "ripple-testnet":       []
     ]
@@ -489,7 +496,7 @@ public final class System {
             let modes = supportedModesMap[blockchain.id]
             supportedModesMap[blockchain.id] = (nil == modes
                 ? [.api_only]
-                : (modes!.contains (.api_only)
+                : (modes!.contains (.api_only)   // all modes contain .api_only; but this does no harm.
                     ? modes!
                     : ([.api_only] + modes!)))
 

--- a/Swift/BRCryptoTests/BRCryptoSystemTests.swift
+++ b/Swift/BRCryptoTests/BRCryptoSystemTests.swift
@@ -65,4 +65,53 @@ class BRCryptoSystemTests: BRCryptoSystemBaseTests {
         XCTAssertTrue (listener.checkWalletEvents(
             [WalletEvent.created], strict: true))
     }
+
+    func testSystemModes () {
+        isMainnet = false
+        currencyCodesNeeded = ["btc"]
+        modeMap = ["btc":WalletManagerMode.api_only]
+        prepareAccount()
+        prepareSystem()
+
+        XCTAssertTrue (system.networks.count >= 1)
+        let network: Network! = system.networks.first { "btc" == $0.currency.code && isMainnet == $0.isMainnet }
+        XCTAssertNotNil (network)
+        XCTAssertTrue (system.supportsMode(network: network, system.defaultMode(network: network)))
+
+        system.networks
+            .forEach { (network) in
+                XCTAssertTrue (system.supportsMode(network: network, system.defaultMode(network: network)))
+        }
+
+        system.supportedModesMap
+            .forEach { (argument) in
+                let (bid, modes) = argument
+                XCTAssertTrue (modes.contains (.api_only))
+                XCTAssertTrue (modes.contains (system.defaultModesMap[bid]!))
+        }
+    }
+
+    func testSystemAddressSchemes () {
+        isMainnet = false
+        currencyCodesNeeded = ["btc"]
+        modeMap = ["btc":WalletManagerMode.api_only]
+        prepareAccount()
+        prepareSystem()
+
+        XCTAssertTrue (system.networks.count >= 1)
+        let network: Network! = system.networks.first { "btc" == $0.currency.code && isMainnet == $0.isMainnet }
+        XCTAssertNotNil (network)
+        XCTAssertTrue (system.supportsAddressScheme (network: network, system.defaultAddressScheme(network: network)))
+
+        system.networks
+            .forEach { (network) in
+                XCTAssertTrue (system.supportsAddressScheme (network: network, system.defaultAddressScheme(network: network)))
+        }
+
+        system.supportedAddressSchemesMap
+            .forEach { (argument) in
+                let (bid, schemes) = argument
+                XCTAssertTrue (schemes.contains (system.defaultAddressSchemeMap[bid]!))
+        }
+    }
 }


### PR DESCRIPTION
Requires Java changes.