### PR TITLE
CORE-599: In Core Ethereum, in `ewmCreate()` announce the provided `blockHeight`

### DIFF
--- a/ethereum/ewm/BREthereumEWM.c
+++ b/ethereum/ewm/BREthereumEWM.c
@@ -682,7 +682,7 @@ ewmCreate (BREthereumNetwork network,
             //
             // One.Event.to.Update.Them.All
             ewmSignalUpdateWalletBalances(ewm);
-
+#if 0
             // ... and then the latest block.
             BREthereumBlock lastBlock = NULL;
             FOR_SET (BREthereumBlock, block, blocks)
@@ -692,6 +692,23 @@ ewmCreate (BREthereumNetwork network,
                                  blockGetHash( lastBlock),
                                  blockGetNumber (lastBlock),
                                  blockGetTimestamp (lastBlock));
+#endif
+            // Use the provided `blockHeight` in API modes.  We only have the `blockHeight` as a
+            // parameter, thus calling `ewmSignalBlockChain()` with 'empty' values for `blockHash`
+            // and `blockTimestamp` works because we know that `ewmHandleBlockChain` doesn't use
+            // those parameters.
+            //
+            // What was the expectation of the above `lastBlock` code in API modes?  It might have
+            // been from a time when `blockHeight` was not passed in as a parameters and thus we
+            // need some block height and the best we could do was the saved blocks (like from a
+            // P2P mode) or the checkpoint which is always there, at least.
+            //
+            // Our current API appraoch is to use BlockSet where a) we have the current block height
+            // or b) if BlockSet, is down we hardcode the block height at the time of the software
+            // distribution (See System.supportedBlockchains) - either way we have a better
+            // current block height than any checkpoint.
+            
+            ewmSignalBlockChain (ewm, EMPTY_HASH_INIT, ewm->blockHeight, 0);
 
             // ... and then just ignore nodes
 


### PR DESCRIPTION
Don't announce the 'lastBlock' height, which is at best old and at worst the earliestKeyTime checkpoint block.