### PR TITLE
CORE-609: In Core Ripple, load in GEN transfer properties

### DIFF
--- a/crypto/BRCryptoTransfer.c
+++ b/crypto/BRCryptoTransfer.c
@@ -249,6 +249,9 @@ cryptoTransferCreateAsGEN (BRCryptoUnit unit,
     BRGenericFeeBasis gwmFeeBasis = gwmTransferGetFeeBasis (gwm, tid); // Will give ownership
     transfer->feeBasisEstimated = cryptoFeeBasisCreateAsGEN (transfer->unitForFee, gwm, gwmFeeBasis);
 
+    transfer->sourceAddress = cryptoAddressCreateAsGEN(gwm, gwmTransferGetSourceAddress (gwm, tid));
+    transfer->targetAddress = cryptoAddressCreateAsGEN(gwm, gwmTransferGetTargetAddress (gwm, tid));
+
     return transfer;
 }
 
@@ -536,7 +539,7 @@ cryptoTransferGetDirection (BRCryptoTransfer transfer) {
             
             if      ( accountIsSource &&  accountIsTarget) return CRYPTO_TRANSFER_RECOVERED;
             else if ( accountIsSource && !accountIsTarget) return CRYPTO_TRANSFER_SENT;
-            else if (!accountIsSource &&  accountIsTarget) return CRYPTO_TRANSFER_RECOVERED;
+            else if (!accountIsSource &&  accountIsTarget) return CRYPTO_TRANSFER_RECEIVED;
 
             assert (0);
         }


### PR DESCRIPTION
1. Load in the source and target addresses when creating
   a GEN transfer.
2. ALSO - noticed a bug in cryptoTransferGetDirection for GEN
   transfers - it needed to return CRYPTO_TRANSFER_RECEIVED in one case.