### PR TITLE
CORE-584: In Core Ethereum, during ewmCreate(), don't create ERC20 wallets up-front.

### DIFF
--- a/Swift/BRCryptoDemo/CoreDemoAppDelegate.swift
+++ b/Swift/BRCryptoDemo/CoreDemoAppDelegate.swift
@@ -37,7 +37,7 @@ class CoreDemoAppDelegate: UIResponder, UIApplicationDelegate, UISplitViewContro
     var btcPeer: NetworkPeer? = nil
     var btcPeerUse = false
 
-    var clearPersistentData: Bool = true
+    var clearPersistentData: Bool = false
 
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
         // Override point for customization after application launch.

--- a/ethereum/ewm/BREthereumEWM.c
+++ b/ethereum/ewm/BREthereumEWM.c
@@ -619,18 +619,8 @@ ewmCreate (BREthereumNetwork network,
 
     // Create a default ETH wallet; other wallets will be created 'on demand'.  This will signal
     // a WALLET_EVENT_CREATED event.
-    ewm->walletHoldingEther = walletCreate(ewm->account,
-                                           ewm->network);
-    ewmInsertWallet(ewm, ewm->walletHoldingEther);
-
-    // Create a wallet for each TOK.  This will signal a WALLET_EVENT_CREATED event.
-    FOR_SET(BREthereumToken, token, tokens) {
-        // Add token
-        BREthereumWallet wallet = walletCreateHoldingToken (ewm->account,
-                                                            ewm->network,
-                                                            token);
-        ewmInsertWallet (ewm, wallet);
-    }
+    ewm->walletHoldingEther = walletCreate (ewm->account, ewm->network);
+    ewmInsertWallet (ewm, ewm->walletHoldingEther);
 
     // Create the BCS listener - allows EWM to handle block, peer, transaction and log events.
     BREthereumBCSListener listener = ewmCreateBCSListener (ewm);


### PR DESCRIPTION
The ETH code says:
```
// Create a default ETH wallet; other wallets will be created 'on demand'.
```
and then it went ahead and created the others.  Thankfully they truly are 'on-demand', via `ewmHandleLog()` - called in both API and P2P modes.

Maybe next time test with `clearPersistentData` set to both `true` and `false`?