### PR TITLE
CORE-598: In Core Ethereum, Persistently Store Balance and Nonce

### DIFF
--- a/Java/Core/CMakeLists.txt
+++ b/Java/Core/CMakeLists.txt
@@ -290,6 +290,7 @@ target_sources (core
                 src/main/cpp/core/ethereum/ewm/BREthereumEWM.h
                 src/main/cpp/core/ethereum/ewm/BREthereumEWMClient.c
                 src/main/cpp/core/ethereum/ewm/BREthereumEWMEvent.c
+                src/main/cpp/core/ethereum/ewm/BREthereumEWMPersist.c
                 src/main/cpp/core/ethereum/ewm/BREthereumEWMPrivate.h
 #                src/main/cpp/core/ethereum/ewm/testEwm.c
                 )

--- a/Java/CoreNative/CMakeLists.txt
+++ b/Java/CoreNative/CMakeLists.txt
@@ -252,6 +252,7 @@ target_sources (crypto
                 src/main/cpp/core/ethereum/ewm/BREthereumEWM.h
                 src/main/cpp/core/ethereum/ewm/BREthereumEWMClient.c
                 src/main/cpp/core/ethereum/ewm/BREthereumEWMEvent.c
+                src/main/cpp/core/ethereum/ewm/BREthereumEWMPersist.c
                 src/main/cpp/core/ethereum/ewm/BREthereumEWMPrivate.h)
 
 # Ethereum Tests

--- a/Java/CryptoDemo/src/main/java/com/breadwallet/cryptodemo/CoreCryptoApplication.java
+++ b/Java/CryptoDemo/src/main/java/com/breadwallet/cryptodemo/CoreCryptoApplication.java
@@ -141,10 +141,8 @@ public class CoreCryptoApplication extends Application {
             WalletManagerMode mode = intent.hasExtra(EXTRA_MODE) ? WalletManagerMode.valueOf(intent.getStringExtra(EXTRA_MODE)) : DEFAULT_MODE;
 
             storageFile = new File(getFilesDir(), "core");
-            if (wipe) {
-                if (storageFile.exists()) deleteRecursively(storageFile);
-                checkState(storageFile.mkdirs());
-            }
+            if (wipe) deleteRecursively(storageFile);
+            if (!storageFile.exists()) checkState(storageFile.mkdirs());
 
             Log.d(TAG, String.format("Account PaperKey:  %s", paperKeyString));
             Log.d(TAG, String.format("Account Timestamp: %s", timestamp));

--- a/Swift/BRCore.xcodeproj/project.pbxproj
+++ b/Swift/BRCore.xcodeproj/project.pbxproj
@@ -60,6 +60,8 @@
 		3C5E1771232D461500A558C7 /* LICENSE in Resources */ = {isa = PBXBuildFile; fileRef = 3C5E176F232D461500A558C7 /* LICENSE */; };
 		3C5E1773232D466700A558C7 /* CONTRIBUTORS in Resources */ = {isa = PBXBuildFile; fileRef = 3C5E1772232D466700A558C7 /* CONTRIBUTORS */; };
 		3C5F5E75212C82310038B732 /* BREthereumMPT.c in Sources */ = {isa = PBXBuildFile; fileRef = 3C5F5E74212C82310038B732 /* BREthereumMPT.c */; };
+		3C69A0EA233AC0FE005E7033 /* BREthereumEWMPersist.c in Sources */ = {isa = PBXBuildFile; fileRef = 3C69A0E9233AC0FE005E7033 /* BREthereumEWMPersist.c */; };
+		3C69A0EB233AC0FE005E7033 /* BREthereumEWMPersist.c in Sources */ = {isa = PBXBuildFile; fileRef = 3C69A0E9233AC0FE005E7033 /* BREthereumEWMPersist.c */; };
 		3C6AE12B2329855300016196 /* sqlite3.c in Sources */ = {isa = PBXBuildFile; fileRef = 3C6AE1272329855300016196 /* sqlite3.c */; settings = {COMPILER_FLAGS = "-D_HAVE_SQLITE_CONFIG_H=1 -Wno-ambiguous-macro -Wno-shorten-64-to-32 -Wno-unreachable-code -Wno-#warnings"; }; };
 		3C6AE12D2329856F00016196 /* sqlite3.c in Sources */ = {isa = PBXBuildFile; fileRef = 3C6AE1272329855300016196 /* sqlite3.c */; };
 		3C6B172F2131CB5B003C313B /* main.c in Sources */ = {isa = PBXBuildFile; fileRef = 3C6B172E2131CB5B003C313B /* main.c */; };
@@ -569,6 +571,7 @@
 		3C5E1804232D574A00A558C7 /* README */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = README; sourceTree = "<group>"; };
 		3C5F5E73212C82310038B732 /* BREthereumMPT.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = BREthereumMPT.h; sourceTree = "<group>"; };
 		3C5F5E74212C82310038B732 /* BREthereumMPT.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = BREthereumMPT.c; sourceTree = "<group>"; };
+		3C69A0E9233AC0FE005E7033 /* BREthereumEWMPersist.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = BREthereumEWMPersist.c; sourceTree = "<group>"; };
 		3C6AE1272329855300016196 /* sqlite3.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = sqlite3.c; sourceTree = "<group>"; };
 		3C6AE1282329855300016196 /* shell.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = shell.c; sourceTree = "<group>"; };
 		3C6AE1292329855300016196 /* sqlite3.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = sqlite3.h; sourceTree = "<group>"; };
@@ -1018,6 +1021,7 @@
 				3C2A53A220AF595400C430F6 /* BREthereumEWM.c */,
 				3C386DD220C6F6070065E355 /* BREthereumEWMEvent.c */,
 				3C386DD120C6F6060065E355 /* BREthereumEWMClient.c */,
+				3C69A0E9233AC0FE005E7033 /* BREthereumEWMPersist.c */,
 				3C9025F82106511700143B69 /* testEwm.c */,
 			);
 			path = ewm;
@@ -1909,6 +1913,7 @@
 				3CFEFE2422BC3AF20044153D /* BRCryptoWalletManagerClient.c in Sources */,
 				3C25BF482236EE40004B093F /* BRBCashParams.c in Sources */,
 				3C6B17552131CE12003C313B /* BRUtilMath.c in Sources */,
+				3C69A0EB233AC0FE005E7033 /* BREthereumEWMPersist.c in Sources */,
 				3C6B17562131CE12003C313B /* BRUtilMathParse.c in Sources */,
 				3C6B17572131CE12003C313B /* BRUtilHex.c in Sources */,
 				3C6B17582131CE12003C313B /* BRBCashAddr.c in Sources */,
@@ -2025,6 +2030,7 @@
 				3CF66AE722A8358200C1E9BB /* BRCryptoNetwork.c in Sources */,
 				3CAB60D320AF8D1A00810CE4 /* BRUtilMathParse.c in Sources */,
 				3CAB60D420AF8D1A00810CE4 /* BRUtilHex.c in Sources */,
+				3C69A0EA233AC0FE005E7033 /* BREthereumEWMPersist.c in Sources */,
 				3CAB60D520AF8D1A00810CE4 /* BRBCashAddr.c in Sources */,
 				3CF66AE622A8342200C1E9BB /* BRCryptoWalletManager.c in Sources */,
 				3C6AE12B2329855300016196 /* sqlite3.c in Sources */,

--- a/Swift/BRCryptoDemo/CoreDemoAppDelegate.swift
+++ b/Swift/BRCryptoDemo/CoreDemoAppDelegate.swift
@@ -90,20 +90,23 @@ class CoreDemoAppDelegate: UIResponder, UIApplicationDelegate, UISplitViewContro
             .urls(for: .documentDirectory, in: .userDomainMask)[0]
             .appendingPathComponent("Core").path
 
-        if clearPersistentData {
-            do {
+        do {
+            // If data shouild be cleared, then remove `storagePath`
+            if clearPersistentData {
                 if FileManager.default.fileExists(atPath: storagePath) {
                     try FileManager.default.removeItem(atPath: storagePath)
                 }
+            }
 
-                try FileManager.default.createDirectory (atPath: storagePath,
-                                                         withIntermediateDirectories: true,
-                                                         attributes: nil)
-            }
-            catch let error as NSError {
-                print("Error: \(error.localizedDescription)")
-            }
+            // Ensure that `storagePath` exists
+            try FileManager.default.createDirectory (atPath: storagePath,
+                                                     withIntermediateDirectories: true,
+                                                     attributes: nil)
         }
+        catch let error as NSError {
+            print("Error: \(error.localizedDescription)")
+        }
+
         
         print ("APP: Account PaperKey  : \(accountSpecification.paperKey.components(separatedBy: CharacterSet.whitespaces).first ?? "<missed>") ...")
         print ("APP: Account Timestamp : \(account.timestamp)")

--- a/ethereum/ewm/BREthereumEWM.c
+++ b/ethereum/ewm/BREthereumEWM.c
@@ -52,60 +52,10 @@ ewmPeriodicDispatcher (BREventHandler handler,
 
 /// MARK: - Transaction File Service
 
-static const char *fileServiceTypeTransactions = "transactions";
-
-enum {
-    EWM_TRANSACTION_VERSION_1
-};
-
-static UInt256
-fileServiceTypeTransactionV1Identifier (BRFileServiceContext context,
-                                        BRFileService fs,
-                                        const void *entity) {
-    BREthereumTransaction transaction = (BREthereumTransaction) entity;
-    BREthereumHash hash = transactionGetHash(transaction);
-
-    UInt256 result;
-    memcpy (result.u8, hash.bytes, ETHEREUM_HASH_BYTES);
-    return result;
-}
-
-static uint8_t *
-fileServiceTypeTransactionV1Writer (BRFileServiceContext context,
-                                    BRFileService fs,
-                                    const void* entity,
-                                    uint32_t *bytesCount) {
-    BREthereumEWM ewm = context;
-    BREthereumTransaction transaction = (BREthereumTransaction) entity;
-
-    BRRlpItem item = transactionRlpEncode(transaction, ewm->network, RLP_TYPE_ARCHIVE, ewm->coder);
-    BRRlpData data = rlpGetData (ewm->coder, item);
-    rlpReleaseItem (ewm->coder, item);
-
-    *bytesCount = (uint32_t) data.bytesCount;
-    return data.bytes;
-}
-
-static void *
-fileServiceTypeTransactionV1Reader (BRFileServiceContext context,
-                                    BRFileService fs,
-                                    uint8_t *bytes,
-                                    uint32_t bytesCount) {
-    BREthereumEWM ewm = context;
-
-    BRRlpData data = { bytesCount, bytes };
-    BRRlpItem item = rlpGetItem (ewm->coder, data);
-
-    BREthereumTransaction transaction = transactionRlpDecode(item, ewm->network, RLP_TYPE_ARCHIVE, ewm->coder);
-    rlpReleaseItem (ewm->coder, item);
-
-    return transaction;
-}
-
 static BRSetOf(BREthereumTransaction)
 initialTransactionsLoad (BREthereumEWM ewm) {
     BRSetOf(BREthereumTransaction) transactions = BRSetNew(transactionHashValue, transactionHashEqual, EWM_INITIAL_SET_SIZE_DEFAULT);
-    if (NULL != transactions && 1 != fileServiceLoad (ewm->fs, transactions, fileServiceTypeTransactions, 1)) {
+    if (NULL != transactions && 1 != fileServiceLoad (ewm->fs, transactions, ewmFileServiceTypeTransactions, 1)) {
         BRSetFreeAll (transactions, (void (*) (void*)) transactionRelease);
         return NULL;
     }
@@ -114,60 +64,10 @@ initialTransactionsLoad (BREthereumEWM ewm) {
 
 /// MARK: - Log File Service
 
-static const char *fileServiceTypeLogs = "logs";
-
-enum {
-    EWM_LOG_VERSION_1
-};
-
-static UInt256
-fileServiceTypeLogV1Identifier (BRFileServiceContext context,
-                                BRFileService fs,
-                                const void *entity) {
-    const BREthereumLog log = (BREthereumLog) entity;
-    BREthereumHash hash = logGetHash( log);
-
-    UInt256 result;
-    memcpy (result.u8, hash.bytes, ETHEREUM_HASH_BYTES);
-    return result;
-}
-
-static uint8_t *
-fileServiceTypeLogV1Writer (BRFileServiceContext context,
-                            BRFileService fs,
-                            const void* entity,
-                            uint32_t *bytesCount) {
-    BREthereumEWM ewm = context;
-    BREthereumLog log = (BREthereumLog) entity;
-
-    BRRlpItem item = logRlpEncode (log, RLP_TYPE_ARCHIVE, ewm->coder);
-    BRRlpData data = rlpGetData (ewm->coder, item);
-    rlpReleaseItem (ewm->coder, item);
-
-    *bytesCount = (uint32_t) data.bytesCount;
-    return data.bytes;
-}
-
-static void *
-fileServiceTypeLogV1Reader (BRFileServiceContext context,
-                            BRFileService fs,
-                            uint8_t *bytes,
-                            uint32_t bytesCount) {
-    BREthereumEWM ewm = context;
-
-    BRRlpData data = { bytesCount, bytes };
-    BRRlpItem item = rlpGetItem (ewm->coder, data);
-
-    BREthereumLog log = logRlpDecode(item, RLP_TYPE_ARCHIVE, ewm->coder);
-    rlpReleaseItem (ewm->coder, item);
-
-    return log;
-}
-
 static BRSetOf(BREthereumLog)
 initialLogsLoad (BREthereumEWM ewm) {
     BRSetOf(BREthereumLog) logs = BRSetNew(logHashValue, logHashEqual, EWM_INITIAL_SET_SIZE_DEFAULT);
-    if (NULL != logs && 1 != fileServiceLoad (ewm->fs, logs, fileServiceTypeLogs, 1)) {
+    if (NULL != logs && 1 != fileServiceLoad (ewm->fs, logs, ewmFileServiceTypeLogs, 1)) {
         BRSetFreeAll (logs, (void (*) (void*)) logRelease);
         return NULL;
     }
@@ -175,185 +75,30 @@ initialLogsLoad (BREthereumEWM ewm) {
 }
 
 
-/// MARK: - Block File Service
-
-static const char *fileServiceTypeBlocks = "blocks";
-enum {
-    EWM_BLOCK_VERSION_1
-};
-
-static UInt256
-fileServiceTypeBlockV1Identifier (BRFileServiceContext context,
-                                  BRFileService fs,
-                                  const void *entity) {
-    const BREthereumBlock block = (BREthereumBlock) entity;
-    BREthereumHash hash = blockGetHash(block);
-
-    UInt256 result;
-    memcpy (result.u8, hash.bytes, ETHEREUM_HASH_BYTES);
-    return result;
-}
-
-static uint8_t *
-fileServiceTypeBlockV1Writer (BRFileServiceContext context,
-                              BRFileService fs,
-                              const void* entity,
-                              uint32_t *bytesCount) {
-    BREthereumEWM ewm = context;
-    BREthereumBlock block = (BREthereumBlock) entity;
-
-    BRRlpItem item = blockRlpEncode(block, ewm->network, RLP_TYPE_ARCHIVE, ewm->coder);
-    BRRlpData data = rlpGetData (ewm->coder, item);
-    rlpReleaseItem (ewm->coder, item);
-
-    *bytesCount = (uint32_t) data.bytesCount;
-    return data.bytes;
-}
-
-static void *
-fileServiceTypeBlockV1Reader (BRFileServiceContext context,
-                              BRFileService fs,
-                              uint8_t *bytes,
-                              uint32_t bytesCount) {
-    BREthereumEWM ewm = context;
-
-    BRRlpData data = { bytesCount, bytes };
-    BRRlpItem item = rlpGetItem (ewm->coder, data);
-
-    BREthereumBlock block = blockRlpDecode (item, ewm->network, RLP_TYPE_ARCHIVE, ewm->coder);
-    rlpReleaseItem (ewm->coder, item);
-
-    return block;
-}
-
 static BRSetOf(BREthereumBlock)
 initialBlocksLoad (BREthereumEWM ewm) {
     BRSetOf(BREthereumBlock) blocks = BRSetNew(blockHashValue, blockHashEqual, EWM_INITIAL_SET_SIZE_DEFAULT);
-    if (NULL != blocks && 1 != fileServiceLoad (ewm->fs, blocks, fileServiceTypeBlocks, 1)) {
+    if (NULL != blocks && 1 != fileServiceLoad (ewm->fs, blocks, ewmFileServiceTypeBlocks, 1)) {
         BRSetFreeAll (blocks,  (void (*) (void*)) blockRelease);
         return NULL;
     }
     return blocks;
 }
 
-/// MARK: - Node File Service
-
-static const char *fileServiceTypeNodes = "nodes";
-enum {
-    EWM_NODE_VERSION_1
-};
-
-static UInt256
-fileServiceTypeNodeV1Identifier (BRFileServiceContext context,
-                                 BRFileService fs,
-                                 const void *entity) {
-    const BREthereumNodeConfig node = (BREthereumNodeConfig) entity;
-
-    BREthereumHash hash = nodeConfigGetHash(node);
-
-    UInt256 result;
-    memcpy (result.u8, hash.bytes, ETHEREUM_HASH_BYTES);
-    return result;
-}
-
-static uint8_t *
-fileServiceTypeNodeV1Writer (BRFileServiceContext context,
-                             BRFileService fs,
-                             const void* entity,
-                             uint32_t *bytesCount) {
-    BREthereumEWM ewm = context;
-    const BREthereumNodeConfig node = (BREthereumNodeConfig) entity;
-
-    BRRlpItem item = nodeConfigEncode (node, ewm->coder);
-    BRRlpData data = rlpGetData (ewm->coder, item);
-    rlpReleaseItem (ewm->coder, item);
-
-    *bytesCount = (uint32_t) data.bytesCount;
-    return data.bytes;
-}
-
-static void *
-fileServiceTypeNodeV1Reader (BRFileServiceContext context,
-                             BRFileService fs,
-                             uint8_t *bytes,
-                             uint32_t bytesCount) {
-    BREthereumEWM ewm = context;
-
-    BRRlpData data = { bytesCount, bytes };
-    BRRlpItem item = rlpGetItem (ewm->coder, data);
-
-    BREthereumNodeConfig node = nodeConfigDecode (item, ewm->coder);
-    rlpReleaseItem (ewm->coder, item);
-
-    return node;
-}
-
 static BRSetOf(BREthereumNodeConfig)
 initialNodesLoad (BREthereumEWM ewm) {
     BRSetOf(BREthereumNodeConfig) nodes = BRSetNew(nodeConfigHashValue, nodeConfigHashEqual, EWM_INITIAL_SET_SIZE_DEFAULT);
-    if (NULL != nodes && 1 != fileServiceLoad (ewm->fs, nodes, fileServiceTypeNodes, 1)) {
+    if (NULL != nodes && 1 != fileServiceLoad (ewm->fs, nodes, ewmFileServiceTypeNodes, 1)) {
         BRSetFreeAll (nodes, (void (*) (void*)) nodeConfigRelease);
         return NULL;
     }
     return nodes;
 }
 
-/// MARK: - Token File Service
-
-static const char *fileServiceTypeTokens = "tokens";
-
-enum {
-    EWM_TOKEN_VERSION_1
-};
-
-static UInt256
-fileServiceTypeTokenV1Identifier (BRFileServiceContext context,
-                                        BRFileService fs,
-                                        const void *entity) {
-    BREthereumToken token = (BREthereumToken) entity;
-    BREthereumHash hash = tokenGetHash(token);
-
-    UInt256 result;
-    memcpy (result.u8, hash.bytes, ETHEREUM_HASH_BYTES);
-    return result;
-}
-
-static uint8_t *
-fileServiceTypeTokenV1Writer (BRFileServiceContext context,
-                                    BRFileService fs,
-                                    const void* entity,
-                                    uint32_t *bytesCount) {
-    BREthereumEWM ewm = context;
-    BREthereumToken token = (BREthereumToken) entity;
-
-    BRRlpItem item = tokenEncode(token, ewm->coder);
-    BRRlpData data = rlpGetData (ewm->coder, item);
-    rlpReleaseItem (ewm->coder, item);
-
-    *bytesCount = (uint32_t) data.bytesCount;
-    return data.bytes;
-}
-
-static void *
-fileServiceTypeTokenV1Reader (BRFileServiceContext context,
-                                    BRFileService fs,
-                                    uint8_t *bytes,
-                                    uint32_t bytesCount) {
-    BREthereumEWM ewm = context;
-
-    BRRlpData data = { bytesCount, bytes };
-    BRRlpItem item = rlpGetItem (ewm->coder, data);
-
-    BREthereumToken token = tokenDecode(item, ewm->coder);
-    rlpReleaseItem (ewm->coder, item);
-
-    return token;
-}
-
 static BRSetOf(BREthereumToken)
 initialTokensLoad (BREthereumEWM ewm) {
     BRSetOf(BREthereumToken) tokens = tokenSetCreate (EWM_INITIAL_SET_SIZE_DEFAULT);
-    if (NULL != tokens && 1 != fileServiceLoad (ewm->fs, tokens, fileServiceTypeTokens, 1)) {
+    if (NULL != tokens && 1 != fileServiceLoad (ewm->fs, tokens, ewmFileServiceTypeTokens, 1)) {
         BRSetFreeAll (tokens, (void (*) (void*)) tokenRelease);
         return NULL;
     }
@@ -530,62 +275,12 @@ ewmCreate (BREthereumNetwork network,
 
     // The file service.  Initialize {nodes, blocks, transactions and logs} from the FileService
 
-    ewm->fs = fileServiceCreate (storagePath, "eth", networkGetName(network),
-                                 ewm,
-                                 ewmFileServiceErrorHandler);
+    ewm->fs = fileServiceCreateFromTypeSpecfications (storagePath, "eth", networkGetName(network),
+                                                      ewm,
+                                                      ewmFileServiceErrorHandler,
+                                                      ewmFileServiceSpecificationsCount,
+                                                      ewmFileServiceSpecifications);
     if (NULL == ewm->fs) return ewmCreateErrorHandler(ewm, 1, "create");
-
-    /// Transaction
-    if (1 != fileServiceDefineType (ewm->fs, fileServiceTypeTransactions, EWM_TRANSACTION_VERSION_1,
-                                    (BRFileServiceContext) ewm,
-                                    fileServiceTypeTransactionV1Identifier,
-                                    fileServiceTypeTransactionV1Reader,
-                                    fileServiceTypeTransactionV1Writer) ||
-        1 != fileServiceDefineCurrentVersion (ewm->fs, fileServiceTypeTransactions,
-                                              EWM_TRANSACTION_VERSION_1))
-        return ewmCreateErrorHandler(ewm, 1, fileServiceTypeTransactions);
-
-    /// Log
-    if (1 != fileServiceDefineType (ewm->fs, fileServiceTypeLogs, EWM_LOG_VERSION_1,
-                                    (BRFileServiceContext) ewm,
-                                    fileServiceTypeLogV1Identifier,
-                                    fileServiceTypeLogV1Reader,
-                                    fileServiceTypeLogV1Writer) ||
-        1 != fileServiceDefineCurrentVersion (ewm->fs, fileServiceTypeLogs,
-                                              EWM_LOG_VERSION_1))
-        return ewmCreateErrorHandler(ewm, 1, fileServiceTypeLogs);
-
-    /// Peer
-    if (1 != fileServiceDefineType (ewm->fs, fileServiceTypeNodes, EWM_NODE_VERSION_1,
-                                    (BRFileServiceContext) ewm,
-                                    fileServiceTypeNodeV1Identifier,
-                                    fileServiceTypeNodeV1Reader,
-                                    fileServiceTypeNodeV1Writer) ||
-        1 != fileServiceDefineCurrentVersion (ewm->fs, fileServiceTypeNodes,
-                                              EWM_NODE_VERSION_1))
-        return ewmCreateErrorHandler(ewm, 1, fileServiceTypeNodes);
-
-
-   /// Block
-    if (1 != fileServiceDefineType (ewm->fs, fileServiceTypeBlocks, EWM_BLOCK_VERSION_1,
-                                    (BRFileServiceContext) ewm,
-                                    fileServiceTypeBlockV1Identifier,
-                                    fileServiceTypeBlockV1Reader,
-                                    fileServiceTypeBlockV1Writer) ||
-        1 != fileServiceDefineCurrentVersion (ewm->fs, fileServiceTypeBlocks,
-                                              EWM_BLOCK_VERSION_1))
-        return ewmCreateErrorHandler(ewm, 1, fileServiceTypeBlocks);
-
-    /// Token
-    if (1 != fileServiceDefineType (ewm->fs, fileServiceTypeTokens, EWM_TOKEN_VERSION_1,
-                                    (BRFileServiceContext) ewm,
-                                    fileServiceTypeTokenV1Identifier,
-                                    fileServiceTypeTokenV1Reader,
-                                    fileServiceTypeTokenV1Writer) ||
-        1 != fileServiceDefineCurrentVersion (ewm->fs, fileServiceTypeTokens,
-                                              EWM_TOKEN_VERSION_1))
-        return ewmCreateErrorHandler(ewm, 1, fileServiceTypeTokens);
-
 
     // Load all the persistent entities
     BRSetOf(BREthereumTransaction) transactions;
@@ -2382,10 +2077,10 @@ ewmHandleSaveBlocks (BREthereumEWM ewm,
     size_t count = array_count(blocks);
 
     eth_log("EWM", "Save Blocks (Storage): %zu", count);
-    fileServiceClear(ewm->fs, fileServiceTypeBlocks);
+    fileServiceClear(ewm->fs, ewmFileServiceTypeBlocks);
 
     for (size_t index = 0; index < count; index++)
-        fileServiceSave (ewm->fs, fileServiceTypeBlocks, blocks[index]);
+        fileServiceSave (ewm->fs, ewmFileServiceTypeBlocks, blocks[index]);
     array_free (blocks);
 }
 
@@ -2395,10 +2090,10 @@ ewmHandleSaveNodes (BREthereumEWM ewm,
     size_t count = array_count(nodes);
 
     eth_log("EWM", "Save Nodes (Storage): %zu", count);
-    fileServiceClear(ewm->fs, fileServiceTypeNodes);
+    fileServiceClear(ewm->fs, ewmFileServiceTypeNodes);
 
     for (size_t index = 0; index < count; index++)
-        fileServiceSave(ewm->fs, fileServiceTypeNodes, nodes[index]);
+        fileServiceSave(ewm->fs, ewmFileServiceTypeNodes, nodes[index]);
 
     array_free (nodes);
 }
@@ -2416,11 +2111,11 @@ ewmHandleSaveTransaction (BREthereumEWM ewm,
             fileName);
 
     if (CLIENT_CHANGE_REM == type || CLIENT_CHANGE_UPD == type)
-        fileServiceRemove (ewm->fs, fileServiceTypeTransactions,
-                           fileServiceTypeTransactionV1Identifier (ewm, ewm->fs, transaction));
+        fileServiceRemove (ewm->fs, ewmFileServiceTypeTransactions,
+                           fileServiceGetIdentifier(ewm->fs, ewmFileServiceTypeTransactions, transaction));
 
     if (CLIENT_CHANGE_ADD == type || CLIENT_CHANGE_UPD == type)
-        fileServiceSave (ewm->fs, fileServiceTypeTransactions, transaction);
+        fileServiceSave (ewm->fs, ewmFileServiceTypeTransactions, transaction);
 }
 
 extern void
@@ -2436,11 +2131,11 @@ ewmHandleSaveLog (BREthereumEWM ewm,
             filename);
 
     if (CLIENT_CHANGE_REM == type || CLIENT_CHANGE_UPD == type)
-        fileServiceRemove (ewm->fs, fileServiceTypeLogs,
-                           fileServiceTypeLogV1Identifier(ewm, ewm->fs, log));
+        fileServiceRemove (ewm->fs, ewmFileServiceTypeLogs,
+                           fileServiceGetIdentifier (ewm->fs, ewmFileServiceTypeLogs, log));
 
     if (CLIENT_CHANGE_ADD == type || CLIENT_CHANGE_UPD == type)
-        fileServiceSave (ewm->fs, fileServiceTypeLogs, log);
+        fileServiceSave (ewm->fs, ewmFileServiceTypeLogs, log);
 }
 
 extern void
@@ -3144,6 +2839,6 @@ ewmCreateToken (BREthereumEWM ewm,
     }
     pthread_mutex_unlock (&ewm->lock);
 
-    fileServiceSave (ewm->fs, fileServiceTypeTokens, token);
+    fileServiceSave (ewm->fs, ewmFileServiceTypeTokens, token);
     return token;
 }

--- a/ethereum/ewm/BREthereumEWM.c
+++ b/ethereum/ewm/BREthereumEWM.c
@@ -2139,6 +2139,33 @@ ewmHandleSaveLog (BREthereumEWM ewm,
 }
 
 extern void
+ewmHandleSaveWallet (BREthereumEWM ewm,
+                     BREthereumWallet wallet,
+                     BREthereumClientChangeType type) {
+    BREthereumWalletState state = walletStateCreate (wallet);
+
+    BREthereumHash hash = walletStateGetHash(state);
+    BREthereumHashString filename;
+    hashFillString(hash, filename);
+
+    eth_log ("EWM", "Wallet: Save: %s: %s",
+             CLIENT_CHANGE_TYPE_NAME (type),
+             filename);
+
+    switch (type) {
+        case CLIENT_CHANGE_REM:
+            fileServiceRemove (ewm->fs, ewmFileServiceTypeWallets,
+                               fileServiceGetIdentifier (ewm->fs, ewmFileServiceTypeWallets, state));
+            break;
+
+        case CLIENT_CHANGE_ADD:
+        case CLIENT_CHANGE_UPD:
+            fileServiceSave (ewm->fs, ewmFileServiceTypeWallets, state);
+            break;
+    }
+}
+
+extern void
 ewmHandleSync (BREthereumEWM ewm,
                BREthereumBCSCallbackSyncType type,
                uint64_t blockNumberStart,

--- a/ethereum/ewm/BREthereumEWMClient.c
+++ b/ethereum/ewm/BREthereumEWMClient.c
@@ -888,11 +888,20 @@ ewmAnnounceTokenComplete (BREthereumEWM ewm,
 //
 // Client
 //
+static int
+ewmNeedWalletSave (BREthereumEWM ewm,
+                   BREthereumWallet wid,
+                   BREthereumWalletEvent event) {
+    return (WALLET_EVENT_BALANCE_UPDATED == event.type); // CREATED?
+}
 
 extern void
 ewmHandleWalletEvent(BREthereumEWM ewm,
                      BREthereumWallet wid,
                      BREthereumWalletEvent event) {
+    if (ewmNeedWalletSave (ewm, wid, event))
+        ewmHandleSaveWallet (ewm, wid, CLIENT_CHANGE_UPD);
+
     ewm->client.funcWalletEvent (ewm->client.context,
                                  ewm,
                                  wid,

--- a/ethereum/ewm/BREthereumEWMClient.c
+++ b/ethereum/ewm/BREthereumEWMClient.c
@@ -350,12 +350,17 @@ ewmAnnounceNonce (BREthereumEWM ewm,
  */
 extern void
 ewmHandleAnnounceNonce (BREthereumEWM ewm,
-                              BREthereumAddress address,
-                              uint64_t nonce,
-                              int rid) {
-    //    BREthereumEncodedAddress address = accountGetPrimaryAddress (ewmGetAccount(ewm));
-    //    assert (ETHEREUM_BOOLEAN_IS_TRUE (addressHasString(address, strAddress)));
-    accountSetAddressNonce(ewm->account, accountGetPrimaryAddress(ewm->account), nonce, ETHEREUM_BOOLEAN_FALSE);
+                        BREthereumAddress address,
+                        uint64_t newNonce,
+                        int rid) {
+    uint64_t oldNonce = accountGetAddressNonce (ewm->account, address);
+    if (oldNonce != newNonce) {
+        // This may not change the nonce
+        accountSetAddressNonce (ewm->account, address, newNonce, ETHEREUM_BOOLEAN_FALSE);
+        // Only save the primaryWallet if the nonce has, in fact, changed.
+        if (oldNonce != accountGetAddressNonce (ewm->account, address))
+            ewmHandleSaveWallet (ewm, ewmGetWallet(ewm), CLIENT_CHANGE_UPD);
+    }
 }
 
 // ==============================================================================================
@@ -365,9 +370,9 @@ ewmHandleAnnounceNonce (BREthereumEWM ewm,
 
 
 extern void
-ewmHandleAnnounceTransaction(BREthereumEWM ewm,
-                                   BREthereumEWMClientAnnounceTransactionBundle *bundle,
-                                   int id) {
+ewmHandleAnnounceTransaction (BREthereumEWM ewm,
+                              BREthereumEWMClientAnnounceTransactionBundle *bundle,
+                              int id) {
     switch (ewm->mode) {
         case SYNC_MODE_BRD_ONLY:
         case SYNC_MODE_BRD_WITH_P2P_SEND: {

--- a/ethereum/ewm/BREthereumEWMPersist.c
+++ b/ethereum/ewm/BREthereumEWMPersist.c
@@ -281,7 +281,7 @@ static UInt256
 fileServiceTypeWalletV1Identifier (BRFileServiceContext context,
                                    BRFileService fs,
                                    const void *entity) {
-    BREthereumWalletState *state = (BREthereumWalletState*) entity;
+    BREthereumWalletState state = (BREthereumWalletState) entity;
     BREthereumHash hash = walletStateGetHash (state);
 
     UInt256 result;
@@ -295,7 +295,7 @@ fileServiceTypeWalletV1Writer (BRFileServiceContext context,
                                const void* entity,
                                uint32_t *bytesCount) {
     BREthereumEWM ewm = context;
-    BREthereumWalletState *state = (BREthereumWalletState*) entity;
+    BREthereumWalletState state = (BREthereumWalletState) entity;
 
     BRRlpItem item = walletStateEncode (state, ewm->coder);
     BRRlpData data = rlpGetData (ewm->coder, item);

--- a/ethereum/ewm/BREthereumEWMPersist.c
+++ b/ethereum/ewm/BREthereumEWMPersist.c
@@ -1,0 +1,354 @@
+//
+//  BREthereumEWMPersist.c
+//  BRCore
+//
+//  Created by Ed Gamble on 9/24/19.
+//  Copyright © 2019 Breadwinner AG. All rights reserved.
+//
+//
+//  See the LICENSE file at the project root for license information.
+//  See the CONTRIBUTORS file at the project root for a list of contributors.
+
+#include "BREthereumEWMPrivate.h"
+
+/// MARK: - Transaction File Service
+#define fileServiceTypeTransactions "transactions"
+
+enum {
+    EWM_TRANSACTION_VERSION_1
+};
+
+static UInt256
+fileServiceTypeTransactionV1Identifier (BRFileServiceContext context,
+                                        BRFileService fs,
+                                        const void *entity) {
+    BREthereumTransaction transaction = (BREthereumTransaction) entity;
+    BREthereumHash hash = transactionGetHash(transaction);
+
+    UInt256 result;
+    memcpy (result.u8, hash.bytes, ETHEREUM_HASH_BYTES);
+    return result;
+}
+
+static uint8_t *
+fileServiceTypeTransactionV1Writer (BRFileServiceContext context,
+                                    BRFileService fs,
+                                    const void* entity,
+                                    uint32_t *bytesCount) {
+    BREthereumEWM ewm = context;
+    BREthereumTransaction transaction = (BREthereumTransaction) entity;
+
+    BRRlpItem item = transactionRlpEncode(transaction, ewm->network, RLP_TYPE_ARCHIVE, ewm->coder);
+    BRRlpData data = rlpGetData (ewm->coder, item);
+    rlpReleaseItem (ewm->coder, item);
+
+    *bytesCount = (uint32_t) data.bytesCount;
+    return data.bytes;
+}
+
+static void *
+fileServiceTypeTransactionV1Reader (BRFileServiceContext context,
+                                    BRFileService fs,
+                                    uint8_t *bytes,
+                                    uint32_t bytesCount) {
+    BREthereumEWM ewm = context;
+
+    BRRlpData data = { bytesCount, bytes };
+    BRRlpItem item = rlpGetItem (ewm->coder, data);
+
+    BREthereumTransaction transaction = transactionRlpDecode(item, ewm->network, RLP_TYPE_ARCHIVE, ewm->coder);
+    rlpReleaseItem (ewm->coder, item);
+
+    return transaction;
+}
+
+/// MARK: - Log File Service
+
+#define fileServiceTypeLogs "logs"
+
+enum {
+    EWM_LOG_VERSION_1
+};
+
+static UInt256
+fileServiceTypeLogV1Identifier (BRFileServiceContext context,
+                                BRFileService fs,
+                                const void *entity) {
+    const BREthereumLog log = (BREthereumLog) entity;
+    BREthereumHash hash = logGetHash( log);
+
+    UInt256 result;
+    memcpy (result.u8, hash.bytes, ETHEREUM_HASH_BYTES);
+    return result;
+}
+
+static uint8_t *
+fileServiceTypeLogV1Writer (BRFileServiceContext context,
+                            BRFileService fs,
+                            const void* entity,
+                            uint32_t *bytesCount) {
+    BREthereumEWM ewm = context;
+    BREthereumLog log = (BREthereumLog) entity;
+
+    BRRlpItem item = logRlpEncode (log, RLP_TYPE_ARCHIVE, ewm->coder);
+    BRRlpData data = rlpGetData (ewm->coder, item);
+    rlpReleaseItem (ewm->coder, item);
+
+    *bytesCount = (uint32_t) data.bytesCount;
+    return data.bytes;
+}
+
+static void *
+fileServiceTypeLogV1Reader (BRFileServiceContext context,
+                            BRFileService fs,
+                            uint8_t *bytes,
+                            uint32_t bytesCount) {
+    BREthereumEWM ewm = context;
+
+    BRRlpData data = { bytesCount, bytes };
+    BRRlpItem item = rlpGetItem (ewm->coder, data);
+
+    BREthereumLog log = logRlpDecode(item, RLP_TYPE_ARCHIVE, ewm->coder);
+    rlpReleaseItem (ewm->coder, item);
+
+    return log;
+}
+
+/// MARK: - Block File Service
+
+#define fileServiceTypeBlocks "blocks"
+enum {
+    EWM_BLOCK_VERSION_1
+};
+
+static UInt256
+fileServiceTypeBlockV1Identifier (BRFileServiceContext context,
+                                  BRFileService fs,
+                                  const void *entity) {
+    const BREthereumBlock block = (BREthereumBlock) entity;
+    BREthereumHash hash = blockGetHash(block);
+
+    UInt256 result;
+    memcpy (result.u8, hash.bytes, ETHEREUM_HASH_BYTES);
+    return result;
+}
+
+static uint8_t *
+fileServiceTypeBlockV1Writer (BRFileServiceContext context,
+                              BRFileService fs,
+                              const void* entity,
+                              uint32_t *bytesCount) {
+    BREthereumEWM ewm = context;
+    BREthereumBlock block = (BREthereumBlock) entity;
+
+    BRRlpItem item = blockRlpEncode(block, ewm->network, RLP_TYPE_ARCHIVE, ewm->coder);
+    BRRlpData data = rlpGetData (ewm->coder, item);
+    rlpReleaseItem (ewm->coder, item);
+
+    *bytesCount = (uint32_t) data.bytesCount;
+    return data.bytes;
+}
+
+static void *
+fileServiceTypeBlockV1Reader (BRFileServiceContext context,
+                              BRFileService fs,
+                              uint8_t *bytes,
+                              uint32_t bytesCount) {
+    BREthereumEWM ewm = context;
+
+    BRRlpData data = { bytesCount, bytes };
+    BRRlpItem item = rlpGetItem (ewm->coder, data);
+
+    BREthereumBlock block = blockRlpDecode (item, ewm->network, RLP_TYPE_ARCHIVE, ewm->coder);
+    rlpReleaseItem (ewm->coder, item);
+
+    return block;
+}
+
+// MARK: - Node File Service
+
+#define fileServiceTypeNodes "nodes"
+enum {
+    EWM_NODE_VERSION_1
+};
+
+static UInt256
+fileServiceTypeNodeV1Identifier (BRFileServiceContext context,
+                                 BRFileService fs,
+                                 const void *entity) {
+    const BREthereumNodeConfig node = (BREthereumNodeConfig) entity;
+
+    BREthereumHash hash = nodeConfigGetHash(node);
+
+    UInt256 result;
+    memcpy (result.u8, hash.bytes, ETHEREUM_HASH_BYTES);
+    return result;
+}
+
+static uint8_t *
+fileServiceTypeNodeV1Writer (BRFileServiceContext context,
+                             BRFileService fs,
+                             const void* entity,
+                             uint32_t *bytesCount) {
+    BREthereumEWM ewm = context;
+    const BREthereumNodeConfig node = (BREthereumNodeConfig) entity;
+
+    BRRlpItem item = nodeConfigEncode (node, ewm->coder);
+    BRRlpData data = rlpGetData (ewm->coder, item);
+    rlpReleaseItem (ewm->coder, item);
+
+    *bytesCount = (uint32_t) data.bytesCount;
+    return data.bytes;
+}
+
+static void *
+fileServiceTypeNodeV1Reader (BRFileServiceContext context,
+                             BRFileService fs,
+                             uint8_t *bytes,
+                             uint32_t bytesCount) {
+    BREthereumEWM ewm = context;
+
+    BRRlpData data = { bytesCount, bytes };
+    BRRlpItem item = rlpGetItem (ewm->coder, data);
+
+    BREthereumNodeConfig node = nodeConfigDecode (item, ewm->coder);
+    rlpReleaseItem (ewm->coder, item);
+
+    return node;
+}
+
+/// MARK: - Token File Service
+
+#define fileServiceTypeTokens "tokens"
+
+enum {
+    EWM_TOKEN_VERSION_1
+};
+
+static UInt256
+fileServiceTypeTokenV1Identifier (BRFileServiceContext context,
+                                        BRFileService fs,
+                                        const void *entity) {
+    BREthereumToken token = (BREthereumToken) entity;
+    BREthereumHash hash = tokenGetHash(token);
+
+    UInt256 result;
+    memcpy (result.u8, hash.bytes, ETHEREUM_HASH_BYTES);
+    return result;
+}
+
+static uint8_t *
+fileServiceTypeTokenV1Writer (BRFileServiceContext context,
+                                    BRFileService fs,
+                                    const void* entity,
+                                    uint32_t *bytesCount) {
+    BREthereumEWM ewm = context;
+    BREthereumToken token = (BREthereumToken) entity;
+
+    BRRlpItem item = tokenEncode(token, ewm->coder);
+    BRRlpData data = rlpGetData (ewm->coder, item);
+    rlpReleaseItem (ewm->coder, item);
+
+    *bytesCount = (uint32_t) data.bytesCount;
+    return data.bytes;
+}
+
+static void *
+fileServiceTypeTokenV1Reader (BRFileServiceContext context,
+                                    BRFileService fs,
+                                    uint8_t *bytes,
+                                    uint32_t bytesCount) {
+    BREthereumEWM ewm = context;
+
+    BRRlpData data = { bytesCount, bytes };
+    BRRlpItem item = rlpGetItem (ewm->coder, data);
+
+    BREthereumToken token = tokenDecode(item, ewm->coder);
+    rlpReleaseItem (ewm->coder, item);
+
+    return token;
+}
+
+
+#define fileServiceSpecificationsCount      (5)
+static BRFileServiceTypeSpecification fileServiceSpecifications[] = {
+    {
+        fileServiceTypeTransactions,
+        EWM_TRANSACTION_VERSION_1,
+        1,
+        {
+            {
+                EWM_TRANSACTION_VERSION_1,
+                fileServiceTypeTransactionV1Identifier,
+                fileServiceTypeTransactionV1Reader,
+                fileServiceTypeTransactionV1Writer
+            }
+        }
+    },
+
+    {
+        fileServiceTypeLogs,
+        EWM_LOG_VERSION_1,
+        1,
+        {
+            {
+                EWM_LOG_VERSION_1,
+                fileServiceTypeLogV1Identifier,
+                fileServiceTypeLogV1Reader,
+                fileServiceTypeLogV1Writer
+            }
+        }
+    },
+
+    {
+        fileServiceTypeBlocks,
+        EWM_BLOCK_VERSION_1,
+        1,
+        {
+            {
+                EWM_BLOCK_VERSION_1,
+                fileServiceTypeBlockV1Identifier,
+                fileServiceTypeBlockV1Reader,
+                fileServiceTypeBlockV1Writer
+            }
+        }
+    },
+
+    {
+        fileServiceTypeNodes,
+        EWM_NODE_VERSION_1,
+        1,
+        {
+            {
+                EWM_NODE_VERSION_1,
+                fileServiceTypeNodeV1Identifier,
+                fileServiceTypeNodeV1Reader,
+                fileServiceTypeNodeV1Writer
+            }
+        }
+    },
+
+    {
+        fileServiceTypeTokens,
+        EWM_TOKEN_VERSION_1,
+        1,
+        {
+            {
+                EWM_TOKEN_VERSION_1,
+                fileServiceTypeTokenV1Identifier,
+                fileServiceTypeTokenV1Reader,
+                fileServiceTypeTokenV1Writer
+            }
+        }
+    }
+};
+
+const char *ewmFileServiceTypeTransactions = fileServiceTypeTransactions;
+const char *ewmFileServiceTypeLogs         = fileServiceTypeLogs;
+const char *ewmFileServiceTypeBlocks       = fileServiceTypeBlocks;
+const char *ewmFileServiceTypeNodes        = fileServiceTypeNodes;
+const char *ewmFileServiceTypeTokens       = fileServiceTypeTokens;
+
+size_t ewmFileServiceSpecificationsCount = fileServiceSpecificationsCount;
+BRFileServiceTypeSpecification *ewmFileServiceSpecifications = fileServiceSpecifications;
+

--- a/ethereum/ewm/BREthereumEWMPrivate.h
+++ b/ethereum/ewm/BREthereumEWMPrivate.h
@@ -11,6 +11,7 @@
 #ifndef BR_Ethereum_EWM_Private_H
 #define BR_Ethereum_EWM_Private_H
 
+#include <stdint.h>
 #include <pthread.h>
 #include "support/BRFileService.h"
 #include "ethereum/blockchain/BREthereumBlockChain.h"
@@ -610,6 +611,17 @@ ewmHandleEWMEvent(BREthereumEWM ewm,
 
 extern const BREventType *ewmEventTypes[];
 extern const unsigned int ewmEventTypesCount;
+
+/// MARK: - File Service
+
+extern const char *ewmFileServiceTypeTransactions;
+extern const char *ewmFileServiceTypeLogs;
+extern const char *ewmFileServiceTypeBlocks;
+extern const char *ewmFileServiceTypeNodes;
+extern const char *ewmFileServiceTypeTokens;
+
+extern size_t ewmFileServiceSpecificationsCount;
+extern BRFileServiceTypeSpecification *ewmFileServiceSpecifications;
 
 #ifdef __cplusplus
 }

--- a/ethereum/ewm/BREthereumEWMPrivate.h
+++ b/ethereum/ewm/BREthereumEWMPrivate.h
@@ -304,6 +304,11 @@ ewmHandleSaveLog (BREthereumEWM ewm,
                   BREthereumLog log,
                   BREthereumClientChangeType type);
 
+extern void
+ewmHandleSaveWallet (BREthereumEWM ewm,
+                     BREthereumWallet wallet,
+                     BREthereumClientChangeType type);
+
 //
 // Signal/Handle Sync (BCS Callback)
 //
@@ -619,6 +624,7 @@ extern const char *ewmFileServiceTypeLogs;
 extern const char *ewmFileServiceTypeBlocks;
 extern const char *ewmFileServiceTypeNodes;
 extern const char *ewmFileServiceTypeTokens;
+extern const char *ewmFileServiceTypeWallets;
 
 extern size_t ewmFileServiceSpecificationsCount;
 extern BRFileServiceTypeSpecification *ewmFileServiceSpecifications;

--- a/ethereum/ewm/BREthereumWallet.c
+++ b/ethereum/ewm/BREthereumWallet.c
@@ -647,6 +647,18 @@ walletStateRelease (BREthereumWalletState state) {
     free (state);
 }
 
+extern BREthereumAddress
+walletStateGetAddress (const BREthereumWalletState walletState) {
+    return (ETHEREUM_BOOLEAN_IS_TRUE (addressEqual (FAKE_ETHER_ADDRESS_INIT, walletState->address))
+            ? EMPTY_ADDRESS_INIT
+            : walletState->address);
+}
+
+extern UInt256
+walletStateGetAmount (const BREthereumWalletState walletState) {
+    return walletState->amount;
+}
+
 extern BRRlpItem
 walletStateEncode (const BREthereumWalletState state,
                    BRRlpCoder coder) {
@@ -673,6 +685,23 @@ walletStateDecode (BRRlpItem item,
 extern BREthereumHash
 walletStateGetHash (const BREthereumWalletState state) {
     return addressGetHash (state->address);
+}
+
+static inline size_t
+walletStateHashValue (const void *t)
+{
+    return addressHashValue(((BREthereumWalletState) t)->address);
+}
+
+static inline int
+walletStateHashEqual (const void *t1, const void *t2) {
+    return t1 == t2 || addressHashEqual (((BREthereumWalletState) t1)->address,
+                                         ((BREthereumWalletState) t2)->address);
+}
+
+extern BRSetOf(BREthereumWalletState)
+walletStateSetCreate (size_t capacity) {
+    return BRSetNew (walletStateHashValue, walletStateHashEqual, capacity);
 }
 
 /*

--- a/ethereum/ewm/BREthereumWallet.h
+++ b/ethereum/ewm/BREthereumWallet.h
@@ -272,6 +272,27 @@ private_extern int
 walletHasTransfer (BREthereumWallet wallet,
                    BREthereumTransfer transaction);
 
+/// MARK: - Persisted Wallet State;
+
+typedef struct BREthereumWalletStateRecord *BREthereumWalletState;
+
+extern BREthereumWalletState
+walletStateCreate (const BREthereumWallet wallet);
+
+extern void
+walletStateRelease (BREthereumWalletState state);
+
+extern BRRlpItem
+walletStateEncode (const BREthereumWalletState walletState,
+                   BRRlpCoder coder);
+
+extern BREthereumWalletState
+walletStateDecode (BRRlpItem item,
+                   BRRlpCoder coder);
+
+extern BREthereumHash
+walletStateGetHash (const BREthereumWalletState walletState);
+
 #ifdef __cplusplus
 }
 #endif

--- a/ethereum/ewm/BREthereumWallet.h
+++ b/ethereum/ewm/BREthereumWallet.h
@@ -282,6 +282,15 @@ walletStateCreate (const BREthereumWallet wallet);
 extern void
 walletStateRelease (BREthereumWalletState state);
 
+/**
+ * If WalletState holds Ether, then the address will be EMPTY_ADDRESS_INIT
+ */
+extern BREthereumAddress
+walletStateGetAddress (const BREthereumWalletState walletState);
+
+extern UInt256
+walletStateGetAmount (const BREthereumWalletState walletState);
+
 extern BRRlpItem
 walletStateEncode (const BREthereumWalletState walletState,
                    BRRlpCoder coder);
@@ -292,6 +301,9 @@ walletStateDecode (BRRlpItem item,
 
 extern BREthereumHash
 walletStateGetHash (const BREthereumWalletState walletState);
+
+extern BRSetOf(BREthereumWalletState)
+walletStateSetCreate (size_t capacity);
 
 #ifdef __cplusplus
 }

--- a/ethereum/ewm/BREthereumWallet.h
+++ b/ethereum/ewm/BREthereumWallet.h
@@ -291,6 +291,13 @@ walletStateGetAddress (const BREthereumWalletState walletState);
 extern UInt256
 walletStateGetAmount (const BREthereumWalletState walletState);
 
+extern uint64_t
+walletStateGetNonce (const BREthereumWalletState walletState);
+
+extern void
+walletStateSetNonce (BREthereumWalletState walletState,
+                     uint64_t nonce);
+
 extern BRRlpItem
 walletStateEncode (const BREthereumWalletState walletState,
                    BRRlpCoder coder);

--- a/support/BRFileService.c
+++ b/support/BRFileService.c
@@ -778,6 +778,20 @@ fileServiceClearAll (BRFileService fs) {
     return success;
 }
 
+extern UInt256
+fileServiceGetIdentifier (BRFileService fs,
+                          const char *type,
+                          const void *entity) {
+
+    BRFileServiceEntityType *entityType = fileServiceLookupType (fs, type);
+    if (NULL == entityType) { fileServiceFailedImpl (fs, 0, NULL, NULL, "missed type"); return UINT256_ZERO; };
+
+    BRFileServiceEntityHandler *handler = fileServiceEntityTypeLookupHandler(entityType, entityType->currentVersion);
+    if (NULL == handler) { fileServiceFailedImpl (fs, 0, NULL, NULL, "missed type handler"); return UINT256_ZERO; };
+
+    return handler->identifier (handler->context, fs, entity);
+}
+
 extern int
 fileServiceDefineType (BRFileService fs,
                        const char *type,

--- a/support/BRFileService.h
+++ b/support/BRFileService.h
@@ -133,6 +133,11 @@ fileServiceClear (BRFileService fs,
 extern int
 fileServiceClearAll (BRFileService fs);
 
+extern UInt256
+fileServiceGetIdentifier (BRFileService fs,
+                          const char *type,
+                          const void *entity);
+
 /**
  * A function type to produce an identifer from an entity.  The identifer must be constant for
  * a particulary entity through time.  The identifier is used to derive a filename (more generally


### PR DESCRIPTION
The balance is saved and restored for every wallet; the nonce only applies to the ETH wallet.  (Note: the nonce actually only applies the the account; but we hackily include it in the wallet state rather than introduce some other persistently stored type).

The balance is saved because it CAN NOT be derived from the sum of the transactions because Ethereum has some wacky, hacky concept of 'internal transactions' and we don't handle those (yet?).  We thus store the balance so that Core comes up with the last known balance (even if in airplane mode).

As the persistent types have grown, this PR moves the File Service specifications into a new file BREthereumEWMPersist.c

Also a fix the the Demo App to always ensure that the 'path' exists (pending CORE-600).  When I changed to a new simulator, the path didn't exist and Core crashed - unable to create the FS.

BREthereumWallet.[ch] are extended with `BREthereumWalletState`

Java change would include: adding the new file; creating the path in the demo app.