### PR TITLE
CORE-538: Expose function to set if the network is reachable

### DIFF
--- a/Java/CoreCrypto/src/main/java/com/breadwallet/corecrypto/System.java
+++ b/Java/CoreCrypto/src/main/java/com/breadwallet/corecrypto/System.java
@@ -405,6 +405,13 @@ final class System implements com.breadwallet.crypto.System {
     }
 
     @Override
+    public void setNetworkReachable(boolean isNetworkReachable) {
+        for (WalletManager manager: getWalletManagers()) {
+            manager.setNetworkReachable(isNetworkReachable);
+        }
+    }
+
+    @Override
     public Account getAccount() {
         return account;
     }

--- a/Java/CoreCrypto/src/main/java/com/breadwallet/corecrypto/WalletManager.java
+++ b/Java/CoreCrypto/src/main/java/com/breadwallet/corecrypto/WalletManager.java
@@ -212,6 +212,11 @@ final class WalletManager implements com.breadwallet.crypto.WalletManager {
     }
 
     @Override
+    public void setNetworkReachable(boolean isNetworkReachable) {
+        core.setNetworkReachable(isNetworkReachable);
+    }
+
+    @Override
     public boolean equals(Object object) {
         if (this == object) {
             return true;

--- a/Java/CoreCrypto/src/main/java/com/breadwallet/corecrypto/WalletManager.java
+++ b/Java/CoreCrypto/src/main/java/com/breadwallet/corecrypto/WalletManager.java
@@ -32,16 +32,19 @@ final class WalletManager implements com.breadwallet.crypto.WalletManager {
                                 String path,
                                 System system,
                                 SystemCallbackCoordinator callbackCoordinator) {
-        CoreBRCryptoWalletManager core = CoreBRCryptoWalletManager.create(
-                listener,
-                client,
-                account.getCoreBRCryptoAccount(),
-                network.getCoreBRCryptoNetwork(),
-                Utilities.walletManagerModeToCrypto(mode),
-                Utilities.addressSchemeToCrypto(addressScheme),
-                path);
-
-        return new WalletManager(core, system, callbackCoordinator);
+        return new WalletManager(
+                CoreBRCryptoWalletManager.create(
+                        listener,
+                        client,
+                        account.getCoreBRCryptoAccount(),
+                        network.getCoreBRCryptoNetwork(),
+                        Utilities.walletManagerModeToCrypto(mode),
+                        Utilities.addressSchemeToCrypto(addressScheme),
+                        path
+                ),
+                system,
+                callbackCoordinator
+        );
     }
 
     /* package */
@@ -212,11 +215,6 @@ final class WalletManager implements com.breadwallet.crypto.WalletManager {
     }
 
     @Override
-    public void setNetworkReachable(boolean isNetworkReachable) {
-        core.setNetworkReachable(isNetworkReachable);
-    }
-
-    @Override
     public boolean equals(Object object) {
         if (this == object) {
             return true;
@@ -238,6 +236,11 @@ final class WalletManager implements com.breadwallet.crypto.WalletManager {
     @Override
     public String toString() {
         return getName();
+    }
+
+    /* package */
+    void setNetworkReachable(boolean isNetworkReachable) {
+        core.setNetworkReachable(isNetworkReachable);
     }
 
     /* package */

--- a/Java/CoreNative/src/main/java/com/breadwallet/corenative/CryptoLibrary.java
+++ b/Java/CoreNative/src/main/java/com/breadwallet/corenative/CryptoLibrary.java
@@ -224,6 +224,7 @@ public interface CryptoLibrary extends Library {
     int cryptoWalletManagerGetAddressScheme (BRCryptoWalletManager cwm);
     void cryptoWalletManagerSetAddressScheme (BRCryptoWalletManager cwm, int scheme);
     Pointer cryptoWalletManagerGetPath(BRCryptoWalletManager cwm);
+    void cryptoWalletManagerSetNetworkReachable(BRCryptoWalletManager manager, int isNetworkReachable);
     BRCryptoWallet cryptoWalletManagerGetWallet(BRCryptoWalletManager cwm);
     Pointer cryptoWalletManagerGetWallets(BRCryptoWalletManager cwm, SizeTByReference count);
     int cryptoWalletManagerHasWallet(BRCryptoWalletManager cwm, BRCryptoWallet wallet);

--- a/Java/CoreNative/src/main/java/com/breadwallet/corenative/crypto/BRCryptoWalletManager.java
+++ b/Java/CoreNative/src/main/java/com/breadwallet/corenative/crypto/BRCryptoWalletManager.java
@@ -76,6 +76,14 @@ public class BRCryptoWalletManager extends PointerType implements CoreBRCryptoWa
     }
 
     @Override
+    public void setNetworkReachable(boolean isNetworkReachable) {
+        CryptoLibrary.INSTANCE.cryptoWalletManagerSetNetworkReachable(
+                this,
+                isNetworkReachable ? BRCryptoBoolean.CRYPTO_TRUE : BRCryptoBoolean.CRYPTO_FALSE
+        );
+    }
+
+    @Override
     public int getMode() {
         return CryptoLibrary.INSTANCE.cryptoWalletManagerGetMode(this);
     }

--- a/Java/CoreNative/src/main/java/com/breadwallet/corenative/crypto/CoreBRCryptoWalletManager.java
+++ b/Java/CoreNative/src/main/java/com/breadwallet/corenative/crypto/CoreBRCryptoWalletManager.java
@@ -37,6 +37,8 @@ public interface CoreBRCryptoWalletManager {
 
     boolean containsWallet(CoreBRCryptoWallet wallet);
 
+    void setNetworkReachable(boolean isNetworkReachable);
+
     int getMode();
 
     void setMode(int mode);

--- a/Java/CoreNative/src/main/java/com/breadwallet/corenative/crypto/OwnedBRCryptoWalletManager.java
+++ b/Java/CoreNative/src/main/java/com/breadwallet/corenative/crypto/OwnedBRCryptoWalletManager.java
@@ -59,6 +59,11 @@ class OwnedBRCryptoWalletManager implements CoreBRCryptoWalletManager {
     }
 
     @Override
+    public void setNetworkReachable(boolean isNetworkReachable) {
+        core.setNetworkReachable(isNetworkReachable);
+    }
+
+    @Override
     public int getMode() {
         return core.getMode();
     }

--- a/Java/Crypto/src/main/java/com/breadwallet/crypto/System.java
+++ b/Java/Crypto/src/main/java/com/breadwallet/crypto/System.java
@@ -29,6 +29,16 @@ public interface System {
 
     void subscribe(String subscriptionToken);
 
+    /**
+     * Set the network reachable flag for all managers.
+     *
+     * Setting or clearing this flag will NOT result in a connect/disconnect attempt by a {@link WalletManager}.
+     * Callers must use the {@link WalletManager#connect()}/{@link WalletManager#disconnect()} methods to
+     * change a WalletManager's connectivity state. Instead, WalletManagers MAY consult this flag when performing
+     * network operations to determine viability.
+     */
+    void setNetworkReachable(boolean isNetworkReachable);
+
     Account getAccount();
 
     String getPath();

--- a/Java/Crypto/src/main/java/com/breadwallet/crypto/WalletManager.java
+++ b/Java/Crypto/src/main/java/com/breadwallet/crypto/WalletManager.java
@@ -61,14 +61,4 @@ public interface WalletManager {
     void setAddressScheme(AddressScheme scheme);
 
     AddressScheme getAddressScheme();
-
-    /**
-     * Set the network reachable flag for this manager.
-     *
-     * Setting or clearing this flag will NOT result in a connect/disconnect attempt. Callers must use the
-     * {@link WalletManager#connect()}/{@link WalletManager#disconnect()} methods to change a WalletManager's
-     * connectivity state. Instead, WalletManagers MAY consult this flag when performing network operations
-     * to determine viability.
-     */
-    void setNetworkReachable(boolean isNetworkReachable);
 }

--- a/Java/Crypto/src/main/java/com/breadwallet/crypto/WalletManager.java
+++ b/Java/Crypto/src/main/java/com/breadwallet/crypto/WalletManager.java
@@ -61,4 +61,14 @@ public interface WalletManager {
     void setAddressScheme(AddressScheme scheme);
 
     AddressScheme getAddressScheme();
+
+    /**
+     * Set the network reachable flag for this manager.
+     *
+     * Setting or clearing this flag will NOT result in a connect/disconnect attempt. Callers must use the
+     * {@link WalletManager#connect()}/{@link WalletManager#disconnect()} methods to change a WalletManager's
+     * connectivity state. Instead, WalletManagers MAY consult this flag when performing network operations
+     * to determine viability.
+     */
+    void setNetworkReachable(boolean isNetworkReachable);
 }

--- a/Java/CryptoDemo/src/main/AndroidManifest.xml
+++ b/Java/CryptoDemo/src/main/AndroidManifest.xml
@@ -3,6 +3,7 @@
     xmlns:tools="http://schemas.android.com/tools"
     package="com.breadwallet.cryptodemo">
 
+    <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
     <uses-permission android:name="android.permission.INTERNET" />
 
     <application

--- a/Java/CryptoDemo/src/main/java/com/breadwallet/cryptodemo/ConnectivityBroadcastReceiver.java
+++ b/Java/CryptoDemo/src/main/java/com/breadwallet/cryptodemo/ConnectivityBroadcastReceiver.java
@@ -1,0 +1,27 @@
+package com.breadwallet.cryptodemo;
+
+import android.content.BroadcastReceiver;
+import android.content.Context;
+import android.content.Intent;
+import android.net.ConnectivityManager;
+import android.util.Log;
+
+public class ConnectivityBroadcastReceiver extends BroadcastReceiver {
+
+    private static final String TAG = ConnectivityBroadcastReceiver.class.getName();
+
+    /* package */
+    ConnectivityBroadcastReceiver() {
+
+    }
+
+    @Override
+    public void onReceive(Context context, Intent intent) {
+        if (ConnectivityManager.CONNECTIVITY_ACTION.equals(intent.getAction())) {
+            boolean isNetworkReachable = Utilities.isNetworkReachable(context);
+
+            Log.d(TAG, "isNetworkReachable: " + isNetworkReachable);
+            CoreCryptoApplication.getSystem().setNetworkReachable(isNetworkReachable);
+        }
+    }
+}

--- a/Java/CryptoDemo/src/main/java/com/breadwallet/cryptodemo/CoreCryptoApplication.java
+++ b/Java/CryptoDemo/src/main/java/com/breadwallet/cryptodemo/CoreCryptoApplication.java
@@ -2,7 +2,10 @@ package com.breadwallet.cryptodemo;
 
 import android.app.Activity;
 import android.app.Application;
+import android.content.Context;
 import android.content.Intent;
+import android.content.IntentFilter;
+import android.net.ConnectivityManager;
 import android.os.StrictMode;
 import android.util.Log;
 
@@ -48,18 +51,70 @@ public class CoreCryptoApplication extends Application {
     private static final String DEFAULT_PAPER_KEY = "boring head harsh green empty clip fatal typical found crane dinner timber";
     private static final WalletManagerMode DEFAULT_MODE = WalletManagerMode.API_ONLY;
 
-    private static System system;
-    private static DispatchingSystemListener systemListener;
-    private static boolean isMainnet;
-    private static BlockchainDb blockchainDb;
-    private static byte[] paperKey;
+    private static CoreCryptoApplication instance;
 
-    private static AtomicBoolean runOnce = new AtomicBoolean(false);
+    private System system;
+    private DispatchingSystemListener systemListener;
+    private ConnectivityBroadcastReceiver connectivityReceiver;
+    private boolean isMainnet;
+    private BlockchainDb blockchainDb;
+    private byte[] paperKey;
 
-    public static void initialize(Activity startingActivity) {
+    private AtomicBoolean runOnce = new AtomicBoolean(false);
+
+    public static void initialize(Activity launchingActivity) {
+        instance.initFromLaunchIntent(launchingActivity.getIntent());
+    }
+
+    public static Context getContext() {
+        return instance.getApplicationContext();
+    }
+
+    public static System getSystem() {
+        checkState(null != instance && instance.runOnce.get());
+
+        return instance.system;
+    }
+
+    public static void resetSystem() {
+        checkState(null != instance && instance.runOnce.get());
+
+        instance.resetSystemImpl();
+    }
+
+    public static DispatchingSystemListener getDispatchingSystemListener() {
+        checkState(null != instance && instance.runOnce.get());
+
+        return instance.systemListener;
+    }
+
+    public static byte[] getPaperKey() {
+        checkState(null != instance && instance.runOnce.get());
+
+        return instance.paperKey;
+    }
+
+    private static void deleteRecursively (File file) {
+        if (file.isDirectory()) {
+            for (File child : file.listFiles()) {
+                deleteRecursively(child);
+            }
+        }
+
+        if (file.exists() && !file.delete()) {
+            Log.e(TAG, "Failed to delete " + file.getAbsolutePath());
+        }
+    }
+
+    @Override
+    public void onCreate() {
+        super.onCreate();
+        instance = this;
+        StrictMode.enableDefaults();
+    }
+
+    private void initFromLaunchIntent(Intent intent) {
         if (!runOnce.getAndSet(true)) {
-            Intent intent = startingActivity.getIntent();
-
             String paperKeyString = (intent.hasExtra(EXTRA_PAPER_KEY) ? intent.getStringExtra(EXTRA_PAPER_KEY) : DEFAULT_PAPER_KEY);
             paperKey = paperKeyString.getBytes(StandardCharsets.UTF_8);
 
@@ -69,13 +124,13 @@ public class CoreCryptoApplication extends Application {
             long timestamp = intent.getLongExtra(EXTRA_TIMESTAMP, DEFAULT_TIMESTAMP);
             WalletManagerMode mode = intent.hasExtra(EXTRA_MODE) ? WalletManagerMode.valueOf(intent.getStringExtra(EXTRA_MODE)) : DEFAULT_MODE;
 
-            File storageFile = new File(startingActivity.getFilesDir(), "core");
+            File storageFile = new File(getFilesDir(), "core");
             if (wipe) {
                 if (storageFile.exists()) deleteRecursively(storageFile);
                 checkState(storageFile.mkdirs());
             }
 
-            Log.d(TAG, String.format("Account PaperKey: %s", paperKeyString));
+            Log.d(TAG, String.format("Account PaperKey:  %s", paperKeyString));
             Log.d(TAG, String.format("Account Timestamp: %s", timestamp));
             Log.d(TAG, String.format("StoragePath:       %s", storageFile.getAbsolutePath()));
             Log.d(TAG, String.format("Mainnet:           %s", isMainnet));
@@ -90,48 +145,24 @@ public class CoreCryptoApplication extends Application {
             Account account = Account.createFromPhrase(paperKey, new Date(TimeUnit.SECONDS.toMillis(timestamp)), uids);
 
             blockchainDb = BlockchainDb.createForTest (new OkHttpClient(), BDB_BASE_URL, BDB_AUTH_TOKEN, API_BASE_URL);
-            system = System.create(Executors.newSingleThreadScheduledExecutor(), systemListener, account, isMainnet, storageFile.getAbsolutePath(), blockchainDb);
+            system = System.create(Executors.newSingleThreadScheduledExecutor(), systemListener, account,
+                    isMainnet, storageFile.getAbsolutePath(), blockchainDb);
             system.configure();
+
+            connectivityReceiver = new ConnectivityBroadcastReceiver();
+            registerReceiver(connectivityReceiver , new IntentFilter(ConnectivityManager.CONNECTIVITY_ACTION));
         }
     }
 
-    public static System getSystem() {
-        return system;
-    }
-
-    public static void resetSystem() {
-        CoreCryptoApplication.system.stop();
-        CoreCryptoApplication.system = System.create(
+    private void resetSystemImpl() {
+        system.stop();
+        system = System.create(
                 Executors.newSingleThreadScheduledExecutor(),
                 systemListener,
-                CoreCryptoApplication.system.getAccount(),
+                system.getAccount(),
                 isMainnet,
-                CoreCryptoApplication.system.getPath(),
+                system.getPath(),
                 blockchainDb);
-        CoreCryptoApplication.system.configure();
-    }
-
-    public static DispatchingSystemListener getDispatchingSystemListener() {
-        return systemListener;
-    }
-
-    public static byte[] getPaperKey() {
-        return paperKey;
-    }
-
-    private static void deleteRecursively (File file) {
-        if (file.isDirectory()) {
-            for (File child : file.listFiles()) {
-                deleteRecursively(child);
-            }
-        }
-        file.delete();
-    }
-
-    @Override
-    public void onCreate() {
-        super.onCreate();
-
-        StrictMode.enableDefaults();
+        system.configure();
     }
 }

--- a/Java/CryptoDemo/src/main/java/com/breadwallet/cryptodemo/CoreSystemListener.java
+++ b/Java/CryptoDemo/src/main/java/com/breadwallet/cryptodemo/CoreSystemListener.java
@@ -51,7 +51,6 @@ public class CoreSystemListener implements SystemListener {
             @Override
             public Void visit(SystemManagerAddedEvent event) {
                 WalletManager manager = event.getWalletManager();
-                manager.setNetworkReachable(Utilities.isNetworkReachable(CoreCryptoApplication.getContext()));
                 manager.connect();
                 return null;
             }

--- a/Java/CryptoDemo/src/main/java/com/breadwallet/cryptodemo/CoreSystemListener.java
+++ b/Java/CryptoDemo/src/main/java/com/breadwallet/cryptodemo/CoreSystemListener.java
@@ -42,7 +42,8 @@ public class CoreSystemListener implements SystemListener {
     private final boolean isMainnet;
     private final List<String> currencyCodesNeeded;
 
-    public CoreSystemListener(WalletManagerMode mode, boolean isMainnet, List<String> currencyCodesNeeded) {
+    /* package */
+    CoreSystemListener(WalletManagerMode mode, boolean isMainnet, List<String> currencyCodesNeeded) {
         this.mode = mode;
         this.isMainnet = isMainnet;
         this.currencyCodesNeeded = new ArrayList<>(currencyCodesNeeded);
@@ -56,6 +57,7 @@ public class CoreSystemListener implements SystemListener {
             @Override
             public Void visit(SystemManagerAddedEvent event) {
                 WalletManager manager = event.getWalletManager();
+                manager.setNetworkReachable(Utilities.isNetworkReachable(CoreCryptoApplication.getContext()));
                 manager.connect();
                 return null;
             }

--- a/Java/CryptoDemo/src/main/java/com/breadwallet/cryptodemo/Utilities.java
+++ b/Java/CryptoDemo/src/main/java/com/breadwallet/cryptodemo/Utilities.java
@@ -1,0 +1,17 @@
+package com.breadwallet.cryptodemo;
+
+import android.content.Context;
+import android.net.ConnectivityManager;
+import android.net.NetworkInfo;
+
+public class Utilities {
+
+    public static boolean isNetworkReachable(Context context) {
+        ConnectivityManager cm = (ConnectivityManager)context.getSystemService(Context.CONNECTIVITY_SERVICE);
+
+        NetworkInfo activeNetwork = cm.getActiveNetworkInfo();
+        return activeNetwork != null && activeNetwork.isConnectedOrConnecting();
+    }
+
+    private Utilities() {}
+}

--- a/Swift/BRCrypto/BRCryptoSystem.swift
+++ b/Swift/BRCrypto/BRCryptoSystem.swift
@@ -476,6 +476,17 @@ public final class System {
         managers.forEach { $0.disconnect() }
     }
 
+    ///
+    /// Set the network reachable flag for all managers. Setting or clearing this flag will
+    /// NOT result in a connect/disconnect operation by a manager. Callers must use the
+    /// `connect`/`disconnect` calls to change a WalletManager's connectivity state. Instead,
+    /// managers MAY consult this flag when performing network operations to determine their
+    /// viability.
+    ///
+    public func setNetworkReachable (_ isNetworkReachable: Bool) {
+        managers.forEach { $0.setNetworkReachable(isNetworkReachable) }
+    }
+
     public func configureMergeBlockchains (builtin: [BlockChainDB.Model.Blockchain],
                                            remote:  [BlockChainDB.Model.Blockchain]) -> [BlockChainDB.Model.Blockchain] {
         // Both `builtin` and `remote` have a non-null blockHeight -> supported.

--- a/Swift/BRCrypto/BRCryptoSystem.swift
+++ b/Swift/BRCrypto/BRCryptoSystem.swift
@@ -41,6 +41,9 @@ public final class System {
     /// the networks, unsorted.
     public internal(set) var networks: [Network] = []
 
+    /// Flag indicating if the network is reachable; defaults to true
+    internal var isNetworkReachable = true
+
     internal let callbackCoordinator: SystemCallbackCoordinator
 
     /// We define default blockchains but these are wholly insufficient given that the
@@ -320,7 +323,7 @@ public final class System {
                                      storagePath: path,
                                      listener: cryptoListener,
                                      client: cryptoClient)
-
+        manager.setNetworkReachable(isNetworkReachable)
         self.add (manager: manager)
     }
 
@@ -491,6 +494,7 @@ public final class System {
     /// viability.
     ///
     public func setNetworkReachable (_ isNetworkReachable: Bool) {
+        self.isNetworkReachable = isNetworkReachable
         managers.forEach { $0.setNetworkReachable(isNetworkReachable) }
     }
 

--- a/Swift/BRCrypto/BRCryptoWalletManager.swift
+++ b/Swift/BRCrypto/BRCryptoWalletManager.swift
@@ -181,7 +181,7 @@ public final class WalletManager: Equatable, CustomStringConvertible {
                                          transfer.core)
     }
 
-    public func setNetworkReachable (_ isNetworkReachable: Bool) {
+    internal func setNetworkReachable (_ isNetworkReachable: Bool) {
         cryptoWalletManagerSetNetworkReachable (core,
                                                 isNetworkReachable ? CRYPTO_TRUE : CRYPTO_FALSE)
     }

--- a/Swift/BRCrypto/BRCryptoWalletManager.swift
+++ b/Swift/BRCrypto/BRCryptoWalletManager.swift
@@ -181,6 +181,11 @@ public final class WalletManager: Equatable, CustomStringConvertible {
                                          transfer.core)
     }
 
+    public func setNetworkReachable (_ isNetworkReachable: Bool) {
+        cryptoWalletManagerSetNetworkReachable (core,
+                                                isNetworkReachable ? CRYPTO_TRUE : CRYPTO_FALSE)
+    }
+
     public func createSweeper (wallet: Wallet,
                                key: Key,
                                completion: @escaping (Result<WalletSweeper, WalletSweeperError>) -> Void) {

--- a/bitcoin/BRSyncManager.h
+++ b/bitcoin/BRSyncManager.h
@@ -149,6 +149,7 @@ BRSyncManagerNewForMode(BRSyncMode mode,
                         uint32_t earliestKeyTime,
                         uint64_t blockHeight,
                         uint64_t confirmationUntilFinal,
+                        int isNetworkReachable,
                         OwnershipKept BRMerkleBlock *blocks[],
                         size_t blocksCount,
                         OwnershipKept const BRPeer peers[],
@@ -162,6 +163,13 @@ BRSyncManagerGetBlockHeight (BRSyncManager manager);
 
 extern uint64_t
 BRSyncManagerGetConfirmationsUntilFinal (BRSyncManager manager);
+
+extern int
+BRSyncManagerGetNetworkReachable (BRSyncManager manager);
+
+extern void
+BRSyncManagerSetNetworkReachable (BRSyncManager manager,
+                                  int isNetworkReachable);
 
 extern void
 BRSyncManagerConnect(BRSyncManager manager);

--- a/bitcoin/BRWalletManager.h
+++ b/bitcoin/BRWalletManager.h
@@ -303,6 +303,10 @@ BRWalletManagerSetMode (BRWalletManager manager, BRSyncMode mode);
 extern BRSyncMode
 BRWalletManagerGetMode (BRWalletManager manager);
 
+extern void
+BRWalletManagerSetNetworkReachable (BRWalletManager manager,
+                                    int isNetworkReachable);
+
 //
 // These should not be needed if the events are sufficient
 //

--- a/crypto/BRCryptoWalletManager.c
+++ b/crypto/BRCryptoWalletManager.c
@@ -384,6 +384,18 @@ cryptoWalletManagerGetPath (BRCryptoWalletManager cwm) {
     return cwm->path;
 }
 
+extern void
+cryptoWalletManagerSetNetworkReachable (BRCryptoWalletManager cwm,
+                                        BRCryptoBoolean isNetworkReachable) {
+    switch (cwm->type) {
+        case BLOCK_CHAIN_TYPE_BTC:
+            BRWalletManagerSetNetworkReachable (cwm->u.btc, isNetworkReachable);
+            break;
+        default:
+            break;
+    }
+}
+
 extern BRCryptoWallet
 cryptoWalletManagerGetWallet (BRCryptoWalletManager cwm) {
     return cryptoWalletTake (cwm->wallet);

--- a/crypto/BRCryptoWalletManager.h
+++ b/crypto/BRCryptoWalletManager.h
@@ -126,6 +126,8 @@ extern "C" {
         BRCryptoCWMListenerTransferEvent transferEventCallback;
     } BRCryptoCWMListener;
 
+    /// MARK: Wallet Manager
+
     extern BRCryptoWalletManager
     cryptoWalletManagerCreate (BRCryptoCWMListener listener,
                                BRCryptoCWMClient client,
@@ -159,6 +161,10 @@ extern "C" {
 
     extern const char *
     cryptoWalletManagerGetPath (BRCryptoWalletManager cwm);
+
+    extern void
+    cryptoWalletManagerSetNetworkReachable (BRCryptoWalletManager cwm,
+                                            BRCryptoBoolean isNetworkReachable);
 
     extern BRCryptoBoolean
     cryptoWalletManagerHasWallet (BRCryptoWalletManager cwm,


### PR DESCRIPTION
@EBGToo, I've updated the Java demo app to announce connectivity changes. I also exposed setNetworkReachable on both System and WalletManager.

I had thought to originally only have it on System but then the case comes up where a WalletManager comes in later on. We *could* have the System cache the value and apply it all created WalletManagers but then it gets a bit "stateful". Thought ultimately this was the most direct way to do it.

BRWalletManager defaults to TRUE for networkIsReachable, rather than expose it in the BRWalletManagerNew as a param (that function already has a ton of params). The comment highlights that this is in the (likely) case where a client doesn't bother keeping the flag up to date (ex: if this is running on a server that doesn't care/monitor network status).