### PR TITLE
CORE-561: In Core Crypto, Add WalletManager.registerWalletFor(currency).

### DIFF
--- a/Java/CoreCrypto/src/main/java/com/breadwallet/corecrypto/System.java
+++ b/Java/CoreCrypto/src/main/java/com/breadwallet/corecrypto/System.java
@@ -44,7 +44,6 @@ import com.breadwallet.crypto.WalletState;
 import com.breadwallet.crypto.blockchaindb.BlockchainDb;
 import com.breadwallet.crypto.blockchaindb.errors.QueryError;
 import com.breadwallet.crypto.blockchaindb.models.bdb.Blockchain;
-import com.breadwallet.crypto.blockchaindb.models.bdb.Currency;
 import com.breadwallet.crypto.blockchaindb.models.bdb.Transaction;
 import com.breadwallet.crypto.blockchaindb.models.brd.EthLog;
 import com.breadwallet.crypto.blockchaindb.models.brd.EthToken;
@@ -99,8 +98,10 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.Date;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.ScheduledExecutorService;
@@ -246,7 +247,7 @@ final class System implements com.breadwallet.crypto.System {
     }
 
     @Override
-    public void configure(List<Currency> appCurrencies) {
+    public void configure(List<com.breadwallet.crypto.blockchaindb.models.bdb.Currency> appCurrencies) {
         NetworkDiscovery.discoverNetworks(query, isMainnet, appCurrencies, new NetworkDiscovery.Callback() {
             @Override
             public void discovered(Network network) {
@@ -264,14 +265,25 @@ final class System implements com.breadwallet.crypto.System {
     }
 
     @Override
-    public void createWalletManager(com.breadwallet.crypto.Network network, WalletManagerMode mode, AddressScheme scheme) {
+    public void createWalletManager(com.breadwallet.crypto.Network network,
+                                    WalletManagerMode mode,
+                                    AddressScheme scheme,
+                                    Set<com.breadwallet.crypto.Currency> currencies) {
+        Network cryptoNetwork = Network.from(network);
+
+        Set<Currency> cryptoCurrencies = new HashSet<>(currencies.size());
+        for (com.breadwallet.crypto.Currency c: currencies) {
+            cryptoCurrencies.add(Currency.from(c));
+        }
+
         WalletManager walletManager = WalletManager.create(
                 cwmListener,
                 cwmClient,
                 account,
-                Network.from(network),
+                cryptoNetwork,
                 mode,
                 scheme,
+                cryptoCurrencies,
                 path,
                 this,
                 callbackCoordinator);

--- a/Java/CoreCrypto/src/main/java/com/breadwallet/corecrypto/WalletManager.java
+++ b/Java/CoreCrypto/src/main/java/com/breadwallet/corecrypto/WalletManager.java
@@ -37,28 +37,19 @@ final class WalletManager implements com.breadwallet.crypto.WalletManager {
                                 Network network,
                                 WalletManagerMode mode,
                                 AddressScheme addressScheme,
-                                Set<Currency> currencies,
                                 String path,
                                 System system,
                                 SystemCallbackCoordinator callbackCoordinator) {
-        CoreBRCryptoWalletManager core = CoreBRCryptoWalletManager.create(
-                listener,
-                client,
-                account.getCoreBRCryptoAccount(),
-                network.getCoreBRCryptoNetwork(),
-                Utilities.walletManagerModeToCrypto(mode),
-                Utilities.addressSchemeToCrypto(addressScheme),
-                path
-        );
-
-        for (Currency currency: currencies) {
-            if (network.hasCurrency(currency)) {
-                core.registerWallet(currency.getCoreBRCryptoCurrency());
-            }
-        }
-
         return new WalletManager(
-                core,
+                CoreBRCryptoWalletManager.create(
+                        listener,
+                        client,
+                        account.getCoreBRCryptoAccount(),
+                        network.getCoreBRCryptoNetwork(),
+                        Utilities.walletManagerModeToCrypto(mode),
+                        Utilities.addressSchemeToCrypto(addressScheme),
+                        path
+                ),
                 system,
                 callbackCoordinator
         );

--- a/Java/CoreNative/src/main/java/com/breadwallet/corenative/CryptoLibrary.java
+++ b/Java/CoreNative/src/main/java/com/breadwallet/corenative/CryptoLibrary.java
@@ -232,6 +232,7 @@ public interface CryptoLibrary extends Library {
     BRCryptoWallet cryptoWalletManagerGetWallet(BRCryptoWalletManager cwm);
     Pointer cryptoWalletManagerGetWallets(BRCryptoWalletManager cwm, SizeTByReference count);
     int cryptoWalletManagerHasWallet(BRCryptoWalletManager cwm, BRCryptoWallet wallet);
+    BRCryptoWallet cryptoWalletManagerRegisterWallet(BRCryptoWalletManager cwm, BRCryptoCurrency currency);
     void cryptoWalletManagerConnect(BRCryptoWalletManager cwm);
     void cryptoWalletManagerDisconnect(BRCryptoWalletManager cwm);
     void cryptoWalletManagerSync(BRCryptoWalletManager cwm);

--- a/Java/CoreNative/src/main/java/com/breadwallet/corenative/crypto/BRCryptoWalletManager.java
+++ b/Java/CoreNative/src/main/java/com/breadwallet/corenative/crypto/BRCryptoWalletManager.java
@@ -11,6 +11,7 @@ import com.breadwallet.corenative.CryptoLibrary;
 import com.breadwallet.corenative.support.BRSyncDepth;
 import com.breadwallet.corenative.utility.SizeT;
 import com.breadwallet.corenative.utility.SizeTByReference;
+import com.google.common.base.Optional;
 import com.google.common.primitives.UnsignedInteger;
 import com.google.common.primitives.UnsignedInts;
 import com.google.common.primitives.UnsignedLong;
@@ -73,6 +74,15 @@ public class BRCryptoWalletManager extends PointerType implements CoreBRCryptoWa
     @Override
     public boolean containsWallet(CoreBRCryptoWallet wallet) {
         return  BRCryptoBoolean.CRYPTO_TRUE == CryptoLibrary.INSTANCE.cryptoWalletManagerHasWallet(this, wallet.asBRCryptoWallet());
+    }
+
+    @Override
+    public Optional<CoreBRCryptoWallet> registerWallet(CoreBRCryptoCurrency currency) {
+        return Optional.fromNullable(
+                CryptoLibrary.INSTANCE.cryptoWalletManagerRegisterWallet(this, currency.asBRCryptoCurrency())
+        ).transform(
+                OwnedBRCryptoWallet::new
+        );
     }
 
     @Override

--- a/Java/CoreNative/src/main/java/com/breadwallet/corenative/crypto/CoreBRCryptoWalletManager.java
+++ b/Java/CoreNative/src/main/java/com/breadwallet/corenative/crypto/CoreBRCryptoWalletManager.java
@@ -9,6 +9,7 @@ package com.breadwallet.corenative.crypto;
 
 import com.breadwallet.corenative.CryptoLibrary;
 import com.breadwallet.corenative.support.BRSyncDepth;
+import com.google.common.base.Optional;
 import com.google.common.primitives.UnsignedInteger;
 import com.google.common.primitives.UnsignedLong;
 
@@ -36,6 +37,8 @@ public interface CoreBRCryptoWalletManager {
     List<CoreBRCryptoWallet> getWallets();
 
     boolean containsWallet(CoreBRCryptoWallet wallet);
+
+    Optional<CoreBRCryptoWallet> registerWallet(CoreBRCryptoCurrency currency);
 
     void setNetworkReachable(boolean isNetworkReachable);
 

--- a/Java/CoreNative/src/main/java/com/breadwallet/corenative/crypto/OwnedBRCryptoWalletManager.java
+++ b/Java/CoreNative/src/main/java/com/breadwallet/corenative/crypto/OwnedBRCryptoWalletManager.java
@@ -9,6 +9,7 @@ package com.breadwallet.corenative.crypto;
 
 import com.breadwallet.corenative.CryptoLibrary;
 import com.breadwallet.corenative.support.BRSyncDepth;
+import com.google.common.base.Optional;
 import com.google.common.primitives.UnsignedInteger;
 import com.google.common.primitives.UnsignedLong;
 
@@ -56,6 +57,11 @@ class OwnedBRCryptoWalletManager implements CoreBRCryptoWalletManager {
     @Override
     public boolean containsWallet(CoreBRCryptoWallet wallet) {
         return core.containsWallet(wallet);
+    }
+
+    @Override
+    public Optional<CoreBRCryptoWallet> registerWallet(CoreBRCryptoCurrency currency) {
+        return core.registerWallet(currency);
     }
 
     @Override

--- a/Java/Crypto/src/main/java/com/breadwallet/crypto/System.java
+++ b/Java/Crypto/src/main/java/com/breadwallet/crypto/System.java
@@ -27,12 +27,16 @@ public interface System {
     /**
      * Create a wallet manager for `network` using `mode.
      *
+     * Note: There are two preconditions - "network" must support "mode" and "addressScheme".
+     *       Thus a fatal error arises if, for example, the network is BTC and the scheme is ETH.
+     *
      * @param network the wallet manager's network
      * @param mode the wallet manager mode to use
      * @param addressScheme the address scheme to use
-     * @param currencies the currencies to 'register'.  A wallet will be created for each one.  It
-     *                   is safe to pass currencies not in `network` as they will be filtered (but bad form
-     *                   to do so).
+     * @param currencies the currencies to register.  A wallet will be created for each one.  It
+     *                   is safe to pass currencies not in "network" as they will be filtered (but bad form
+     *                   to do so). The "primaryWallet", for the network's currency, is always created; if
+     *                   the primaryWallet's currency is in `currencies` then it is effectively ignored.
      */
     void createWalletManager(Network network,
                              WalletManagerMode mode,
@@ -73,5 +77,5 @@ public interface System {
 
     List<WalletManagerMode> getSupportedWalletManagerModes(Network network);
 
-    boolean supportsWalletManagerModes(Network network, WalletManagerMode mode);
+    boolean supportsWalletManagerMode(Network network, WalletManagerMode mode);
 }

--- a/Java/Crypto/src/main/java/com/breadwallet/crypto/System.java
+++ b/Java/Crypto/src/main/java/com/breadwallet/crypto/System.java
@@ -10,10 +10,10 @@
 package com.breadwallet.crypto;
 
 import com.breadwallet.crypto.blockchaindb.BlockchainDb;
-import com.breadwallet.crypto.blockchaindb.models.bdb.Currency;
 import com.breadwallet.crypto.events.system.SystemListener;
 
 import java.util.List;
+import java.util.Set;
 import java.util.concurrent.ScheduledExecutorService;
 
 public interface System {
@@ -22,9 +22,22 @@ public interface System {
         return CryptoApi.getProvider().systemProvider().create(executor, listener, account, isMainnet,path, query);
     }
 
-    void configure(List<Currency> appCurrencies);
+    void configure(List<com.breadwallet.crypto.blockchaindb.models.bdb.Currency> appCurrencies);
 
-    void createWalletManager(Network network, WalletManagerMode mode, AddressScheme addressScheme);
+    /**
+     * Create a wallet manager for `network` using `mode.
+     *
+     * @param network the wallet manager's network
+     * @param mode the wallet manager mode to use
+     * @param addressScheme the address scheme to use
+     * @param currencies the currencies to 'register'.  A wallet will be created for each one.  It
+     *                   is safe to pass currencies not in `network` as they will be filtered (but bad form
+     *                   to do so).
+     */
+    void createWalletManager(Network network,
+                             WalletManagerMode mode,
+                             AddressScheme addressScheme,
+                             Set<Currency> currencies);
 
     void stop();
 

--- a/Java/Crypto/src/main/java/com/breadwallet/crypto/WalletManager.java
+++ b/Java/Crypto/src/main/java/com/breadwallet/crypto/WalletManager.java
@@ -11,6 +11,7 @@ package com.breadwallet.crypto;
 
 import com.breadwallet.crypto.errors.WalletSweeperError;
 import com.breadwallet.crypto.utility.CompletionHandler;
+import com.google.common.base.Optional;
 
 import java.util.List;
 
@@ -39,6 +40,18 @@ public interface WalletManager {
     Wallet getPrimaryWallet();
 
     List<? extends Wallet> getWallets();
+
+    /**
+     * Ensure that a wallet for currency exists.  If the wallet already exists, it is returned.
+     * If the wallet needs to be created then `nil` is returned and a series of events will
+     * occur - notably WalletEvent.created and WalletManagerEvent.walletAdded if the wallet is
+     * created
+     *
+     * Note: There is a precondition on `currency` being one in the managers' network
+     *
+     * @return The wallet for currency if it already exists, otherwise "absent"
+     */
+    Optional<? extends Wallet> registerWalletFor(Currency currency);
 
     WalletManagerMode getMode();
 

--- a/Java/CryptoDemo/src/main/java/com/breadwallet/cryptodemo/CoreSystemListener.java
+++ b/Java/CryptoDemo/src/main/java/com/breadwallet/cryptodemo/CoreSystemListener.java
@@ -33,6 +33,7 @@ import com.breadwallet.crypto.events.walletmanager.WalletManagerEvent;
 import com.google.common.base.Optional;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 public class CoreSystemListener implements SystemListener {
@@ -81,7 +82,7 @@ public class CoreSystemListener implements SystemListener {
                             mode : system.getDefaultWalletManagerMode(network);
 
                     AddressScheme addressScheme = system.getDefaultAddressScheme(network);
-                    system.createWalletManager(event.getNetwork(), wmMode, addressScheme);
+                    system.createWalletManager(event.getNetwork(), wmMode, addressScheme, Collections.emptySet());
                 }
                 return null;
             }

--- a/Java/CryptoDemo/src/main/java/com/breadwallet/cryptodemo/CoreSystemListener.java
+++ b/Java/CryptoDemo/src/main/java/com/breadwallet/cryptodemo/CoreSystemListener.java
@@ -78,7 +78,7 @@ public class CoreSystemListener implements SystemListener {
                 }
 
                 if (isMainnet == network.isMainnet() && isNetworkNeeded) {
-                    WalletManagerMode wmMode = system.supportsWalletManagerModes(network, mode) ?
+                    WalletManagerMode wmMode = system.supportsWalletManagerMode(network, mode) ?
                             mode : system.getDefaultWalletManagerMode(network);
 
                     AddressScheme addressScheme = system.getDefaultAddressScheme(network);

--- a/Swift/BRCrypto/BRCryptoSystem.swift
+++ b/Swift/BRCrypto/BRCryptoSystem.swift
@@ -318,7 +318,14 @@ public final class System {
     }
 
     ///
-    /// Create a wallet manager for `network` using `mode.
+    /// Create a wallet manager for `network` using `mode`, `addressScheme`, and `currencies.  A
+    /// wallet will be 'registered' for each of:
+    ///    a) the network's currency - this is the primaryWallet
+    ///    b) for each of `currences` that are in `network`.
+    /// These wallets are announced using WalletEvent.created and WalletManagerEvent.walledAdded.
+    ///
+    /// The created wallet manager is announed using WalletManagerEvent.created and
+    /// SystemEvent.managerAdded.
     ///
     /// - Parameters:
     ///   - network: the wallet manager's network
@@ -326,12 +333,18 @@ public final class System {
     ///   - addressScheme: the address scheme to use
     ///   - currencies: the currencies to 'register'.  A wallet will be created for each one.  It
     ///       is safe to pass currencies not in `network` as they will be filtered (but bad form
-    ///       to do so).
+    ///       to do so).  The 'primaryWallet', for the network's currency, is always created; if
+    ///       the primaryWallet's currency is in `currencies` then it is effectively ignored.
+    ///
+    /// - Note: There are two preconditions - `network` must support `mode` and `addressScheme`.
+    ///     Thus a fatal error arises if, for example, the network is BTC and the scheme is ETH.
     ///
     public func createWalletManager (network: Network,
                                      mode: WalletManagerMode,
                                      addressScheme: AddressScheme,
                                      currencies: Set<Currency>) {
+        precondition (supportsMode(network: network, mode))
+        precondition (supportsAddressScheme(network: network, addressScheme))
 
         let manager = WalletManager (system: self,
                                      callbackCoordinator: callbackCoordinator,

--- a/Swift/BRCrypto/BRCryptoSystem.swift
+++ b/Swift/BRCrypto/BRCryptoSystem.swift
@@ -322,11 +322,16 @@ public final class System {
     ///
     /// - Parameters:
     ///   - network: the wallet manager's network
-    ///   - mode: the mode to use
+    ///   - mode: the wallet manager mode to use
+    ///   - addressScheme: the address scheme to use
+    ///   - currencies: the currencies to 'register'.  A wallet will be created for each one.  It
+    ///       is safe to pass currencies not in `network` as they will be filtered (but bad form
+    ///       to do so).
     ///
     public func createWalletManager (network: Network,
                                      mode: WalletManagerMode,
-                                     addressScheme: AddressScheme) {
+                                     addressScheme: AddressScheme,
+                                     currencies: Set<Currency>) {
 
         let manager = WalletManager (system: self,
                                      callbackCoordinator: callbackCoordinator,
@@ -334,6 +339,7 @@ public final class System {
                                      network: network,
                                      mode: mode,
                                      addressScheme: addressScheme,
+                                     currencies: currencies,
                                      storagePath: path,
                                      listener: cryptoListener,
                                      client: cryptoClient)

--- a/Swift/BRCrypto/BRCryptoWalletManager.swift
+++ b/Swift/BRCrypto/BRCryptoWalletManager.swift
@@ -76,6 +76,27 @@ public final class WalletManager: Equatable, CustomStringConvertible {
                        take: false)
     }()
 
+    ///
+    /// Ensure that a wallet for currency exists.  If the wallet already exists, it is returned.
+    /// If the wallet needs to be created then `nil` is returned and a series of events will
+    //// occur - notably WalletEvent.created and WalletManagerEvent.walletAdded if the wallet is
+    /// created
+    ///
+    /// - Note: There is a precondition on `currency` being one in the managers' network
+    ///
+    /// - Parameter currency:
+    /// - Returns: The wallet for currency if it already exists, othersise `nil`
+    ///
+    public func requireWalletFor (currency: Currency) -> Wallet? {
+        precondition (network.hasCurrency(currency))
+        return cryptoWalletManagerRequireWalletForCurrency (core, currency.core)
+            .map { Wallet (core: $0,
+                           manager: self,
+                           callbackCoordinator: callbackCoordinator,
+                           take: false)
+        }
+    }
+
     /// The managed wallets - often will just be [primaryWallet]
     public var wallets: [Wallet] {
         let listener = system.listener

--- a/Swift/BRCrypto/BRCryptoWalletManager.swift
+++ b/Swift/BRCrypto/BRCryptoWalletManager.swift
@@ -269,7 +269,8 @@ public final class WalletManager: Equatable, CustomStringConvertible {
         currencies
             .forEach {
                 if network.hasCurrency ($0) {
-                    cryptoWalletManagerRegisterWallet (core, $0.core) }
+                    let _ = registerWalletFor(currency: $0)
+                }
         }
     }
 

--- a/Swift/BRCryptoDemo/CoreDemoAppDelegate.swift
+++ b/Swift/BRCryptoDemo/CoreDemoAppDelegate.swift
@@ -107,10 +107,13 @@ class CoreDemoAppDelegate: UIResponder, UIApplicationDelegate, UISplitViewContro
 
         }
 
+        var requiredTokenCurrencies = ["ZLA", "ADT"]
+
         print ("APP: Currencies        : \(currencies)")
 
         // Create the listener
         let listener = CoreDemoListener (currencyCodesNeeded: currencies,
+                                         currencyTokensNeeded: requiredTokenCurrencies,
                                          isMainnet: mainnet)
 
         // Create the BlockChainDB

--- a/Swift/BRCryptoDemo/CoreDemoAppDelegate.swift
+++ b/Swift/BRCryptoDemo/CoreDemoAppDelegate.swift
@@ -98,7 +98,12 @@ class CoreDemoAppDelegate: UIResponder, UIApplicationDelegate, UISplitViewContro
         print ("APP: Account Timestamp : \(account.timestamp)")
         print ("APP: StoragePath       : \(storagePath)");
         print ("APP: Mainnet           : \(mainnet)")
-        var currencies: [String] = ["btc", "eth", "brd" /*, "xrp"*/]
+        let currencies: [String] = [
+            "btc",
+            "eth",
+//            "bch",
+//            "xrp"
+        ]
 
         if mainnet {
 
@@ -107,13 +112,15 @@ class CoreDemoAppDelegate: UIResponder, UIApplicationDelegate, UISplitViewContro
 
         }
 
-        var requiredTokenCurrencies = ["ZLA", "ADT"]
+        let registerCurrencyCodes = [
+            "ZLA",
+            "ADT"]
 
         print ("APP: Currencies        : \(currencies)")
 
         // Create the listener
-        let listener = CoreDemoListener (currencyCodesNeeded: currencies,
-                                         currencyTokensNeeded: requiredTokenCurrencies,
+        let listener = CoreDemoListener (networkCurrencyCodes: currencies,
+                                         registerCurrencyCodes: registerCurrencyCodes,
                                          isMainnet: mainnet)
 
         // Create the BlockChainDB

--- a/Swift/BRCryptoDemo/CoreDemoListener.swift
+++ b/Swift/BRCryptoDemo/CoreDemoListener.swift
@@ -23,8 +23,13 @@ class CoreDemoListener: SystemListener {
     private let currencyCodesNeeded: [String]
     private let isMainnet: Bool
 
-    public init (currencyCodesNeeded: [String], isMainnet: Bool) {
+    private let currencyTokensNeeded: [String]
+
+    public init (currencyCodesNeeded: [String],
+                 currencyTokensNeeded: [String],
+                 isMainnet: Bool) {
         self.currencyCodesNeeded = currencyCodesNeeded
+        self.currencyTokensNeeded = currencyTokensNeeded;
         self.isMainnet = isMainnet
     }
 
@@ -108,6 +113,12 @@ class CoreDemoListener: SystemListener {
         case .managerAdded (let manager):
             //TODO: Don't connect here. connect on touch...
             manager.connect()
+            currencyTokensNeeded
+                .forEach {
+                    if let currency = manager.network.currencyBy(code: $0) {
+                        let _ = manager.requireWalletFor(currency: currency)
+                    }
+            }
 
         case .discoveredNetworks (let networks):
             let allCurrencies = networks.flatMap { $0.currencies }

--- a/crypto/BRCryptoWalletManager.c
+++ b/crypto/BRCryptoWalletManager.c
@@ -437,8 +437,8 @@ cryptoWalletManagerGetWalletForCurrency (BRCryptoWalletManager cwm,
 }
 
 extern BRCryptoWallet
-cryptoWalletManagerRequireWalletForCurrency (BRCryptoWalletManager cwm,
-                                             BRCryptoCurrency currency) {
+cryptoWalletManagerRegisterWallet (BRCryptoWalletManager cwm,
+                                   BRCryptoCurrency currency) {
     BRCryptoWallet wallet = cryptoWalletManagerGetWalletForCurrency (cwm, currency);
     if (NULL == wallet) {
         switch (cwm->type) {

--- a/crypto/BRCryptoWalletManager.h
+++ b/crypto/BRCryptoWalletManager.h
@@ -193,6 +193,10 @@ extern "C" {
     cryptoWalletManagerGetWalletForCurrency (BRCryptoWalletManager cwm,
                                              BRCryptoCurrency currency);
 
+    extern BRCryptoWallet
+    cryptoWalletManagerRequireWalletForCurrency (BRCryptoWalletManager cwm,
+                                                 BRCryptoCurrency currency);
+
     extern void
     cryptoWalletManagerConnect (BRCryptoWalletManager cwm);
 

--- a/crypto/BRCryptoWalletManager.h
+++ b/crypto/BRCryptoWalletManager.h
@@ -194,8 +194,8 @@ extern "C" {
                                              BRCryptoCurrency currency);
 
     extern BRCryptoWallet
-    cryptoWalletManagerRequireWalletForCurrency (BRCryptoWalletManager cwm,
-                                                 BRCryptoCurrency currency);
+    cryptoWalletManagerRegisterWallet (BRCryptoWalletManager cwm,
+                                       BRCryptoCurrency currency);
 
     extern void
     cryptoWalletManagerConnect (BRCryptoWalletManager cwm);


### PR DESCRIPTION
What is your feeling on this.  I think `requireWalletFor(...)` returning `Wallet?` is a bit awkward - unlike other interfaces.

It might be better to axe this function (as least publicly) and provide something at the `System` level.  Thinking...

Maybe add a `currencies: [Currency]` argument to `<system>.createWalletManager (..., currencies)`?  The `createWalletManager` call occurs in .networkAdded so all the currencies are known; they can be filtered by the App and then handled on CWM create.  <== This is better, no?