### PR TITLE
CORE-634: In Core Ripple, Define BRGenericNetwork

### DIFF
--- a/Swift/BRCrypto/BRCryptoNetwork.swift
+++ b/Swift/BRCrypto/BRCryptoNetwork.swift
@@ -181,7 +181,7 @@ public final class Network: CustomStringConvertible {
             }
 
         default:
-            core = cryptoNetworkCreateAsGEN (uids, name, (isMainnet ? 1 : 0))
+            core = cryptoNetworkCreateAsGEN (uids, name, currency.core, (isMainnet ? 1 : 0))
             break
         }
 

--- a/crypto/BRCryptoAddress.c
+++ b/crypto/BRCryptoAddress.c
@@ -31,7 +31,7 @@ struct BRCryptoAddressRecord {
         } btc;
         BREthereumAddress eth;
         struct {
-            BRGenericWalletManager gwm;
+            BRGenericNetwork nid;
             BRGenericAddress aid;
         } gen;
     } u;
@@ -72,10 +72,10 @@ cryptoAddressCreateAsBTC (BRAddress btc, BRCryptoBoolean isBitcoinAddr) {
 }
 
 private_extern BRCryptoAddress
-cryptoAddressCreateAsGEN (BRGenericWalletManager gwm,
+cryptoAddressCreateAsGEN (BRGenericNetwork nid,
                           BRGenericAddress aid) { // TODO: BRGenericAddress - ownership given?
     BRCryptoAddress address = cryptoAddressCreate (BLOCK_CHAIN_TYPE_GEN);
-    address->u.gen.gwm = gwm;
+    address->u.gen.nid = nid;
     address->u.gen.aid = aid;
     return address;
 }
@@ -157,7 +157,7 @@ cryptoAddressAsString (BRCryptoAddress address) {
         case BLOCK_CHAIN_TYPE_ETH:
             return addressGetEncodedString(address->u.eth, 1);
         case BLOCK_CHAIN_TYPE_GEN:
-            return gwmAddressAsString (address->u.gen.gwm, address->u.gen.aid);
+            return gwmAddressAsString (address->u.gen.nid, address->u.gen.aid);
     }
 }
 
@@ -170,5 +170,5 @@ cryptoAddressIsIdentical (BRCryptoAddress a1,
                                 ? (0 == strcmp (a1->u.btc.addr.s, a2->u.btc.addr.s) && a1->u.btc.isBitcoinAddr == a2->u.btc.isBitcoinAddr)
                                 : ( a1->type == BLOCK_CHAIN_TYPE_ETH
                                    ? ETHEREUM_BOOLEAN_IS_TRUE (addressEqual (a1->u.eth, a2->u.eth))
-                                   : gwmAddressEqual (a1->u.gen.gwm, a1->u.gen.aid, a2->u.gen.aid)))));
+                                   : gwmAddressEqual (a1->u.gen.nid, a1->u.gen.aid, a2->u.gen.aid)))));
 }

--- a/crypto/BRCryptoNetwork.c
+++ b/crypto/BRCryptoNetwork.c
@@ -515,7 +515,7 @@ cryptoNetworkCreateAddressFromString (BRCryptoNetwork network,
 
         case BLOCK_CHAIN_TYPE_GEN:
         {
-            BRGenericAddress genericAddress = gwmNetworkCreateAddress(network->u.gen.net, string);
+            BRGenericAddress genericAddress = gwmNetworkAddressCreate(network->u.gen.net, string);
             return cryptoAddressCreateAsGEN (network->u.gen.net, genericAddress);
         }
     }

--- a/crypto/BRCryptoNetwork.c
+++ b/crypto/BRCryptoNetwork.c
@@ -139,6 +139,7 @@ struct BRCryptoNetworkRecord {
 
         struct {
             // TODO: TBD
+            BRGenericNetwork net;
             uint8_t mainnet;
         } gen;
     } u;
@@ -203,10 +204,13 @@ cryptoNetworkCreateAsETH (const char *uids,
 private_extern BRCryptoNetwork
 cryptoNetworkCreateAsGEN (const char *uids,
                           const char *name,
+                          BRCryptoCurrency currency,
                           uint8_t isMainnet) {
     BRCryptoNetwork network = cryptoNetworkCreate (uids, name);
     network->type = BLOCK_CHAIN_TYPE_GEN;
     network->u.gen.mainnet = isMainnet;
+    network->u.gen.net = gwmNetworkCreate(cryptoCurrencyGetCode(currency));
+    network->currency = cryptoCurrencyTake(currency);
     return network;
 }
 
@@ -241,6 +245,7 @@ cryptoNetworkRelease (BRCryptoNetwork network) {
             break;
     }
 
+    if (network->currency) cryptoCurrencyGive(network->currency);
     free (network->name);
     free (network->uids);
     if (NULL != network->currency) cryptoCurrencyGive (network->currency);
@@ -509,7 +514,10 @@ cryptoNetworkCreateAddressFromString (BRCryptoNetwork network,
             return cryptoAddressCreateFromStringAsETH (string);
 
         case BLOCK_CHAIN_TYPE_GEN:
-            return cryptoAddressCreateFromStringAsGEN (string);
+        {
+            BRGenericAddress genericAddress = gwmNetworkCreateAddress(network->u.gen.net, string);
+            return cryptoAddressCreateAsGEN(NULL, genericAddress);
+        }
     }
 }
 

--- a/crypto/BRCryptoNetwork.c
+++ b/crypto/BRCryptoNetwork.c
@@ -538,7 +538,7 @@ cryptoNetworkAsBTC (BRCryptoNetwork network) {
 private_extern void *
 cryptoNetworkAsGEN (BRCryptoNetwork network) {
     assert (BLOCK_CHAIN_TYPE_GEN == network->type);
-    return NULL;
+    return network->u.gen.net;
 }
 
 private_extern BRCryptoBlockChainType

--- a/crypto/BRCryptoNetwork.c
+++ b/crypto/BRCryptoNetwork.c
@@ -516,7 +516,7 @@ cryptoNetworkCreateAddressFromString (BRCryptoNetwork network,
         case BLOCK_CHAIN_TYPE_GEN:
         {
             BRGenericAddress genericAddress = gwmNetworkCreateAddress(network->u.gen.net, string);
-            return cryptoAddressCreateAsGEN(NULL, genericAddress);
+            return cryptoAddressCreateAsGEN (network->u.gen.net, genericAddress);
         }
     }
 }

--- a/crypto/BRCryptoPrivate.h
+++ b/crypto/BRCryptoPrivate.h
@@ -119,7 +119,7 @@ extern "C" {
     cryptoAddressCreateAsETH (BREthereumAddress eth);
 
     private_extern BRCryptoAddress
-    cryptoAddressCreateAsGEN (BRGenericWalletManager gwm,
+    cryptoAddressCreateAsGEN (BRGenericNetwork nid,
                               BRGenericAddress aid);
 
     private_extern BRCryptoBlockChainType

--- a/crypto/BRCryptoPrivate.h
+++ b/crypto/BRCryptoPrivate.h
@@ -306,6 +306,7 @@ extern "C" {
     private_extern BRCryptoNetwork
     cryptoNetworkCreateAsGEN (const char *uids,
                               const char *name,
+                              BRCryptoCurrency currency,
                               uint8_t isMainnet);
 
     private_extern BRCryptoBlockChainType

--- a/crypto/BRCryptoTransfer.c
+++ b/crypto/BRCryptoTransfer.c
@@ -257,8 +257,9 @@ cryptoTransferCreateAsGEN (BRCryptoUnit unit,
     BRGenericFeeBasis gwmFeeBasis = gwmTransferGetFeeBasis (gwm, tid); // Will give ownership
     transfer->feeBasisEstimated = cryptoFeeBasisCreateAsGEN (transfer->unitForFee, gwm, gwmFeeBasis);
 
-    transfer->sourceAddress = cryptoAddressCreateAsGEN(gwm, gwmTransferGetSourceAddress (gwm, tid));
-    transfer->targetAddress = cryptoAddressCreateAsGEN(gwm, gwmTransferGetTargetAddress (gwm, tid));
+    BRGenericNetwork nid = gwmGetNetwork(gwm);
+    transfer->sourceAddress = cryptoAddressCreateAsGEN (nid, gwmTransferGetSourceAddress (gwm, tid));
+    transfer->targetAddress = cryptoAddressCreateAsGEN (nid, gwmTransferGetTargetAddress (gwm, tid));
 
     return transfer;
 }

--- a/crypto/BRCryptoWallet.c
+++ b/crypto/BRCryptoWallet.c
@@ -357,7 +357,8 @@ cryptoWalletGetAddress (BRCryptoWallet wallet,
             BRGenericWallet wid = wallet->u.gen.wid;
 
             BRGenericAddress genAddress = gwmWalletGetAddress (gwm, wid);
-            return cryptoAddressCreateAsGEN (gwm, genAddress);
+            BRGenericNetwork genNetwork = gwmGetNetwork(gwm);
+            return cryptoAddressCreateAsGEN (genNetwork, genAddress);
         }
     }
 }

--- a/crypto/BRCryptoWalletManager.c
+++ b/crypto/BRCryptoWalletManager.c
@@ -212,6 +212,7 @@ cryptoWalletManagerCreate (BRCryptoCWMListener listener,
 
             cwm->u.gen = gwmCreate (client,
                                     type,
+                                    cryptoNetworkAsGEN (network),
                                     cryptoAccountAsGEN (account, type),
                                     cryptoAccountGetTimestamp(account),
                                     cwmPath,

--- a/generic/BRGeneric.c
+++ b/generic/BRGeneric.c
@@ -34,9 +34,15 @@ gwmNetworkGetHandlers(BRGenericNetwork network) {
 }
 
 extern BRGenericAddress
-gwmNetworkCreateAddress(BRGenericNetwork network, const char * address) {
+gwmNetworkAddressCreate(BRGenericNetwork network, const char * address) {
     BRGenericNetworkRecord * networkRecord = network;
-    return networkRecord->handlers->network.createAddress(address);
+    return networkRecord->handlers->network.networkAddressCreate(address);
+}
+
+extern void
+gwmNetworkAddressRelease(BRGenericNetwork network, BRGenericAddress address) {
+    BRGenericNetworkRecord * networkRecord = network;
+    return networkRecord->handlers->network.networkAddressFree(address);
 }
 
 // This is, admittedly, a little odd.

--- a/generic/BRGeneric.c
+++ b/generic/BRGeneric.c
@@ -28,6 +28,11 @@ gwmNetworkRelease(BRGenericNetwork network) {
     free(networkToRelease);
 }
 
+extern BRGenericHandlers
+gwmNetworkGetHandlers(BRGenericNetwork network) {
+    return ((BRGenericNetworkRecord *) network)->handlers;
+}
+
 extern BRGenericAddress
 gwmNetworkCreateAddress(BRGenericNetwork network, const char * address) {
     BRGenericNetworkRecord * networkRecord = network;
@@ -112,16 +117,16 @@ gwmAccountGetSerialization (BRGenericAccount account, size_t *bytesCount) {
 // MARK: - Address
 
 extern char *
-gwmAddressAsString (BRGenericWalletManager gwm,
+gwmAddressAsString (BRGenericNetwork nid,
                     BRGenericAddress aid) {
-    return gwmGetHandlers(gwm)->address.asString (aid);
+    return gwmNetworkGetHandlers(nid)->address.asString (aid);
 }
 
 extern int
-gwmAddressEqual (BRGenericWalletManager gwm,
+gwmAddressEqual (BRGenericNetwork nid,
                  BRGenericAddress aid1,
                  BRGenericAddress aid2) {
-    return gwmGetHandlers(gwm)->address.equal (aid1, aid2);
+    return gwmNetworkGetHandlers(nid)->address.equal (aid1, aid2);
 }
 
 // MARK: - Transfer

--- a/generic/BRGeneric.c
+++ b/generic/BRGeneric.c
@@ -15,6 +15,25 @@
 #include "BRGeneric.h"
 #include "BRGenericHandlers.h"
 
+extern BRGenericNetwork
+gwmNetworkCreate(const char * type) {
+    BRGenericNetworkRecord * network = calloc(1, sizeof(BRGenericNetworkRecord));
+    network->handlers = genericHandlerLookup(type);
+    return network;
+}
+
+extern void
+gwmNetworkRelease(BRGenericNetwork network) {
+    BRGenericNetworkRecord * networkToRelease = network;
+    free(networkToRelease);
+}
+
+extern BRGenericAddress
+gwmNetworkCreateAddress(BRGenericNetwork network, const char * address) {
+    BRGenericNetworkRecord * networkRecord = network;
+    return networkRecord->handlers->network.createAddress(address);
+}
+
 // This is, admittedly, a little odd.
 
 static BRGenericAccount

--- a/generic/BRGeneric.h
+++ b/generic/BRGeneric.h
@@ -30,7 +30,10 @@ extern "C" {
     gwmNetworkRelease(BRGenericNetwork network);
 
     extern BRGenericAddress
-    gwmNetworkCreateAddress(BRGenericNetwork network, const char * address);
+    gwmNetworkAddressCreate(BRGenericNetwork network, const char * address);
+
+    extern void
+    gwmNetworkAddressRelease(BRGenericNetwork network, BRGenericAddress address);
 
     // MARK: - Account
 

--- a/generic/BRGeneric.h
+++ b/generic/BRGeneric.h
@@ -21,8 +21,19 @@
 extern "C" {
 #endif
 
+    // MARK: - Network
+
+    extern BRGenericNetwork
+    gwmNetworkCreate(const char * type);
+
+    extern void
+    gwmNetworkRelease(BRGenericNetwork network);
+
+    extern BRGenericAddress
+    gwmNetworkCreateAddress(BRGenericNetwork network, const char * address);
+
     // MARK: - Account
-    
+
     extern BRGenericAccount
     gwmAccountCreate (const char *type,
                       UInt512 seed);

--- a/generic/BRGeneric.h
+++ b/generic/BRGeneric.h
@@ -66,11 +66,11 @@ extern "C" {
      // Address
 
     extern char *
-    gwmAddressAsString (BRGenericWalletManager gwm,
+    gwmAddressAsString (BRGenericNetwork nid,
                         BRGenericAddress aid);
 
     extern int
-    gwmAddressEqual (BRGenericWalletManager gwm,
+    gwmAddressEqual (BRGenericNetwork nid,
                      BRGenericAddress aid1,
                      BRGenericAddress aid2);
 

--- a/generic/BRGenericBase.h
+++ b/generic/BRGenericBase.h
@@ -21,7 +21,7 @@ extern "C" {
     typedef void *BRGenericAddress;
     typedef void *BRGenericTransfer;
     typedef void *BRGenericWallet;
-
+    typedef void *BRGenericNetwork;
     typedef void *BRGenericFeeBasis;
 
     typedef struct {

--- a/generic/BRGenericHandlers.h
+++ b/generic/BRGenericHandlers.h
@@ -93,7 +93,8 @@ extern "C" {
 
     // MARK: - Network
 
-    typedef BRGenericAddress (*BRGenericNetworkCreateAddress) (const char * address);
+    typedef BRGenericAddress (*BRGenericNetworkAddressCreate) (const char * address);
+    typedef void (*BRGenericNetworkAddressFree) (BRGenericAddress address);
 
     // MARK: - Generic Handlers
 
@@ -150,7 +151,8 @@ extern "C" {
         } feebasis;
 
         struct {
-            BRGenericNetworkCreateAddress createAddress;
+            BRGenericNetworkAddressCreate networkAddressCreate;
+            BRGenericNetworkAddressFree networkAddressFree;
         } network;
     };
 

--- a/generic/BRGenericHandlers.h
+++ b/generic/BRGenericHandlers.h
@@ -33,6 +33,10 @@ extern "C" {
         BRGenericAccount base;
     } *BRGenericAccountWithType;;
 
+    typedef struct {
+        BRGenericHandlers handlers;
+    } BRGenericNetworkRecord;
+
     // MARK: - Generic Account
 
     typedef void * (*BRGenericAccountCreate) (const char *type, UInt512 seed);
@@ -60,7 +64,7 @@ extern "C" {
     typedef void (*BRGenericWalletFree) (BRGenericWallet wallet);
     typedef UInt256 (*BRGenericWalletGetBalance) (BRGenericWallet wallet);
 
-    // MAEK: - Generic Wallet Manager
+    // MARK: - Generic Wallet Manager
     // Create a transfer from the
     typedef BRGenericTransfer (*BRGenericWalletManagerRecoverTransfer) (const char *hash,
                                                                         const char *from,
@@ -81,11 +85,15 @@ extern "C" {
 
     typedef BRGenericAPISyncType (*BRGenericWalletManagerGetAPISyncType) (void);
 
-    // FeeBasis
+    // MARK: - FeeBasis
     typedef UInt256 (*BRGenericFeeBasisGetPricePerCostFactor) (BRGenericFeeBasis feeBasis);
     typedef double (*BRGenericFeeBasisGetCostFactor) (BRGenericFeeBasis feeBasis);
     typedef uint32_t (*BRGenericFeeBasisIsEqual) (BRGenericFeeBasis fb1, BRGenericFeeBasis fb2);
     typedef void (*BRGenericFeeBasisFree) (BRGenericFeeBasis feeBasis);
+
+    // MARK: - Network
+
+    typedef BRGenericAddress (*BRGenericNetworkCreateAddress) (const char * address);
 
     // MARK: - Generic Handlers
 
@@ -140,6 +148,10 @@ extern "C" {
             BRGenericFeeBasisIsEqual feeBasisIsEqual;
             BRGenericFeeBasisFree free;
         } feebasis;
+
+        struct {
+            BRGenericNetworkCreateAddress createAddress;
+        } network;
     };
 
     extern void

--- a/generic/BRGenericRipple.c
+++ b/generic/BRGenericRipple.c
@@ -272,11 +272,17 @@ genericRippleFeeBasisFree (BRGenericFeeBasis feeBasis) {
 }
 
 static BRGenericAddress
-genericRippleNetworkCreateAddress(const char* address) {
+genericRippleNetworkAddressCreate(const char* address) {
     BRRippleAddress rippleAddress = rippleAddressCreate(address);
     BRRippleAddress *genericAddress = calloc(1, sizeof(BRRippleAddress));
     memcpy(genericAddress->bytes, rippleAddress.bytes, sizeof(rippleAddress.bytes));
     return genericAddress;
+}
+
+static void
+genericRippleNetworkAddressFree(BRGenericAddress address) {
+    BRRippleAddress *rippleAddress = address;
+    free(rippleAddress);
 }
 
 struct BRGenericHandersRecord genericRippleHandlersRecord = {
@@ -327,7 +333,8 @@ struct BRGenericHandersRecord genericRippleHandlersRecord = {
     },
 
     { // Network
-        genericRippleNetworkCreateAddress,
+        genericRippleNetworkAddressCreate,
+        genericRippleNetworkAddressFree
     },
 };
 

--- a/generic/BRGenericRipple.c
+++ b/generic/BRGenericRipple.c
@@ -271,6 +271,14 @@ genericRippleFeeBasisFree (BRGenericFeeBasis feeBasis) {
     free (rippleFeeBasis);
 }
 
+static BRGenericAddress
+genericRippleNetworkCreateAddress(const char* address) {
+    BRRippleAddress rippleAddress = rippleAddressCreate(address);
+    BRRippleAddress *genericAddress = calloc(1, sizeof(BRRippleAddress));
+    memcpy(genericAddress->bytes, rippleAddress.bytes, sizeof(rippleAddress.bytes));
+    return genericAddress;
+}
+
 struct BRGenericHandersRecord genericRippleHandlersRecord = {
     "xrp",
     {    // Account
@@ -316,7 +324,11 @@ struct BRGenericHandersRecord genericRippleHandlersRecord = {
         genericRippleFeeBasisGetCostFactor,
         genericRippleFeeBasisIsEqual,
         genericRippleFeeBasisFree
-    }
+    },
+
+    { // Network
+        genericRippleNetworkCreateAddress,
+    },
 };
 
 const BRGenericHandlers genericRippleHandlers = &genericRippleHandlersRecord;

--- a/generic/BRGenericWalletManager.c
+++ b/generic/BRGenericWalletManager.c
@@ -42,6 +42,7 @@ gwmInstallFileService (BRGenericWalletManager gwm,
 ///
 struct BRGenericWalletManagerRecord {
     BRGenericHandlers handlers;
+    BRGenericNetwork network;
     BRGenericAccount account;
     BRGenericClient client;
     char *storagePath;
@@ -86,6 +87,7 @@ struct BRGenericWalletManagerRecord {
 extern BRGenericWalletManager
 gwmCreate (BRGenericClient client,
            const char *type,
+           BRGenericNetwork network,
            BRGenericAccount account,
            uint64_t accountTimestamp,
            const char *storagePath,
@@ -96,6 +98,7 @@ gwmCreate (BRGenericClient client,
     gwm->handlers = genericHandlerLookup (type);
     assert (NULL != gwm->handlers);
 
+    gwm->network = network;
     gwm->account = account;
     gwm->client  = client;
     gwm->storagePath = strdup (storagePath);
@@ -160,6 +163,11 @@ extern void
 gwmStop (BRGenericWalletManager gwm) {
     eventHandlerStop (gwm->handler);
     fileServiceClose (gwm->fileService);
+}
+
+extern BRGenericNetwork
+gwmGetNetwork (BRGenericWalletManager gwm) {
+    return gwm->network;
 }
 
 extern BRGenericHandlers

--- a/generic/BRGenericWalletManager.h
+++ b/generic/BRGenericWalletManager.h
@@ -86,6 +86,7 @@ extern "C" {
     extern BRGenericWalletManager
     gwmCreate (BRGenericClient client,
                const char *type,
+               BRGenericNetwork network,
                BRGenericAccount account,
                uint64_t accountTimestamp,
                const char *storagePath,
@@ -126,6 +127,9 @@ extern "C" {
 
     extern BRGenericAccount
     gwmGetAccount (BRGenericWalletManager gwm);
+
+    extern BRGenericNetwork
+    gwmGetNetwork (BRGenericWalletManager gwm);
 
     extern BRGenericTransfer
     gwmRecoverTransfer (BRGenericWalletManager gwm, BRGenericWallet wallet,


### PR DESCRIPTION
1. Add the BRGenericNetwork interfacei, functions, and handlers
2. Implement the single handler function "createAddress"
3. Add a BRGenericNetwork to BRCryptoNetwork
4. Modify cryptoNetworkCreateAddressFromString to use the generic
   network to create the address
5. Add a BRCryptoCurrency parameter to cryptoNetworkCreateAsGEN so
   that it can create the correct BRGenericNetwork.