### PR TITLE
CORE-564: Fix eventHandlerIsCurrentThread and eventHandlerIsRunning

### DIFF
--- a/ethereum/event/BREvent.c
+++ b/ethereum/event/BREvent.c
@@ -280,16 +280,25 @@ eventHandlerStop (BREventHandler handler) {
     pthread_mutex_unlock(&handler->lock);
 }
 
+static pthread_t
+eventHandlerGetThread (BREventHandler handler) {
+    // Retrieve the `handler->thread` under lock so that we can be
+    // sure that it has been set via pthread_create as that
+    // function call also occurs under this lock.
+    pthread_mutex_lock(&handler->lock);
+    pthread_t handlerThread = handler->thread;
+    pthread_mutex_unlock(&handler->lock);
+    return handlerThread;
+}
+
 extern int
 eventHandlerIsCurrentThread (BREventHandler handler) {
-    // TODO(fix): This is a hack; fix the ordering such that `handler->thread` is
-    //            is properly set by the time `eventHandlerThread()` runs (CORE-564)
-    return PTHREAD_NULL == handler->thread || pthread_self() == handler->thread;
+    return pthread_self() == eventHandlerGetThread (handler);
 }
 
 extern int
 eventHandlerIsRunning (BREventHandler handler) {
-    return PTHREAD_NULL != handler->thread;
+    return PTHREAD_NULL != eventHandlerGetThread (handler);
 }
 
 extern BREventStatus


### PR DESCRIPTION
Tested using:
```
-            pthread_create(&handler->thread, &attr, (ThreadRoutine) eventHandlerThread, handler);
+            pthread_t temp;
+            pthread_create(&temp, &attr, (ThreadRoutine) eventHandlerThread, handler);
+            sleep (2);
+            handler->thread = temp;
```

Confirmed failure before (with the NULL guard removed) and success after. Forces the issue, which was gap between `handler->thread` being set in `eventHandlerStart` and the actual event handler thread asserting on that value.