### PR TITLE
CORE-547: In ewmDestroy() don't hold ewm->lock before ewmStop()

### DIFF
--- a/Swift/BRCryptoTests/BRCryptoSystemTests.swift
+++ b/Swift/BRCryptoTests/BRCryptoSystemTests.swift
@@ -123,7 +123,6 @@ class BRCryptoSystemTests: BRCryptoSystemBaseTests {
         system.supportedModesMap
             .forEach { (argument) in
                 let (bid, modes) = argument
-                XCTAssertTrue (modes.contains (.api_only))
                 XCTAssertTrue (modes.contains (system.defaultModesMap[bid]!))
         }
     }

--- a/ethereum/ewm/BREthereumEWM.c
+++ b/ethereum/ewm/BREthereumEWM.c
@@ -678,10 +678,10 @@ ewmCreateWithPublicKey (BREthereumNetwork network,
 
 extern void
 ewmDestroy (BREthereumEWM ewm) {
-    pthread_mutex_lock(&ewm->lock);
-
-    // Stop, including disconnect.
+    // Stop, including disconnect.  This WILL take `ewm->lock` and it MUST be available.
     ewmStop (ewm);
+
+    pthread_mutex_lock(&ewm->lock);
 
     //
     // Begin destroy


### PR DESCRIPTION
Doing so causes a deadlock as the EWM event thread can't handle a cond signal.
Also, fix a system test eror.