### PR TITLE
CORE-635: In Core Ripple, To 'Handler Types' Add a Release/Free handler

### DIFF
--- a/crypto/BRCryptoWallet.c
+++ b/crypto/BRCryptoWallet.c
@@ -536,7 +536,7 @@ cryptoWalletCreateTransfer (BRCryptoWallet  wallet,
             UInt256 genValue  = cryptoAmountGetValue (amount);
             BRGenericAddress genAddr = cryptoAddressAsGEN (target);
 
-            BRGenericTransfer tid = gwmWalletCreateTransfer (gwm, wid, genAddr, genValue);
+            BRGenericTransfer tid = gwmTransferCreate (gwm, wid, genAddr, genValue);
             transfer = NULL == tid ? NULL : cryptoTransferCreateAsGEN (unit, unitForFee, gwm, tid);
             break;
         }

--- a/crypto/BRCryptoWallet.c
+++ b/crypto/BRCryptoWallet.c
@@ -536,7 +536,7 @@ cryptoWalletCreateTransfer (BRCryptoWallet  wallet,
             UInt256 genValue  = cryptoAmountGetValue (amount);
             BRGenericAddress genAddr = cryptoAddressAsGEN (target);
 
-            BRGenericTransfer tid = gwmTransferCreate (gwm, wid, genAddr, genValue);
+            BRGenericTransfer tid = gwmWalletCreateTransfer (gwm, wid, genAddr, genValue);
             transfer = NULL == tid ? NULL : cryptoTransferCreateAsGEN (unit, unitForFee, gwm, tid);
             break;
         }

--- a/generic/BRGeneric.c
+++ b/generic/BRGeneric.c
@@ -137,6 +137,20 @@ gwmAddressEqual (BRGenericNetwork nid,
 
 // MARK: - Transfer
 
+extern BRGenericTransfer
+gwmTransferCreate (BRGenericWalletManager gwm,
+                   BRGenericWallet wid,
+                   BRGenericAddress target, // TODO: BRGenericAddress - ownership given
+                   UInt256 amount) {
+    BRGenericAccountWithType accountWithType = gwmGetAccount(gwm);
+    BRGenericAddress accountAddress = accountWithType->handlers->account.getAddress(accountWithType->base);
+    return gwmGetHandlers(gwm)->transfer.create(accountAddress, target, amount);
+}
+
+extern void gwmTransferRelease (BRGenericWalletManager gwm, BRGenericTransfer transfer) {
+    gwmGetHandlers(gwm)->transfer.free(transfer);
+}
+
 extern BRGenericAddress
 gwmTransferGetSourceAddress (BRGenericWalletManager gwm,
                              BRGenericTransfer tid) {
@@ -182,6 +196,11 @@ gwmWalletCreate (BRGenericWalletManager gwm) {
     return gwmGetHandlers(gwm)->wallet.create (gwmGetAccount(gwm));
 }
 
+extern void
+gwmWalletRelease (BRGenericWalletManager gwm, BRGenericWallet wallet) {
+    gwmGetHandlers(gwm)->wallet.free (wallet);
+}
+
 extern UInt256
 gwmWalletGetBalance (BRGenericWalletManager gwm,
                      BRGenericWallet wallet) {
@@ -207,16 +226,6 @@ gwmWalletSetDefaultFeeBasis (BRGenericWalletManager gwm,
                              BRGenericWallet wid,
                              BRGenericFeeBasis bid) {
     return;
-}
-
-extern BRGenericTransfer
-gwmWalletCreateTransfer (BRGenericWalletManager gwm,
-                         BRGenericWallet wid,
-                         BRGenericAddress target, // TODO: BRGenericAddress - ownership given
-                         UInt256 amount) {
-    BRGenericAccountWithType accountWithType = gwmGetAccount(gwm);
-    BRGenericAddress accountAddress = accountWithType->handlers->account.getAddress(accountWithType->base);
-    return gwmGetHandlers(gwm)->transfer.create(accountAddress, target, amount);
 }
 
 extern UInt256

--- a/generic/BRGeneric.c
+++ b/generic/BRGeneric.c
@@ -137,16 +137,6 @@ gwmAddressEqual (BRGenericNetwork nid,
 
 // MARK: - Transfer
 
-extern BRGenericTransfer
-gwmTransferCreate (BRGenericWalletManager gwm,
-                   BRGenericWallet wid,
-                   BRGenericAddress target, // TODO: BRGenericAddress - ownership given
-                   UInt256 amount) {
-    BRGenericAccountWithType accountWithType = gwmGetAccount(gwm);
-    BRGenericAddress accountAddress = accountWithType->handlers->account.getAddress(accountWithType->base);
-    return gwmGetHandlers(gwm)->transfer.create(accountAddress, target, amount);
-}
-
 extern void gwmTransferRelease (BRGenericWalletManager gwm, BRGenericTransfer transfer) {
     gwmGetHandlers(gwm)->transfer.free(transfer);
 }
@@ -226,6 +216,16 @@ gwmWalletSetDefaultFeeBasis (BRGenericWalletManager gwm,
                              BRGenericWallet wid,
                              BRGenericFeeBasis bid) {
     return;
+}
+
+extern BRGenericTransfer
+gwmWalletCreateTransfer (BRGenericWalletManager gwm,
+                         BRGenericWallet wid,
+                         BRGenericAddress target, // TODO: BRGenericAddress - ownership given
+                         UInt256 amount) {
+    BRGenericAccountWithType accountWithType = gwmGetAccount(gwm);
+    BRGenericAddress accountAddress = accountWithType->handlers->account.getAddress(accountWithType->base);
+    return gwmGetHandlers(gwm)->transfer.create(accountAddress, target, amount);
 }
 
 extern UInt256

--- a/generic/BRGeneric.h
+++ b/generic/BRGeneric.h
@@ -79,12 +79,6 @@ extern "C" {
 
     // Transfer
 
-    extern BRGenericTransfer
-    gwmTransferCreate (BRGenericWalletManager gwm,
-                       BRGenericWallet wid,
-                       BRGenericAddress target,
-                       UInt256 amount);
-
     extern void
     gwmTransferRelease (BRGenericWalletManager gwm, BRGenericTransfer transfer);
 
@@ -143,6 +137,13 @@ extern "C" {
     gwmWalletSetDefaultFeeBasis (BRGenericWalletManager gwm,
                                  BRGenericWallet wid,
                                  BRGenericFeeBasis bid);
+
+    extern BRGenericTransfer
+    gwmWalletCreateTransfer (BRGenericWalletManager gwm,
+                             BRGenericWallet wid,
+                             BRGenericAddress target,
+                             UInt256 amount);
+                             // ...
 
     extern UInt256
     gwmWalletEstimateTransferFee (BRGenericWalletManager gwm,

--- a/generic/BRGeneric.h
+++ b/generic/BRGeneric.h
@@ -24,16 +24,16 @@ extern "C" {
     // MARK: - Network
 
     extern BRGenericNetwork
-    gwmNetworkCreate(const char * type);
+    gwmNetworkCreate (const char * type);
 
     extern void
-    gwmNetworkRelease(BRGenericNetwork network);
+    gwmNetworkRelease (BRGenericNetwork network);
 
     extern BRGenericAddress
-    gwmNetworkAddressCreate(BRGenericNetwork network, const char * address);
+    gwmNetworkAddressCreate (BRGenericNetwork network, const char * address);
 
     extern void
-    gwmNetworkAddressRelease(BRGenericNetwork network, BRGenericAddress address);
+    gwmNetworkAddressRelease (BRGenericNetwork network, BRGenericAddress address);
 
     // MARK: - Account
 
@@ -46,9 +46,9 @@ extern "C" {
                                    BRKey publicKey);
 
     extern BRGenericAccount
-    gwmAccountCreateWithSerialization(const char *type,
-                                      uint8_t *bytes,
-                                      size_t   bytesCount);
+    gwmAccountCreateWithSerialization (const char *type,
+                                       uint8_t *bytes,
+                                       size_t   bytesCount);
     
     extern void
     gwmAccountRelease (BRGenericAccount account);
@@ -78,6 +78,15 @@ extern "C" {
                      BRGenericAddress aid2);
 
     // Transfer
+
+    extern BRGenericTransfer
+    gwmTransferCreate (BRGenericWalletManager gwm,
+                       BRGenericWallet wid,
+                       BRGenericAddress target,
+                       UInt256 amount);
+
+    extern void
+    gwmTransferRelease (BRGenericWalletManager gwm, BRGenericTransfer transfer);
 
     extern BRGenericAddress
     gwmTransferGetSourceAddress (BRGenericWalletManager gwm,
@@ -115,6 +124,9 @@ extern "C" {
     extern BRGenericWallet
     gwmWalletCreate (BRGenericWalletManager gwm);
 
+    extern void
+    gwmWalletRelease (BRGenericWalletManager gwm, BRGenericWallet wallet);
+
     extern UInt256
     gwmWalletGetBalance (BRGenericWalletManager gwm,
                           BRGenericWallet wallet);
@@ -131,13 +143,6 @@ extern "C" {
     gwmWalletSetDefaultFeeBasis (BRGenericWalletManager gwm,
                                  BRGenericWallet wid,
                                  BRGenericFeeBasis bid);
-
-    extern BRGenericTransfer
-    gwmWalletCreateTransfer (BRGenericWalletManager gwm,
-                             BRGenericWallet wid,
-                             BRGenericAddress target,
-                             UInt256 amount);
-                             // ...
 
     extern UInt256
     gwmWalletEstimateTransferFee (BRGenericWalletManager gwm,

--- a/generic/BRGenericRipple.c
+++ b/generic/BRGenericRipple.c
@@ -55,7 +55,7 @@ genericRippleAccountGetSerialization (void *account, size_t *bytesCount) {
 }
 
 static void
-genericRippleAccountSerializeTransfer(BRGenericAccount account, BRGenericTransfer transfer, UInt512 seed)
+genericRippleAccountSerializeTransfer (BRGenericAccount account, BRGenericTransfer transfer, UInt512 seed)
 {
     // Get the transaction pointer from this transfer
     BRRippleTransaction transaction = rippleTransferGetTransaction(transfer);
@@ -84,7 +84,7 @@ genericRippleAddressEqual (BRGenericAddress address1,
 // Transfer
 
 static BRGenericTransfer
-genericRippleTransferCreate(BRGenericAddress source, BRGenericAddress target, UInt256 amount)
+genericRippleTransferCreate (BRGenericAddress source, BRGenericAddress target, UInt256 amount)
 {
     BRRippleUnitDrops amountDrops = UInt64GetLE(amount.u8);
     BRRippleAddress *from = source;
@@ -144,7 +144,7 @@ static BRGenericHash genericRippleTransferGetHash (BRGenericTransfer transfer) {
     return (BRGenericHash) { value };
 }
 
-static uint8_t * genericRippleTransferGetSerialization(BRGenericTransfer transfer, size_t *bytesCount)
+static uint8_t * genericRippleTransferGetSerialization (BRGenericTransfer transfer, size_t *bytesCount)
 {
     uint8_t * result = NULL;
     *bytesCount = 0;
@@ -309,7 +309,7 @@ genericRippleFeeBasisFree (BRGenericFeeBasis feeBasis) {
 }
 
 static BRGenericAddress
-genericRippleNetworkAddressCreate(const char* address) {
+genericRippleNetworkAddressCreate (const char* address) {
     BRRippleAddress *genericAddress = calloc(1, sizeof(BRRippleAddress));
     int bytesWritten = rippleAddressStringToAddress(address, genericAddress);
     if (bytesWritten > 0) {
@@ -322,7 +322,7 @@ genericRippleNetworkAddressCreate(const char* address) {
 }
 
 static void
-genericRippleNetworkAddressFree(BRGenericAddress address) {
+genericRippleNetworkAddressFree (BRGenericAddress address) {
     BRRippleAddress *rippleAddress = address;
     free(rippleAddress);
 }

--- a/generic/BRGenericWalletManager.h
+++ b/generic/BRGenericWalletManager.h
@@ -133,7 +133,7 @@ extern "C" {
     gwmGetNetwork (BRGenericWalletManager gwm);
 
     extern BRGenericClient
-    gwmGetClient(BRGenericWalletManager gwm);
+    gwmGetClient (BRGenericWalletManager gwm);
 
     extern BRGenericTransfer
     gwmRecoverTransfer (BRGenericWalletManager gwm, BRGenericWallet wallet,
@@ -150,10 +150,10 @@ extern "C" {
                                            uint8_t *bytes,
                                            size_t   bytesCount);
 
-    extern UInt256 gwmGetFeeBasisPricePerCostFactor(BRGenericWalletManager gwm, BRGenericFeeBasis feeBasis);
-    extern double gwmGetFeeBasisCostFactor(BRGenericWalletManager gwm, BRGenericFeeBasis feeBasis);
-    extern uint32_t gwmGetFeeBasisIsEqual(BRGenericWalletManager gwm, BRGenericFeeBasis fb1, BRGenericFeeBasis fb2);
-    extern void gwmFeeBasisRelease(BRGenericWalletManager gwm, BRGenericFeeBasis feeBasis);
+    extern UInt256 gwmGetFeeBasisPricePerCostFactor (BRGenericWalletManager gwm, BRGenericFeeBasis feeBasis);
+    extern double gwmGetFeeBasisCostFactor (BRGenericWalletManager gwm, BRGenericFeeBasis feeBasis);
+    extern uint32_t gwmGetFeeBasisIsEqual (BRGenericWalletManager gwm, BRGenericFeeBasis fb1, BRGenericFeeBasis fb2);
+    extern void gwmFeeBasisRelease (BRGenericWalletManager gwm, BRGenericFeeBasis feeBasis);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
Added missing Release functions.

Also - while making changes did some formatting fixes for function defines/declarations
i.e. add space between name and "("