### PR TITLE
CORE-646: In Core Crypto, Add 'common' checks to BRCryptoBaseTests for Swift

### DIFF
--- a/Swift/BRCore.xcodeproj/project.pbxproj
+++ b/Swift/BRCore.xcodeproj/project.pbxproj
@@ -47,6 +47,9 @@
 		3C386DD420C6F6070065E355 /* BREthereumEWMEvent.c in Sources */ = {isa = PBXBuildFile; fileRef = 3C386DD220C6F6070065E355 /* BREthereumEWMEvent.c */; };
 		3C3B37FD20D82335004F9928 /* BREventAlarm.c in Sources */ = {isa = PBXBuildFile; fileRef = 3C3B37FB20D82335004F9928 /* BREventAlarm.c */; };
 		3C3DC5BB21DFCA7C004188BD /* BRFileService.c in Sources */ = {isa = PBXBuildFile; fileRef = 3C3DC5BA21DFCA7C004188BD /* BRFileService.c */; };
+		3C4B1AA6234CE14500189DD5 /* InstallCoreTestsConfig.sh in Resources */ = {isa = PBXBuildFile; fileRef = 3C4B1AA5234CDFA200189DD5 /* InstallCoreTestsConfig.sh */; };
+		3C4B1AA7234CE14600189DD5 /* InstallCoreTestsConfig.sh in Resources */ = {isa = PBXBuildFile; fileRef = 3C4B1AA5234CDFA200189DD5 /* InstallCoreTestsConfig.sh */; };
+		3C4B1AA8234CE14700189DD5 /* InstallCoreTestsConfig.sh in Resources */ = {isa = PBXBuildFile; fileRef = 3C4B1AA5234CDFA200189DD5 /* InstallCoreTestsConfig.sh */; };
 		3C54A7FF2121F1D200C57B1B /* BREthereumMessage.c in Sources */ = {isa = PBXBuildFile; fileRef = 3C54A7FE2121F1D200C57B1B /* BREthereumMessage.c */; };
 		3C54A8022122284900C57B1B /* BREthereumNode.c in Sources */ = {isa = PBXBuildFile; fileRef = 3C54A8012122284900C57B1B /* BREthereumNode.c */; };
 		3C54A80521234C9700C57B1B /* BREthereumNodeEndpoint.c in Sources */ = {isa = PBXBuildFile; fileRef = 3C54A80421234C9700C57B1B /* BREthereumNodeEndpoint.c */; };
@@ -500,6 +503,7 @@
 		3C3DC5BA21DFCA7C004188BD /* BRFileService.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = BRFileService.c; sourceTree = "<group>"; };
 		3C42EF512095143D000E58E0 /* module.modulemap */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = "sourcecode.module-map"; path = module.modulemap; sourceTree = "<group>"; };
 		3C42EF8E209763AB000E58E0 /* test.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = test.c; sourceTree = "<group>"; };
+		3C4B1AA5234CDFA200189DD5 /* InstallCoreTestsConfig.sh */ = {isa = PBXFileReference; lastKnownFileType = text.script.sh; path = InstallCoreTestsConfig.sh; sourceTree = "<group>"; };
 		3C54A7FD2121F1D200C57B1B /* BREthereumMessage.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = BREthereumMessage.h; sourceTree = "<group>"; };
 		3C54A7FE2121F1D200C57B1B /* BREthereumMessage.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = BREthereumMessage.c; sourceTree = "<group>"; };
 		3C54A8002122284900C57B1B /* BREthereumNode.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = BREthereumNode.h; sourceTree = "<group>"; };
@@ -1169,6 +1173,7 @@
 				3C5E176E232D461500A558C7 /* README.md */,
 				3C5E176F232D461500A558C7 /* LICENSE */,
 				3C5E1772232D466700A558C7 /* CONTRIBUTORS */,
+				3C4B1AA5234CDFA200189DD5 /* InstallCoreTestsConfig.sh */,
 				3C590F1820950C160005597B /* Products */,
 				3CAB610A20AF938E00810CE4 /* Frameworks */,
 			);
@@ -1665,6 +1670,7 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				3C4B1AA7234CE14600189DD5 /* InstallCoreTestsConfig.sh in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1676,6 +1682,7 @@
 				3C18F8BB21950748006F738F /* Assets.xcassets in Resources */,
 				3C1D1F2222ECDD760028B20C /* CoreTestsConfig.json in Resources */,
 				3C18F8B921950746006F738F /* Main.storyboard in Resources */,
+				3C4B1AA8234CE14700189DD5 /* InstallCoreTestsConfig.sh in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1683,6 +1690,7 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				3C4B1AA6234CE14500189DD5 /* InstallCoreTestsConfig.sh in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1705,7 +1713,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "SRC_FILE=\"${HOME}/.brdCoreTestsConfig.json\"\nTGT_FILE=\"${SOURCE_ROOT}/BRCryptoDemo/CoreTestsConfig.json\"\n\nif [ -f \"${SRC_FILE}\"  ]; then \ncp \"${SRC_FILE}\" \"${TGT_FILE}\"\nchmod 644 \"${TGT_FILE}\"\nif [ ! -f \"${TGT_FILE}\" ]; then\necho \"Copy to  \\\"${TGT_FILE}\\\" failed.\"\nelse\necho \"Copied \\\"${SRC_FILE}\\\" to \\\"${TGT_FILE}\\\"\"\nfi\nelse\necho \"Missing file ${SRC_FILE} - You must provide this file.\"\nexit 1\nfi\n";
+			shellScript = "# Type a script or drag a script file from your workspace to insert its path.\n${SOURCE_ROOT}/InstallCoreTestsConfig.sh \"${HOME}/.brdCoreTestsConfig.json\" \"${SOURCE_ROOT}/BRCryptoDemo/CoreTestsConfig.json\"\n";
 		};
 		3C8EDD042232F54900D5D146 /* Copy CoreTestsConfig As Bundle Resource */ = {
 			isa = PBXShellScriptBuildPhase;
@@ -1742,7 +1750,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "SRC_FILE=\"${HOME}/.brdCoreTestsConfig.json\"\nTGT_FILE=\"${SOURCE_ROOT}/CoreTests/CoreTestsConfig.json\"\n\nif [ -f \"${SRC_FILE}\"  ]; then \n  cp \"${SRC_FILE}\" \"${TGT_FILE}\"\n  chmod 644 \"${TGT_FILE}\"\n  if [ ! -f \"${TGT_FILE}\" ]; then\n    echo \"Copy to  \\\"${TGT_FILE}\\\" failed.\"\n  else\n    echo \"Copied \\\"${SRC_FILE}\\\" to \\\"${TGT_FILE}\\\"\"\n  fi\nelse\n  echo \"Missing file ${SRC_FILE} - You must provide this file.\"\n  exit 1\nfi\n";
+			shellScript = "# Type a script or drag a script file from your workspace to insert its path.\n${SOURCE_ROOT}/InstallCoreTestsConfig.sh \"${HOME}/.brdCoreTestsConfig.json\" \"${SOURCE_ROOT}/CoreTests/CoreTestsConfig.json\"\n";
 		};
 		3CCB1364224D97AF00ADCDB9 /* Ensure CoreTestsConfig.json */ = {
 			isa = PBXShellScriptBuildPhase;
@@ -1760,7 +1768,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "SRC_FILE=\"${HOME}/.brdCoreTestsConfig.json\"\nTGT_FILE=\"${SOURCE_ROOT}/CoreTests/CoreTestsConfig.json\"\n\nif [ -f \"${SRC_FILE}\"  ]; then \ncp \"${SRC_FILE}\" \"${TGT_FILE}\"\nchmod 644 \"${TGT_FILE}\"\nif [ ! -f \"${TGT_FILE}\" ]; then\necho \"Copy to  \\\"${TGT_FILE}\\\" failed.\"\nelse\necho \"Copied \\\"${SRC_FILE}\\\" to \\\"${TGT_FILE}\\\"\"\nfi\nelse\necho \"Missing file ${SRC_FILE} - You must provide this file.\"\nexit 1\nfi\n";
+			shellScript = "# Type a script or drag a script file from your workspace to insert its path.\n${SOURCE_ROOT}/InstallCoreTestsConfig.sh \"${HOME}/.brdCoreTestsConfig.json\" \"${SOURCE_ROOT}/CoreTests/CoreTestsConfig.json\"\n";
 		};
 		3CCB1365224D9B2600ADCDB9 /* Copy CoreTestsConfig as Resource */ = {
 			isa = PBXShellScriptBuildPhase;

--- a/Swift/BRCryptoDemo/CoreDemoAppDelegate.swift
+++ b/Swift/BRCryptoDemo/CoreDemoAppDelegate.swift
@@ -62,9 +62,10 @@ class CoreDemoAppDelegate: UIResponder, UIApplicationDelegate, UISplitViewContro
 
         let accountSpecificationsPath = Bundle(for: CoreDemoAppDelegate.self).path(forResource: "CoreTestsConfig", ofType: "json")!
         let accountSpecifications     = AccountSpecification.loadFrom(configPath: accountSpecificationsPath)
-        let accountIdentifier         = CommandLine.arguments[1]
+        let accountIdentifier         = (CommandLine.argc >= 2 ? CommandLine.arguments[1] : "ginger")
 
         guard let accountSpecification = accountSpecifications.first (where: { $0.identifier == accountIdentifier })
+            ?? (accountSpecifications.count > 0 ? accountSpecifications[0] : nil)
             else {
                 precondition (false, "No AccountSpecification: \(accountIdentifier)");
                 return false
@@ -274,7 +275,10 @@ extension UIApplication {
 
         accountSpecifications
             .forEach { (accountSpecification) in
-                let action = UIAlertAction (title: accountSpecification.identifier, style: .default) { (action) in
+                let action = UIAlertAction (
+                    title: "\(accountSpecification.identifier) (\(accountSpecification.network))",
+                    style: .default)
+                { (action) in
                     app.summaryController.reset()
 
                     System.wipe (system: app.system)

--- a/Swift/BRCryptoTests/BRCryptoWalletManagerTests.swift
+++ b/Swift/BRCryptoTests/BRCryptoWalletManagerTests.swift
@@ -88,12 +88,9 @@ class BRCryptoWalletManagerTests: BRCryptoSystemBaseTests {
         XCTAssertFalse (system.wallets.isEmpty)
 
         // Events
-        
-        XCTAssertTrue (listener.checkSystemEvents(
-            [EventMatcher (event: SystemEvent.created),
-             EventMatcher (event: SystemEvent.networkAdded(network: network), strict: true, scan: true),
-             EventMatcher (event: SystemEvent.managerAdded(manager: manager), strict: true, scan: true)
-            ]))
+
+        XCTAssertTrue (listener.checkSystemEventsCommonlyWith (network: network,
+                                                               manager: manager))
 
         XCTAssertTrue (listener.checkManagerEvents(
             [WalletManagerEvent.created,
@@ -116,21 +113,8 @@ class BRCryptoWalletManagerTests: BRCryptoSystemBaseTests {
         manager.disconnect()
         wait (for: [walletManagerDisconnectExpectation], timeout: 5)
 
-        XCTAssertTrue (listener.checkManagerEvents (
-            [EventMatcher (event: WalletManagerEvent.created),
-             EventMatcher (event: WalletManagerEvent.walletAdded(wallet: wallet)),
-             EventMatcher (event: WalletManagerEvent.changed(oldState: WalletManagerState.created,   newState: WalletManagerState.connected)),
-
-             EventMatcher (event: WalletManagerEvent.syncStarted),
-             EventMatcher (event: WalletManagerEvent.changed(oldState: WalletManagerState.connected, newState: WalletManagerState.syncing)),
-             // We might not see `syncProgress`
-             // EventMatcher (event: WalletManagerEvent.syncProgress(timestamp: nil, percentComplete: 0), strict: false),
-
-             EventMatcher (event: WalletManagerEvent.syncEnded(reason: WalletManagerSyncStoppedReason.complete), strict: false, scan: true),
-             EventMatcher (event: WalletManagerEvent.changed(oldState: WalletManagerState.syncing, newState: WalletManagerState.connected)),
-             EventMatcher (event: WalletManagerEvent.changed(oldState: WalletManagerState.connected,
-                                                             newState: WalletManagerState.disconnected (reason: WalletManagerDisconnectReason.requested))),
-             ]))
+        XCTAssertTrue (listener.checkManagerEventsCommonlyWith (mode: manager.mode,
+                                                               wallet: wallet))
     }
 
     func testWalletManagerETH () {
@@ -175,11 +159,8 @@ class BRCryptoWalletManagerTests: BRCryptoSystemBaseTests {
 
         // Events
 
-        XCTAssertTrue (listener.checkSystemEvents(
-            [EventMatcher (event: SystemEvent.created),
-             EventMatcher (event: SystemEvent.networkAdded(network: network), strict: true, scan: true),
-             EventMatcher (event: SystemEvent.managerAdded(manager: manager), strict: true, scan: true)
-            ]))
+        XCTAssertTrue (listener.checkSystemEventsCommonlyWith (network: network,
+                                                               manager: manager))
 
         XCTAssertTrue (listener.checkManagerEvents(
             [EventMatcher (event: WalletManagerEvent.created),
@@ -205,7 +186,7 @@ class BRCryptoWalletManagerTests: BRCryptoSystemBaseTests {
         manager.disconnect()
         wait (for: [walletManagerDisconnectExpectation], timeout: 5)
 
-        // Same as BTC
+        // TODO: We have an 'extra' syncStarted in here; the disconnect reason is 'unknown'?
         XCTAssertTrue (listener.checkManagerEvents (
             [EventMatcher (event: WalletManagerEvent.created),
              EventMatcher (event: WalletManagerEvent.walletAdded(wallet: walletETH)),
@@ -223,7 +204,7 @@ class BRCryptoWalletManagerTests: BRCryptoSystemBaseTests {
 
              // Can have another sync started here... so scan
              EventMatcher (event: WalletManagerEvent.changed(oldState: WalletManagerState.connected,
-                                                             newState: WalletManagerState.disconnected (reason: WalletManagerDisconnectReason.requested)),
+                                                             newState: WalletManagerState.disconnected (reason: WalletManagerDisconnectReason.unknown)),
                            strict: true, scan: true),
             ]))
     }

--- a/Swift/InstallCoreTestsConfig.sh
+++ b/Swift/InstallCoreTestsConfig.sh
@@ -1,0 +1,85 @@
+
+if [ 2 != $# ]; then exit 0; fi
+
+SRC_FILE=$1
+TGT_FILE=$2
+
+if [ -f "${SRC_FILE}"  ]; then
+    cp "${SRC_FILE}" "${TGT_FILE}"
+    chmod 644 "${TGT_FILE}"
+    if [ ! -f "${TGT_FILE}" ]; then
+	echo "Copy to  \\"${TGT_FILE}\\" failed."
+    else
+	echo "Copied \\"${SRC_FILE}\\" to \\"${TGT_FILE}\\""
+    fi
+else
+    echo "Missing file ${SRC_FILE} - You must provide this file. (Created a default at '${TGT_FILE}')"
+    rm -rf ${TGT_FILE}
+    cat > ${TGT_FILE} <<EOF
+[
+  {
+    "identifier": "ginger",
+    "paperKey":   "ginger settle marine tissue robot crane night number ramp coast roast critic",
+    "timestamp":  "2018-01-01",
+    "network":    "testnet",
+    "content":    "BTC, BCH, ETH"
+  },
+
+  {
+    "identifier": "tape",
+    "paperKey":   "tape argue fetch truck cattle quiz wide equal inform rabbit ranch educate",
+    "timestamp":  "2018-04-02",
+    "network":    "testnet",
+    "content":    "(NO) BTC"
+  },
+
+  {
+    "identifier": "infant",
+    "paperKey":   "infant impulse panda donate sea  language champion art uphold stable water ice",
+    "timestamp":  "2019-05-01",
+    "network":    "testnet",
+    "content":    "(NO?) BTC"
+  },
+
+  {
+    "identifier": "vault",
+    "paperKey":   "vault area cruel pull found hold collect current install  proud fluid isolate",
+    "timestamp":  "2019-03-01",
+    "network":    "testnet",
+    "content":    "BTC"
+  },
+
+  {
+    "identifier": "toe",
+    "paperKey":   "toe web edge social worth borrow argue shield globe ritual fat upgrade",
+    "timestamp":  "2018-01-01",
+    "network":    "testnet",
+    "content":    "BTC, ETH"
+  },
+
+  {
+    "identifier": "general",
+    "paperKey":   "general shaft mirror pave page talk basket crumble thrive gaze bamboo maid",
+    "timestamp":  "2019-08-15",
+    "network":    "testnet",
+    "content":    "(Core - test transactions) BTC - ADDR-0: mzjmRwzABk67iPSrLys1ACDdGkuLcS6WQ4"
+  },
+
+  {
+    "identifier": "blush",
+    "paperKey":   "blush wear arctic fruit unique quantum because mammal entry country school curtain",
+    "timestamp":  "2018-01-01",
+    "network":    "testnet",
+    "content":    "BCH"
+  },
+
+  {
+    "identifier": "boring",
+    "paperKey":   "boring head harsh green empty clip fatal typical found crane dinner timber",
+    "timestamp":  "2018-04-26",
+    "network":    "mainnet",
+    "content":    "<COMPROMISED>"
+  }
+]
+EOF
+fi


### PR DESCRIPTION
Handle some BTC/ETH and API/P2P differences (but added a JIRA CORE-647 to reconcile).