### PR TITLE
CORE-489: Ensure that alarm expiration times are not in the past

### DIFF
--- a/ethereum/event/BREventAlarm.c
+++ b/ethereum/event/BREventAlarm.c
@@ -137,8 +137,12 @@ alarmIsPeriodic (BREventAlarm *alarm) {
 
 static void
 alarmPeriodUpdate (BREventAlarm *alarm) {
-    if (alarmIsPeriodic(alarm)) {
-        timespecInc(&alarm->expiration, &alarm->period);
+    timespecInc(&alarm->expiration, &alarm->period);
+
+    // ensure that expiration does not occur in the past
+    struct timespec now = getTime();
+    if (-1 == timespecCompare(&alarm->expiration, &now)) {
+        alarm->expiration = now;
     }
 }
 


### PR DESCRIPTION
@EBGToo, took a pretty conservative approach here. Just make sure that calculated expiration times are not in the past.

The app shouldn't ever assume real-time scheduling/behaviour so I think this is a fair change.

Tested by breaking while debugging, waiting a period of time and then resuming.  Without the change, timer fires for each missed period; with it, doesn't bother with missed periods.

Note that this change doesn't fix the event queue being swamped with periodic events in the case of a slow periodic dispatch function.