### PR TITLE
CORE-601: If the eth_blocknumber query produces '0', return Result.failure

### DIFF
--- a/Swift/BRCrypto/BRCryptoSystem.swift
+++ b/Swift/BRCrypto/BRCryptoSystem.swift
@@ -1505,7 +1505,14 @@ extension System {
                 manager.query.getBlockNumberAsETH (network: network) {
                     (res: Result<String, BlockChainDB.QueryError>) in
                     defer { cryptoWalletManagerGive (cwm!) }
-                    res.resolve (
+                    // If we get a successful response, but the provided blocknumber is "0" then
+                    // that indicates that the JSON-RPC node is syncing.  Thus, if "0" transform
+                    // to a .failure
+                    res.flatMap {
+                        return ($0 != "0" && $0 != "0x0"
+                            ? Result.success ($0)
+                            : Result.failure (BlockChainDB.QueryError.noData))
+                    }.resolve (
                         success: { cwmAnnounceGetBlockNumberSuccessAsString (cwm, sid, $0) },
                         failure: { (_) in cwmAnnounceGetBlockNumberFailure (cwm, sid) })
                 }},


### PR DESCRIPTION
A '0' indicates that the queried ETH node is in the process of syncing.

Requires a corresponding Java change.  [I did the validity check in the System.swift in `funcGetBlockNumber` for the ETH callbacks.  To me, the JSON-RPC returning "0" is wrong; it should be returning some 'error code' - so passing "0" along into CryptoC as an error flag is wrong.  But maybe I can be convinced otherwise.]