### PR TITLE
CORE-447: Improve Core Ethereum Syncing

### DIFF
--- a/crypto/BRCryptoWalletManagerClient.c
+++ b/crypto/BRCryptoWalletManagerClient.c
@@ -834,7 +834,7 @@ cwmWalletManagerEventAsETH (BREthereumClientContext context,
                                                           cryptoWalletManagerTake(cwm),
                                                           (BRCryptoWalletManagerEvent) {
                                                               CRYPTO_WALLET_MANAGER_EVENT_SYNC_STOPPED,
-                                                              { .syncStopped = { BRSyncStoppedReasonUnknown() } }
+                                                              { .syncStopped = { BRSyncStoppedReasonComplete() } }
                                                           });
             }
 

--- a/ethereum/ewm/BREthereumEWM.c
+++ b/ethereum/ewm/BREthereumEWM.c
@@ -258,6 +258,7 @@ ewmCreate (BREthereumNetwork network,
     ewm->bcs = NULL;
     ewm->blockHeight = blockHeight;
     ewm->confirmationsUntilFinal = confirmationsUntilFinal;
+    ewm->requestId = 0;
 
     {
         char address [ADDRESS_ENCODED_CHARS];
@@ -266,8 +267,8 @@ ewmCreate (BREthereumNetwork network,
     }
 
     // Initialize the `brdSync` struct
-    ewm->brdSync.ridTransaction = -1;
-    ewm->brdSync.ridLog = -1;
+    ewm->brdSync.ridTransaction = EWM_REQUEST_ID_UNKNOWN;
+    ewm->brdSync.ridLog = EWM_REQUEST_ID_UNKNOWN;
     ewm->brdSync.begBlockNumber = 0;
     ewm->brdSync.endBlockNumber = ewm->blockHeight;
     ewm->brdSync.completedTransaction = 1;
@@ -954,8 +955,8 @@ ewmSyncToDepth (BREthereumEWM ewm,
                 // (that is below) will immediately reassign new rids thereby mooting the need for
                 // assignin -1 here.  However, assigning -1 here does no harm and allows replacing
                 // of `ewmHandleSyncAPI` with `ewmSignalSyncAPI` if need be.
-                ewm->brdSync.ridLog = -1;
-                ewm->brdSync.ridTransaction = -1;
+                ewm->brdSync.ridLog = EWM_REQUEST_ID_UNKNOWN;
+                ewm->brdSync.ridTransaction = EWM_REQUEST_ID_UNKNOWN;
 
                 // If this was not an 'ongoing' sync, then signal back to 'connected'.  This will
                 // appear as syncEnded(success) - that is okay.

--- a/ethereum/ewm/BREthereumEWM.c
+++ b/ethereum/ewm/BREthereumEWM.c
@@ -270,8 +270,8 @@ ewmCreate (BREthereumNetwork network,
     ewm->brdSync.ridLog = -1;
     ewm->brdSync.begBlockNumber = 0;
     ewm->brdSync.endBlockNumber = ewm->blockHeight;
-    ewm->brdSync.completedTransaction = 0;
-    ewm->brdSync.completedLog = 0;
+    ewm->brdSync.completedTransaction = 1;
+    ewm->brdSync.completedLog = 1;
 
     // Get the client assigned early; callbacks as EWM/BCS state is re-establish, regarding
     // blocks, peers, transactions and logs, will be invoked.
@@ -629,8 +629,12 @@ ewmConnect(BREthereumEWM ewm) {
 
         switch (ewm->mode) {
             case SYNC_MODE_BRD_ONLY:
+                // Immediately start an API sync
+                ewmSignalSyncAPI (ewm, ETHEREUM_BOOLEAN_TRUE);
                 break;
             case SYNC_MODE_BRD_WITH_P2P_SEND:
+                ewmSignalSyncAPI (ewm, ETHEREUM_BOOLEAN_TRUE);
+                // fall-through
             case SYNC_MODE_P2P_WITH_BRD_SYNC:
             case SYNC_MODE_P2P_ONLY:
                 bcsStart(ewm->bcs);
@@ -691,8 +695,8 @@ ewmDisconnect (BREthereumEWM ewm) {
 
                     ewm->brdSync.begBlockNumber = 0;
                     ewm->brdSync.endBlockNumber = ewm->blockHeight;
-                    ewm->brdSync.completedTransaction = 0;
-                    ewm->brdSync.completedLog = 0;
+                    ewm->brdSync.completedTransaction = 1;
+                    ewm->brdSync.completedLog = 1;
                 }
                 break;
             default: break;
@@ -943,14 +947,38 @@ ewmSyncToDepth (BREthereumEWM ewm,
                 free (wallets);
             }
 
+            // Abort an in progress sync
+            if (!ewm->brdSync.completedTransaction || !ewm->brdSync.completedLog) {
+                // With the following, any callback to `ewmHandleAnnounceComplete` WILL skip out
+                // before changing `brdSync` state.  Of course, the call to ewmHandleSyncAPI()
+                // (that is below) will immediately reassign new rids thereby mooting the need for
+                // assignin -1 here.  However, assigning -1 here does no harm and allows replacing
+                // of `ewmHandleSyncAPI` with `ewmSignalSyncAPI` if need be.
+                ewm->brdSync.ridLog = -1;
+                ewm->brdSync.ridTransaction = -1;
+
+                // If this was not an 'ongoing' sync, then signal back to 'connected'.  This will
+                // appear as syncEnded(success) - that is okay.
+                if (ewmIsNotAnOngoingSync (ewm))
+                    ewmSignalEWMEvent (ewm, (BREthereumEWMEvent) {
+                        EWM_EVENT_CHANGED,
+                        SUCCESS,
+                        { .changed = { EWM_STATE_SYNCING, EWM_STATE_CONNECTED }}
+                    });
+
+                // Start anew as 'completed'
+                ewm->brdSync.completedTransaction = 1;
+                ewm->brdSync.completedLog = 1;
+            }
+
             // don't allow the sync to jump forward so that we don't have a situation where
             // we miss transfers
             ewm->brdSync.begBlockNumber = (ewm->brdSync.begBlockNumber < blockHeight ?
                                            ewm->brdSync.begBlockNumber : blockHeight);
 
-            // Try to avoid letting a nearly completed sync from continuing.
-            ewm->brdSync.completedTransaction = 0;
-            ewm->brdSync.completedLog = 0;
+            // Immediately sync - inline call (not via 'signal'; directly 'handle')
+            ewmHandleSyncAPI (ewm);
+
             pthread_mutex_unlock(&ewm->lock);
             return ETHEREUM_BOOLEAN_TRUE;
         }
@@ -2457,35 +2485,37 @@ ewmHandleAnnounceComplete (BREthereumEWM ewm,
                            BREthereumBoolean success,
                            int rid) {
     if (ETHEREUM_BOOLEAN_IS_TRUE(isTransaction)) {
-        if (rid == ewm->brdSync.ridTransaction)
-            ewm->brdSync.completedTransaction = 1; // completed, no matter success or failure
+        // skip out if `rid` doesn't match
+        if (rid != ewm->brdSync.ridTransaction) return;
+        ewm->brdSync.completedTransaction = 1; // completed, no matter success or failure
     }
     else /* isLog */ {
-        if (rid == ewm->brdSync.ridLog)
-            ewm->brdSync.completedLog = 1;         // completed, no matter success or failure
+        // skip out if `rid` doesn't match
+        if (rid != ewm->brdSync.ridLog) return;
+        ewm->brdSync.completedLog = 1;         // completed, no matter success or failure
     }
 
+    // If both transaction and log are completed we'll signal complete and then, on
+    // success, update `begBlockNumber`
     if (ewm->brdSync.completedTransaction && ewm->brdSync.completedLog) {
         // If this was not an 'ongoing' sync, then signal back to 'connected'
-        if (ewmIsNotAnOngoingSync (ewm))
+        if (ewmIsNotAnOngoingSync(ewm))
             ewmSignalEWMEvent (ewm, (BREthereumEWMEvent) {
                 EWM_EVENT_CHANGED,
                 SUCCESS,
                 { .changed = { EWM_STATE_SYNCING, EWM_STATE_CONNECTED }}
             });
+
+        // On success, advance the begBlockNumber
+        if (ETHEREUM_BOOLEAN_IS_TRUE(success))
+            ewm->brdSync.begBlockNumber = (ewm->brdSync.endBlockNumber >=  EWM_BRD_SYNC_START_BLOCK_OFFSET
+                                           ? ewm->brdSync.endBlockNumber - EWM_BRD_SYNC_START_BLOCK_OFFSET
+                                           : 0);
     }
 }
 
-//
-// Periodicaly query the BRD backend to get current status (block number, nonce, balances,
-// transactions and logs) The event will be NULL (as specified for a 'period dispatcher' - See
-// `eventHandlerSetTimeoutDispatcher()`)
-//
-static void
-ewmPeriodicDispatcher (BREventHandler handler,
-                       BREventTimeout *event) {
-    BREthereumEWM ewm = (BREthereumEWM) event->context;
-
+extern void
+ewmHandleSyncAPI (BREthereumEWM ewm) {
     if (ewm->state != EWM_STATE_CONNECTED) return;
     if (SYNC_MODE_P2P_ONLY == ewm->mode || SYNC_MODE_P2P_WITH_BRD_SYNC == ewm->mode) return;
 
@@ -2495,15 +2525,10 @@ ewmPeriodicDispatcher (BREventHandler handler,
 
     // Handle a BRD Sync:
 
-    // 1) check if the prior sync has completed.
-    if (ewm->brdSync.completedTransaction && ewm->brdSync.completedLog) {
-        // 1a) if so, advance the sync range by updating `begBlockNumber`
-        ewm->brdSync.begBlockNumber = (ewm->brdSync.endBlockNumber >=  EWM_BRD_SYNC_START_BLOCK_OFFSET
-                                       ? ewm->brdSync.endBlockNumber - EWM_BRD_SYNC_START_BLOCK_OFFSET
-                                       : 0);
-    }
+    // 1) if a prior sync has not completed, skip out
+    if (!ewm->brdSync.completedTransaction || !ewm->brdSync.completedLog) return;
 
-    // 2) completed or not, update the `endBlockNumber` to the current block height.
+    // 2) Update the `endBlockNumber` to the current block height.
     ewm->brdSync.endBlockNumber = ewmGetBlockHeight(ewm);
 
     // 3) if the `endBlockNumber` differs from the `begBlockNumber` then perform a 'sync'
@@ -2565,6 +2590,18 @@ ewmPeriodicDispatcher (BREventHandler handler,
     // End handling a BRD Sync
 
     if (NULL != ewm->bcs) bcsClean (ewm->bcs);
+}
+
+//
+// Periodicaly query the BRD backend to get current status (block number, nonce, balances,
+// transactions and logs) The event will be NULL (as specified for a 'period dispatcher' - See
+// `eventHandlerSetTimeoutDispatcher()`)
+//
+static void
+ewmPeriodicDispatcher (BREventHandler handler,
+                       BREventTimeout *event) {
+    BREthereumEWM ewm = (BREthereumEWM) event->context;
+    ewmHandleSyncAPI(ewm);
 }
 
 extern void

--- a/ethereum/ewm/BREthereumEWMClient.c
+++ b/ethereum/ewm/BREthereumEWMClient.c
@@ -601,25 +601,6 @@ ewmAnnounceLogComplete (BREthereumEWM ewm,
 
 // ==============================================================================================
 //
-// Announce {Transactions, Logs} Complete
-//
-extern void
-ewmHandleAnnounceComplete (BREthereumEWM ewm,
-                           BREthereumBoolean isTransaction,
-                           BREthereumBoolean success,
-                           int rid) {
-    if (ETHEREUM_BOOLEAN_IS_TRUE(isTransaction)) {
-        if (rid == ewm->brdSync.ridTransaction)
-            ewm->brdSync.completedTransaction = ETHEREUM_BOOLEAN_IS_TRUE(success);
-    }
-    else {
-        if (rid == ewm->brdSync.ridLog)
-            ewm->brdSync.completedLog = ETHEREUM_BOOLEAN_IS_TRUE(success);
-    }
-}
-
-// ==============================================================================================
-//
 // Blocks
 //
 

--- a/ethereum/ewm/BREthereumEWMEvent.c
+++ b/ethereum/ewm/BREthereumEWMEvent.c
@@ -388,6 +388,35 @@ ewmSignalSync (BREthereumEWM ewm,
 
 // ==============================================================================================
 //
+// Handle Sync API
+//
+typedef struct {
+    BREvent base;
+    BREthereumEWM ewm;
+} BREthereumHandleSyncAPIEvent;
+
+static void
+ewmHandleSyncAPIEventDispatcher(BREventHandler ignore,
+                             BREthereumHandleSyncAPIEvent *event) {
+    ewmHandleSyncAPI (event->ewm);
+}
+
+BREventType handleSyncAPIEventType = {
+    "EWM: Handle Sync API Event",
+    sizeof (BREthereumHandleSyncAPIEvent),
+    (BREventDispatcher) ewmHandleSyncAPIEventDispatcher
+};
+
+extern void
+ewmSignalSyncAPI (BREthereumEWM ewm,
+                  BREthereumBoolean OOB) {
+    BREthereumHandleSyncEvent event = { { NULL, &handleSyncAPIEventType }, ewm };
+    if (ETHEREUM_BOOLEAN_IS_TRUE(OOB)) eventHandlerSignalEventOOB (ewm->handler, (BREvent*) &event);
+    else eventHandlerSignalEvent (ewm->handler, (BREvent*) &event);
+}
+
+// ==============================================================================================
+//
 // Handle GetBlocks
 //
 typedef struct {
@@ -995,6 +1024,7 @@ const BREventType *ewmEventTypes[] = {
     &handleSaveBlocksEventType,
     &handleSaveNodesEventType,
     &handleSyncEventType,
+    &handleSyncAPIEventType,
     &handleGetBlocksEventType,
 
     &ewmClientWalletEventType,

--- a/ethereum/ewm/BREthereumEWMPrivate.h
+++ b/ethereum/ewm/BREthereumEWMPrivate.h
@@ -36,6 +36,8 @@ typedef enum {
 (CLIENT_CHANGE_ADD == (ev) ? "Add" \
 : (CLIENT_CHANGE_REM == (ev) ? "Rem" : "Upd"))
 
+#define EWM_REQUEST_ID_UNKNOWN    (UINT_MAX)
+
 //
 // EWM
 //

--- a/ethereum/ewm/BREthereumEWMPrivate.h
+++ b/ethereum/ewm/BREthereumEWMPrivate.h
@@ -146,11 +146,11 @@ struct BREthereumEWMRecord {
         uint64_t begBlockNumber;
         uint64_t endBlockNumber;
 
-        int ridTransaction;
-        int ridLog;
+        unsigned int ridTransaction;
+        unsigned int ridLog;
 
-        int completedTransaction:1;
-        int completedLog:1;
+        unsigned int completedTransaction:1;
+        unsigned int completedLog:1;
     } brdSync;
 };
 

--- a/ethereum/ewm/BREthereumEWMPrivate.h
+++ b/ethereum/ewm/BREthereumEWMPrivate.h
@@ -327,6 +327,16 @@ ewmSignalSync (BREthereumEWM ewm,
                uint64_t blockNumberStop);
 
 //
+// Signal/Handle Sync (BCS Callback)
+//
+extern void
+ewmHandleSyncAPI (BREthereumEWM ewm);
+
+extern void
+ewmSignalSyncAPI (BREthereumEWM ewm,
+                  BREthereumBoolean OOB);
+
+//
 // Signal/Handle Get Blocks (BCS Callback)
 //
 extern void


### PR DESCRIPTION
Start a sync immediately upon 'connect'; when 'complete' is announced for both 'transactions' and 'logs' immediately report 'syncEnded(success)' (rather than waiting for the next periodic dispatch). 