### PR TITLE
CORE-602: In Core Ripple, Modify the GEN Wallet Manager to be either Transfer or Transaction based.

### DIFF
--- a/crypto/BRCryptoWalletManagerClient.c
+++ b/crypto/BRCryptoWalletManagerClient.c
@@ -1660,6 +1660,28 @@ cwmGetTransactionsAsGEN (BRGenericClientContext context,
 }
 
 static void
+cwmGetTransfersAsGEN (BRGenericClientContext context,
+                       BRGenericWalletManager manager,
+                       const char *address,
+                       uint64_t begBlockNumber,
+                       uint64_t endBlockNumber,
+                       int rid) {
+    BRCryptoWalletManager cwm = cryptoWalletManagerTake (context);
+
+    BRCryptoCWMClientCallbackState callbackState = calloc (1, sizeof(struct BRCryptoCWMClientCallbackStateRecord));
+    callbackState->type = CWM_CALLBACK_TYPE_GEN_GET_TRANSFERS;
+    callbackState->rid = rid;
+
+    cwm->client.gen.funcGetTransfers (cwm->client.context,
+                                      cryptoWalletManagerTake (cwm),
+                                      callbackState,
+                                      address,
+                                      begBlockNumber, endBlockNumber);
+
+    cryptoWalletManagerGive (cwm);
+}
+
+static void
 cwmSubmitTransactionAsGEN (BRGenericClientContext context,
                            BRGenericWalletManager manager,
                            BRGenericWallet wallet,
@@ -1741,6 +1763,7 @@ cryptoWalletManagerClientCreateGENClient (BRCryptoWalletManager cwm) {
         cwm,
         cwmGetBlockNumberAsGEN,
         cwmGetTransactionsAsGEN,
+        cwmGetTransfersAsGEN,
         cwmSubmitTransactionAsGEN
     };
 }

--- a/generic/BRGenericHandlers.h
+++ b/generic/BRGenericHandlers.h
@@ -21,6 +21,11 @@
 extern "C" {
 #endif
 
+    typedef enum {
+        GENERIC_SYNC_TYPE_TRANSACTION,
+        GENERIC_SYNC_TYPE_TRANSFER
+    } BRGenericAPISyncType;
+
     typedef struct BRGenericHandersRecord *BRGenericHandlers;
 
     typedef struct BRGenericAccountWithTypeRecord {
@@ -74,6 +79,8 @@ extern "C" {
     typedef BRArrayOf(BRGenericTransfer) (*BRGenericWalletManagerLoadTransfers) (BRFileServiceContext context,
                                                                                  BRFileService fileService);
 
+    typedef BRGenericAPISyncType (*BRGenericWalletManagerGetAPISyncType) (void);
+
     // MARK: - Generic Handlers
 
     struct BRGenericHandersRecord {
@@ -118,6 +125,7 @@ extern "C" {
             BRGenericWalletManagerRecoverTransfersFromRawTransaction transfersRecoverFromRawTransaction;
             BRGenericWalletManagerInitializeFileService fileServiceInit;
             BRGenericWalletManagerLoadTransfers fileServiceLoadTransfers;
+            BRGenericWalletManagerGetAPISyncType apiSyncType;
         } manager;
     };
 

--- a/generic/BRGenericRipple.c
+++ b/generic/BRGenericRipple.c
@@ -240,6 +240,11 @@ genericRippleWalletManagerLoadTransfers (BRFileServiceContext context,
     return result;
 }
 
+static BRGenericAPISyncType
+genericRippleWalletManagerGetAPISyncType (void) {
+    return GENERIC_SYNC_TYPE_TRANSFER;
+}
+
 struct BRGenericHandersRecord genericRippleHandlersRecord = {
     "xrp",
     {    // Account
@@ -276,7 +281,8 @@ struct BRGenericHandersRecord genericRippleHandlersRecord = {
         genericRippleWalletManagerRecoverTransfer,
         genericRippleWalletManagerRecoverTransfersFromRawTransaction,
         genericRippleWalletManagerInitializeFileService,
-        genericRippleWalletManagerLoadTransfers
+        genericRippleWalletManagerLoadTransfers,
+        genericRippleWalletManagerGetAPISyncType
     }
 };
 

--- a/generic/BRGenericWalletManager.c
+++ b/generic/BRGenericWalletManager.c
@@ -257,12 +257,21 @@ gwmPeriodicDispatcher (BREventHandler handler,
         // Callback to 'client' to get all transactions (for all wallet addresses) between
         // a {beg,end}BlockNumber.  The client will gather the transactions and then call
         // bwmAnnounceTransaction()  (for each one or with all of them).
-        gwm->client.getTransactions (gwm->client.context,
-                                     gwm,
-                                     address,
-                                     gwm->brdSync.begBlockNumber,
-                                     gwm->brdSync.endBlockNumber,
-                                     gwm->requestId++);
+        if (gwm->handlers->manager.apiSyncType() == GENERIC_SYNC_TYPE_TRANSFER) {
+            gwm->client.getTransfers (gwm->client.context,
+                                         gwm,
+                                         address,
+                                         gwm->brdSync.begBlockNumber,
+                                         gwm->brdSync.endBlockNumber,
+                                         gwm->requestId++);
+        } else {
+            gwm->client.getTransactions (gwm->client.context,
+                                      gwm,
+                                      address,
+                                      gwm->brdSync.begBlockNumber,
+                                      gwm->brdSync.endBlockNumber,
+                                      gwm->requestId++);
+        }
 
         // TODO: Handle address
         // free (address);

--- a/generic/BRGenericWalletManager.h
+++ b/generic/BRGenericWalletManager.h
@@ -42,6 +42,13 @@ extern "C" {
                                          uint64_t endBlockNumber,
                                          int rid);
 
+    typedef void
+    (*BRGenericGetTransfersCallback) (BRGenericClientContext context,
+                                      BRGenericWalletManager manager,
+                                      const char *address,
+                                      uint64_t begBlockNumber,
+                                      uint64_t endBlockNumber,
+                                      int rid);
 
     extern int // success - data is valid
     gwmAnnounceTransfer (BRGenericWalletManager manager,
@@ -70,6 +77,7 @@ extern "C" {
         BRGenericClientContext context;
         BRGenericGetBlockNumberCallback getBlockNumber;
         BRGenericGetTransactionsCallback getTransactions;
+        BRGenericGetTransfersCallback getTransfers;
         BRGenericSubmitTransactionCallback submitTransaction;
     } BRGenericClient;
 


### PR DESCRIPTION
…saction based

Add support for the gen wallet to either call
- client.getTransactions OR
- client.getTransfers

based on a propery in the generic wallet manager

Also - add the client.getTransfers callback
