### PR TITLE
CORE-608: In Core Ripple: get values from transfer (not tx)

### DIFF
--- a/generic/BRGenericRipple.c
+++ b/generic/BRGenericRipple.c
@@ -74,7 +74,7 @@ static BRGenericAddress
 genericRippleTransferGetSourceAddress (BRGenericTransfer transfer) {
     BRRippleAddress *address = malloc (sizeof (BRRippleAddress));
 
-    *address = rippleTransactionGetSource(transfer);
+    *address = rippleTransferGetSource(transfer);
     return address;
 }
 


### PR DESCRIPTION
Get the target address using the rippleTransfer... function
(not rippleTransaction...)

This is the last transfer "getter" that needed to be changed