### PR TITLE
CORE-619: add GEN feeBasis functions w/ Ripple Implementations

### DIFF
--- a/Swift/BRCore.xcodeproj/project.pbxproj
+++ b/Swift/BRCore.xcodeproj/project.pbxproj
@@ -281,6 +281,7 @@
 		C3169686232283A200743E45 /* BRRippleTransfer.c in Sources */ = {isa = PBXBuildFile; fileRef = C3169685232283A200743E45 /* BRRippleTransfer.c */; };
 		C31696892322B0A800743E45 /* BRRippleUtils.c in Sources */ = {isa = PBXBuildFile; fileRef = C31696872322B0A800743E45 /* BRRippleUtils.c */; };
 		C316968B2322F17500743E45 /* BRRippleUtils.c in Sources */ = {isa = PBXBuildFile; fileRef = C31696872322B0A800743E45 /* BRRippleUtils.c */; };
+		C32DAD04233E7DCB005FDD54 /* BRRippleFeeBasis.c in Sources */ = {isa = PBXBuildFile; fileRef = C32DAD03233E7DCB005FDD54 /* BRRippleFeeBasis.c */; };
 		C3C453E1226E2C62004CC0C7 /* BRRippleSerialize.c in Sources */ = {isa = PBXBuildFile; fileRef = C3C453DD226E2C62004CC0C7 /* BRRippleSerialize.c */; };
 		C3C453E2226E2C62004CC0C7 /* BRRippleTransaction.c in Sources */ = {isa = PBXBuildFile; fileRef = C3C453DE226E2C62004CC0C7 /* BRRippleTransaction.c */; };
 		C3C453E5226E4863004CC0C7 /* BRRippleAccount.c in Sources */ = {isa = PBXBuildFile; fileRef = C3C453E3226E4862004CC0C7 /* BRRippleAccount.c */; };
@@ -701,6 +702,8 @@
 		C3169685232283A200743E45 /* BRRippleTransfer.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = BRRippleTransfer.c; sourceTree = "<group>"; };
 		C31696872322B0A800743E45 /* BRRippleUtils.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = BRRippleUtils.c; sourceTree = "<group>"; };
 		C31696882322B0A800743E45 /* BRRippleUtils.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = BRRippleUtils.h; sourceTree = "<group>"; };
+		C32DAD02233E7DCB005FDD54 /* BRRippleFeeBasis.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = BRRippleFeeBasis.h; sourceTree = "<group>"; };
+		C32DAD03233E7DCB005FDD54 /* BRRippleFeeBasis.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = BRRippleFeeBasis.c; sourceTree = "<group>"; };
 		C370DC362295776000314FBB /* testRippleTxList1.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = testRippleTxList1.h; sourceTree = "<group>"; };
 		C370DC372295776000314FBB /* testRippleTxList2.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = testRippleTxList2.h; sourceTree = "<group>"; };
 		C3C453DD226E2C62004CC0C7 /* BRRippleSerialize.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = BRRippleSerialize.c; sourceTree = "<group>"; };
@@ -1282,6 +1285,8 @@
 				C3C453E0226E2C62004CC0C7 /* BRRippleBase.h */,
 				C3C864A6227CA28E0055120E /* BRRippleBase58.c */,
 				C3C864A5227CA28E0055120E /* BRRippleBase58.h */,
+				C32DAD02233E7DCB005FDD54 /* BRRippleFeeBasis.h */,
+				C32DAD03233E7DCB005FDD54 /* BRRippleFeeBasis.c */,
 				C3C864B02284E8250055120E /* BRRipplePrivateStructs.h */,
 				C3C453DF226E2C62004CC0C7 /* BRRippleSerialize.h */,
 				C3C453DD226E2C62004CC0C7 /* BRRippleSerialize.c */,
@@ -2003,6 +2008,7 @@
 				3CAB60CD20AF8D1A00810CE4 /* BREthereumEWM.c in Sources */,
 				C3C864A4227C6B490055120E /* BRRippleWallet.c in Sources */,
 				3C25BF472236EE40004B093F /* BRBCashParams.c in Sources */,
+				C32DAD04233E7DCB005FDD54 /* BRRippleFeeBasis.c in Sources */,
 				3CAB60D120AF8D1A00810CE4 /* BRRlpCoder.c in Sources */,
 				3C7BE5A8230EFD2E005FD4CD /* BRCryptoTransfer.c in Sources */,
 				3CAB60D220AF8D1A00810CE4 /* BRUtilMath.c in Sources */,

--- a/crypto/BRCryptoFeeBasis.c
+++ b/crypto/BRCryptoFeeBasis.c
@@ -92,7 +92,7 @@ cryptoFeeBasisRelease (BRCryptoFeeBasis feeBasis) {
         case BLOCK_CHAIN_TYPE_ETH: break;
 
         case BLOCK_CHAIN_TYPE_GEN:
-            // TODO: Release BRGenericFeeBasis
+            gwmFeeBasisRelease(feeBasis->u.gen.gwm, feeBasis->u.gen.bid);
             break;
     }
     free (feeBasis);
@@ -113,8 +113,7 @@ cryptoFeeBasisGetPricePerCostFactorAsUInt256 (BRCryptoFeeBasis feeBasis) {
             return feeBasis->u.eth.u.gas.price.etherPerGas.valueInWEI;
 
         case BLOCK_CHAIN_TYPE_GEN:
-            assert (0);
-            return UINT256_ZERO;
+            return gwmGetFeeBasisPricePerCostFactor(feeBasis->u.gen.gwm, feeBasis->u.gen.bid);
     }
 }
 
@@ -141,8 +140,7 @@ cryptoFeeBasisGetCostFactor (BRCryptoFeeBasis feeBasis) {
             return feeBasis->u.eth.u.gas.limit.amountOfGas;
 
         case BLOCK_CHAIN_TYPE_GEN:
-            assert (0);
-            return 0;
+            return gwmGetFeeBasisCostFactor(feeBasis->u.gen.gwm, feeBasis->u.gen.bid);
     }
 }
 
@@ -193,10 +191,8 @@ cryptoFeeBasisIsIdentical (BRCryptoFeeBasis feeBasis1,
             return AS_CRYPTO_BOOLEAN (ETHEREUM_BOOLEAN_IS_TRUE (feeBasisEqual (&feeBasis1->u.eth, &feeBasis2->u.eth)));
 
         case BLOCK_CHAIN_TYPE_GEN:
-            // TODO: Compare GEN fee basis.
-            assert (0);
-            return AS_CRYPTO_BOOLEAN (feeBasis1->u.gen.gwm == feeBasis2->u.gen.gwm &&
-                                      feeBasis1->u.gen.bid == feeBasis2->u.gen.bid);
+            if (feeBasis1->u.gen.gwm != feeBasis2->u.gen.gwm) return CRYPTO_FALSE;
+            return AS_CRYPTO_BOOLEAN (gwmGetFeeBasisIsEqual(feeBasis1->u.gen.gwm, feeBasis1->u.gen.bid, feeBasis2->u.gen.bid));
     }
 }
 

--- a/generic/BRGenericHandlers.h
+++ b/generic/BRGenericHandlers.h
@@ -81,6 +81,12 @@ extern "C" {
 
     typedef BRGenericAPISyncType (*BRGenericWalletManagerGetAPISyncType) (void);
 
+    // FeeBasis
+    typedef UInt256 (*BRGenericFeeBasisGetPricePerCostFactor) (BRGenericFeeBasis feeBasis);
+    typedef double (*BRGenericFeeBasisGetCostFactor) (BRGenericFeeBasis feeBasis);
+    typedef uint32_t (*BRGenericFeeBasisIsEqual) (BRGenericFeeBasis fb1, BRGenericFeeBasis fb2);
+    typedef void (*BRGenericFeeBasisFree) (BRGenericFeeBasis feeBasis);
+
     // MARK: - Generic Handlers
 
     struct BRGenericHandersRecord {
@@ -127,6 +133,13 @@ extern "C" {
             BRGenericWalletManagerLoadTransfers fileServiceLoadTransfers;
             BRGenericWalletManagerGetAPISyncType apiSyncType;
         } manager;
+
+        struct {
+            BRGenericFeeBasisGetPricePerCostFactor pricePerCostFactor;
+            BRGenericFeeBasisGetCostFactor costFactor;
+            BRGenericFeeBasisIsEqual feeBasisIsEqual;
+            BRGenericFeeBasisFree free;
+        } feebasis;
     };
 
     extern void

--- a/generic/BRGenericWalletManager.c
+++ b/generic/BRGenericWalletManager.c
@@ -337,15 +337,7 @@ gwmInstallFileService(BRGenericWalletManager gwm,
     gwm->handlers->manager.fileServiceInit (gwm, gwm->fileService);
 }
 
-
-/// MARK: - Events
-
-const BREventType *gwmEventTypes[] = {
-    // ...
-};
-
-const unsigned int
-gwmEventTypesCount = (sizeof (gwmEventTypes) / sizeof (BREventType*));
+/// MARK: - Fee Basis
 
 extern UInt256
 gwmGetFeeBasisPricePerCostFactor (BRGenericWalletManager gwm, BRGenericFeeBasis feeBasis) {
@@ -364,3 +356,12 @@ extern uint32_t gwmGetFeeBasisIsEqual (BRGenericWalletManager gwm, BRGenericFeeB
 extern void gwmFeeBasisRelease(BRGenericWalletManager gwm, BRGenericFeeBasis feeBasis) {
     gwm->handlers->feebasis.free (feeBasis);
 }
+
+/// MARK: - Events
+
+const BREventType *gwmEventTypes[] = {
+    // ...
+};
+
+const unsigned int
+gwmEventTypesCount = (sizeof (gwmEventTypes) / sizeof (BREventType*));

--- a/generic/BRGenericWalletManager.c
+++ b/generic/BRGenericWalletManager.c
@@ -347,3 +347,20 @@ const BREventType *gwmEventTypes[] = {
 const unsigned int
 gwmEventTypesCount = (sizeof (gwmEventTypes) / sizeof (BREventType*));
 
+extern UInt256
+gwmGetFeeBasisPricePerCostFactor (BRGenericWalletManager gwm, BRGenericFeeBasis feeBasis) {
+    return gwm->handlers->feebasis.pricePerCostFactor (feeBasis);
+}
+
+extern double
+gwmGetFeeBasisCostFactor (BRGenericWalletManager gwm, BRGenericFeeBasis feeBasis) {
+    return gwm->handlers->feebasis.costFactor (feeBasis);
+}
+
+extern uint32_t gwmGetFeeBasisIsEqual (BRGenericWalletManager gwm, BRGenericFeeBasis fb1, BRGenericFeeBasis fb2) {
+    return gwm->handlers->feebasis.feeBasisIsEqual (fb1, fb2);
+}
+
+extern void gwmFeeBasisRelease(BRGenericWalletManager gwm, BRGenericFeeBasis feeBasis) {
+    gwm->handlers->feebasis.free (feeBasis);
+}

--- a/generic/BRGenericWalletManager.h
+++ b/generic/BRGenericWalletManager.h
@@ -138,6 +138,12 @@ extern "C" {
     gwmRecoverTransfersFromRawTransaction (BRGenericWalletManager gwm,
                                            uint8_t *bytes,
                                            size_t   bytesCount);
+
+    extern UInt256 gwmGetFeeBasisPricePerCostFactor(BRGenericWalletManager gwm, BRGenericFeeBasis feeBasis);
+    extern double gwmGetFeeBasisCostFactor(BRGenericWalletManager gwm, BRGenericFeeBasis feeBasis);
+    extern uint32_t gwmGetFeeBasisIsEqual(BRGenericWalletManager gwm, BRGenericFeeBasis fb1, BRGenericFeeBasis fb2);
+    extern void gwmFeeBasisRelease(BRGenericWalletManager gwm, BRGenericFeeBasis feeBasis);
+
 #ifdef __cplusplus
 }
 #endif

--- a/ripple/BRRippleAccount.c
+++ b/ripple/BRRippleAccount.c
@@ -31,8 +31,7 @@
 
 #define WORD_LIST_LENGTH 2048
 
-// A hard-coded representation of the __fee__ address
-uint8_t feeBytes[] = {
+uint8_t feeAddressBytes[20] = {
     0x42, 0x52, 0x44, 0x5F, 0x5F, 0x66, 0x65, 0x65,
     0x5F, 0x5F, 0x42, 0x52, 0x44, 0x00, 0x00, 0x00,
     0x00, 0x00, 0x00, 0x00
@@ -93,7 +92,8 @@ extern char * createRippleAddressString (BRRippleAddress address, int useChecksu
     char *string = calloc (1, 36);
 
     // Check for our special case __fee__ address
-    if (memcmp(address.bytes, feeBytes, sizeof(feeBytes)) == 0) {
+    // See the note in BRRippleAcount.h with respect to the feeAddressBytes
+    if (memcmp(address.bytes, feeAddressBytes, sizeof(feeAddressBytes)) == 0) {
         strcpy(string, "__fee__");
     } else {
         // The process is this:
@@ -316,9 +316,10 @@ rippleAddressCreate(const char * rippleAddressString)
 {
     BRRippleAddress address;
     memset(address.bytes, 0x00, sizeof(address.bytes));
-    // 1 special case so far - the __fee__ address
+    // 1 special case so far - the __fee__ address.
+    // See the note in BRRippleAcount.h with respect to the feeAddressBytes
     if (strcmp(rippleAddressString, "__fee__") == 0) {
-        memcpy(address.bytes, feeBytes, sizeof(feeBytes));
+        memcpy(address.bytes, feeAddressBytes, sizeof(feeAddressBytes));
     } else {
         // Work backwards from this ripple address (string) to what is
         // known as the acount ID (20 bytes)

--- a/ripple/BRRippleAccount.h
+++ b/ripple/BRRippleAccount.h
@@ -14,6 +14,12 @@
 #include "BRRippleTransaction.h"
 #include "BRKey.h"
 
+// We cannot do the normal conversion from bytes
+// to ripple address for the __fee__ address. So
+// instead we convert it to these hard-coded bytes
+// (and back again when needed) - defined in BRRippleAccount.c
+extern uint8_t feeAddressBytes[20];
+
 typedef struct BRRippleAccountRecord *BRRippleAccount;
 
 /**

--- a/ripple/BRRippleBase.h
+++ b/ripple/BRRippleBase.h
@@ -88,6 +88,4 @@ typedef uint32_t BRRippleLastLedgerSequence;
 typedef uint32_t BRRippleSourceTag;
 typedef uint32_t BRRippleDestinationTag;
 
-typedef BRRippleUnitDrops BRRippleFeeBasis;
-
 #endif

--- a/ripple/BRRippleFeeBasis.c
+++ b/ripple/BRRippleFeeBasis.c
@@ -1,0 +1,38 @@
+//
+//  BRRippleFeeBasis.c
+//  Core
+//
+//  Created by Carl Cherry on 9/27/19.
+//  Copyright © 2019 Breadwinner AG. All rights reserved.
+//
+//  See the LICENSE file at the project root for license information.
+//  See the CONTRIBUTORS file at the project root for a list of contributors.
+//
+
+#include <stdint.h>
+#include "BRRippleFeeBasis.h"
+#include <stdio.h>
+
+extern BRRippleUnitDrops rippleFeeBasisGetPricePerCostFactor(BRRippleFeeBasis *feeBasis)
+{
+    assert(feeBasis);
+    return feeBasis->pricePerCostFactor;
+}
+
+extern uint32_t rippleFeeBasisGetCostFactor(BRRippleFeeBasis *feeBasis)
+{
+    assert(feeBasis);
+    return feeBasis->costFactor;
+}
+
+extern uint32_t rippleFeeBasisIsEqual(BRRippleFeeBasis *fb1, BRRippleFeeBasis *fb2)
+{
+    assert(fb1);
+    assert(fb2);
+    if (fb1->pricePerCostFactor == fb2->pricePerCostFactor &&
+        fb1->costFactor == fb2->costFactor) {
+        return 1;
+    }
+    return 0;
+}
+

--- a/ripple/BRRippleFeeBasis.h
+++ b/ripple/BRRippleFeeBasis.h
@@ -1,0 +1,35 @@
+//
+//  BRRippleFeeBasis.h
+//  Core
+//
+//  Created by Carl Cherry on 9/27/19.
+//  Copyright © 2019 Breadwinner AG. All rights reserved.
+//
+//  See the LICENSE file at the project root for license information.
+//  See the CONTRIBUTORS file at the project root for a list of contributors.
+//
+#ifndef BRRippleFeeBasis_h
+#define BRRippleFeeBasis_h
+
+#include <stdint.h>
+#include "BRRippleBase.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef struct
+{
+    BRRippleUnitDrops pricePerCostFactor;
+    uint32_t          costFactor;
+} BRRippleFeeBasis;
+
+extern BRRippleUnitDrops rippleFeeBasisGetPricePerCostFactor(BRRippleFeeBasis *feeBasis);
+extern uint32_t rippleFeeBasisGetCostFactor(BRRippleFeeBasis *feeBasis);
+extern uint32_t rippleFeeBasisIsEqual(BRRippleFeeBasis *fb1, BRRippleFeeBasis *fb2);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* BRRippleUtils_h */

--- a/ripple/BRRippleTransaction.c
+++ b/ripple/BRRippleTransaction.c
@@ -70,7 +70,7 @@ struct BRRippleTransactionRecord {
     BRRippleTransactionType transactionType;
 
     // The base fee according to the Ripple network.
-    BRRippleAmount feeBasis;
+    BRRippleFeeBasis feeBasis;
 
     BRRippleUnitDrops fee; // The actual fee sent in the tx
     
@@ -133,8 +133,7 @@ rippleTransactionCreate(BRRippleAddress sourceAddress,
     BRRippleTransaction transaction = createTransactionObject();
 
     // Common fields
-    transaction->feeBasis.currencyType = 0; // XRP
-    transaction->feeBasis.amount.u64Amount = feeBasis; // NOTE: the actual fee will be calculated during serialization
+    transaction->feeBasis = feeBasis;
     transaction->fee = 0; // Don't know it yet
     transaction->sourceAddress = sourceAddress;
     transaction->transactionType = RIPPLE_TX_TYPE_PAYMENT;
@@ -229,7 +228,7 @@ static uint64_t calculateFee(BRRippleTransaction transaction)
     // the fee = baseFee * numSignatures and since we only support a single
     // signature there is nothing to do here yet.
     // See https://xrpl.org/transaction-cost.html for the calculations required
-    return transaction->feeBasis.amount.u64Amount;
+    return transaction->feeBasis.pricePerCostFactor * transaction->feeBasis.costFactor;
 }
 
 /*
@@ -570,7 +569,7 @@ rippleTransactionCreateFromBytes(uint8_t *bytes, int length)
 extern BRRippleFeeBasis rippleTransactionGetFeeBasis(BRRippleTransaction transaction)
 {
     assert(transaction);
-    return (BRRippleFeeBasis)transaction->feeBasis.amount.u64Amount;
+    return transaction->feeBasis;
 }
 
 static size_t

--- a/ripple/BRRippleTransaction.h
+++ b/ripple/BRRippleTransaction.h
@@ -12,6 +12,7 @@
 #define BRRipple_transaction_h
 
 #include "BRRippleBase.h"
+#include "BRRippleFeeBasis.h"
 #include "BRKey.h"
 #include "support/BRSet.h"
 

--- a/ripple/BRRippleTransfer.c
+++ b/ripple/BRRippleTransfer.c
@@ -13,6 +13,7 @@
 #include "BRRippleAccount.h"
 #include "BRRippleUtils.h"
 #include "BRRipplePrivateStructs.h"
+#include "BRRippleFeeBasis.h"
 #include <stdlib.h>
 
 const char * fee = "__fee__";
@@ -64,7 +65,10 @@ extern BRRippleAddress rippleTransferGetTarget(BRRippleTransfer transfer)
 extern BRRippleUnitDrops rippleTransferGetFee(BRRippleTransfer transfer)
 {
     assert(transfer);
-    if (memcmp(transfer->targetAddress.bytes, fee, strlen(fee)) == 0) {
+    // See the note in BRRippleAcount.h with respect to the feeAddressBytes
+    // If the "target" address is set to the feeAddressBytes then return the
+    // amount on this transfer - otherwise return 0.
+    if (memcmp(transfer->targetAddress.bytes, feeAddressBytes, sizeof(transfer->targetAddress.bytes)) == 0) {
         return transfer->amount;
     } else {
         return (BRRippleUnitDrops)0L;

--- a/ripple/BRRippleWallet.c
+++ b/ripple/BRRippleWallet.c
@@ -13,6 +13,7 @@
 #include "BRRippleWallet.h"
 #include "support/BRArray.h"
 #include "BRRipplePrivateStructs.h"
+#include "BRRippleFeeBasis.h"
 #include <stdio.h>
 //
 // Wallet
@@ -20,7 +21,7 @@
 struct BRRippleWalletRecord
 {
     BRRippleUnitDrops balance; // XRP balance
-    BRRippleUnitDrops feeBasis; // Base fee for transactions
+    BRRippleFeeBasis feeBasis; // Base fee for transactions
 
     // Ripple account
     BRRippleAccount account;
@@ -76,13 +77,13 @@ rippleWalletSetBalance (BRRippleWallet wallet, BRRippleUnitDrops balance)
     wallet->balance = balance;
 }
 
-extern void rippleWalletSetDefaultFeeBasis (BRRippleWallet wallet, BRRippleUnitDrops feeBasis)
+extern void rippleWalletSetDefaultFeeBasis (BRRippleWallet wallet, BRRippleFeeBasis feeBasis)
 {
     assert(wallet);
     wallet->feeBasis = feeBasis;
 }
 
-extern BRRippleUnitDrops rippleWalletGetDefaultFeeBasis (BRRippleWallet wallet)
+extern BRRippleFeeBasis rippleWalletGetDefaultFeeBasis (BRRippleWallet wallet)
 {
     assert(wallet);
     return wallet->feeBasis;

--- a/ripple/BRRippleWallet.h
+++ b/ripple/BRRippleWallet.h
@@ -93,7 +93,7 @@ rippleWalletSetBalance (BRRippleWallet wallet, BRRippleUnitDrops balance);
  * @return void
  */
 extern void
-rippleWalletSetDefaultFeeBasis (BRRippleWallet wallet, BRRippleUnitDrops feeBasis);
+rippleWalletSetDefaultFeeBasis (BRRippleWallet wallet, BRRippleFeeBasis feeBasis);
 
 /**
  * Get the ripple default fee basis that is stored with this wallet
@@ -102,7 +102,7 @@ rippleWalletSetDefaultFeeBasis (BRRippleWallet wallet, BRRippleUnitDrops feeBasi
  *
  * @return feeBasis  the default base fee that has been set for this wallet
  */
-extern BRRippleUnitDrops
+extern BRRippleFeeBasis
 rippleWalletGetDefaultFeeBasis (BRRippleWallet wallet);
 
 extern void rippleWalletAddTransfer(BRRippleWallet wallet, BRRippleTransfer transfer);

--- a/ripple/testRipple.c
+++ b/ripple/testRipple.c
@@ -14,6 +14,7 @@
 #include <unistd.h>
 #include "BRRipple.h"
 #include "BRRippleBase58.h"
+#include "BRRippleFeeBasis.h"
 #include "BRCrypto.h"
 #include "support/BRBIP32Sequence.h"
 #include "support/BRBIP39WordsEn.h"
@@ -74,7 +75,10 @@ testRippleTransaction (void /* ... */) {
     // Create an account so we can get a public key
     const char * paper_key = "patient doctor olympic frog force glimpse endless antenna online dragon bargain someone";
     BRRippleAccount account = rippleAccountCreate(paper_key);
-    transaction = rippleTransactionCreate(sourceAddress, targetAddress, 1000000, 12);
+    BRRippleFeeBasis feeBasis;
+    feeBasis.pricePerCostFactor = 12;
+    feeBasis.costFactor = 1;
+    transaction = rippleTransactionCreate(sourceAddress, targetAddress, 1000000, feeBasis);
     assert(transaction);
 
     rippleAccountFree(account);
@@ -98,7 +102,10 @@ testRippleTransactionGetters (void /* ... */) {
     // Create an account so we can get a public key
     const char * paper_key = "patient doctor olympic frog force glimpse endless antenna online dragon bargain someone";
     BRRippleAccount account = rippleAccountCreate(paper_key);
-    transaction = rippleTransactionCreate(sourceAddress, targetAddress, 1000000, 10);
+    BRRippleFeeBasis feeBasis;
+    feeBasis.pricePerCostFactor = 10;
+    feeBasis.costFactor = 1;
+    transaction = rippleTransactionCreate(sourceAddress, targetAddress, 1000000, feeBasis);
     assert(transaction);
 
     uint64_t fee = rippleTransactionGetFee(transaction);
@@ -122,8 +129,8 @@ testRippleTransactionGetters (void /* ... */) {
     BRRippleAddress target = rippleTransactionGetTarget(transaction);
     assert(0 == memcmp(target.bytes, targetAddress.bytes, 20));
     
-    BRRippleFeeBasis feeBasis = rippleTransactionGetFeeBasis(transaction);
-    assert(feeBasis == 10);
+    BRRippleFeeBasis actualFeeBasis = rippleTransactionGetFeeBasis(transaction);
+    assert(actualFeeBasis.pricePerCostFactor == 10);
 
     rippleAccountFree(account);
     rippleTransactionFree(transaction);
@@ -310,7 +317,10 @@ testSerializeWithSignature () {
     memcpy(sourceAddress.bytes, address.bytes, 20);
     memcpy(targetAddress.bytes, destBytes, 20);
 
-    transaction = rippleTransactionCreate(sourceAddress, targetAddress, 1000000, 10);
+    BRRippleFeeBasis feeBasis;
+    feeBasis.pricePerCostFactor = 10;
+    feeBasis.costFactor = 1;
+    transaction = rippleTransactionCreate(sourceAddress, targetAddress, 1000000, feeBasis);
     assert(transaction);
 
     uint32_t sequence_number = 25;
@@ -583,10 +593,11 @@ static void testWalletValues()
     assert(balance == expected_balance);
 
     BRRippleFeeBasis feeBasis = rippleWalletGetDefaultFeeBasis(wallet);
-    assert(0 == feeBasis);
-    rippleWalletSetDefaultFeeBasis(wallet, 10);
-    feeBasis = rippleWalletGetDefaultFeeBasis(wallet);
-    assert(10 == feeBasis);
+    assert(0 == feeBasis.pricePerCostFactor);
+    feeBasis.pricePerCostFactor = 10;
+    rippleWalletSetDefaultFeeBasis(wallet, feeBasis);
+    BRRippleFeeBasis newFeeBasis = rippleWalletGetDefaultFeeBasis(wallet);
+    assert(10 == newFeeBasis.pricePerCostFactor);
 
     rippleWalletFree(wallet);
 }
@@ -652,7 +663,10 @@ testTransactionId (void /* ... */) {
 
     BRRippleAddress sourceAddress = rippleAccountGetAddress(sourceAccount);
     BRRippleAddress targetAddress = rippleAccountGetAddress(targetAccount);
-    BRRippleTransaction transaction = rippleTransactionCreate(sourceAddress, targetAddress, 50000000, 12);
+    BRRippleFeeBasis feeBasis;
+    feeBasis.pricePerCostFactor = 12;
+    feeBasis.costFactor = 1;
+    BRRippleTransaction transaction = rippleTransactionCreate(sourceAddress, targetAddress, 50000000, feeBasis);
 
     // Serialize and sign
     rippleAccountSetSequence(sourceAccount, 2);
@@ -786,7 +800,10 @@ createSubmittableTransaction (void /* ... */) {
 
     BRRippleAddress sourceAddress = rippleAccountGetAddress(sourceAccount);
     BRRippleAddress targetAddress = rippleAccountGetAddress(targetAccount);
-    transaction = rippleTransactionCreate(sourceAddress, targetAddress, 50000000, 12);
+    BRRippleFeeBasis feeBasis;
+    feeBasis.pricePerCostFactor = 12;
+    feeBasis.costFactor = 1;
+    transaction = rippleTransactionCreate(sourceAddress, targetAddress, 50000000, feeBasis);
 
     // Serialize and sign
     rippleAccountSetSequence(sourceAccount, 2);


### PR DESCRIPTION
1. Added feeBasis structure and functions to generic
2. Modified BRRippleFeeBasis to be a structure and store
   the required fields to support BRCryptoFeeBasis functions
   - modified unit tests and all run successfully
3. Added required functions in BRGenericWalletManager
3. Implemented the GEN features in BRCryptoFeeBasis

Tested that I can get the fee shown in the demo app.