### PR TITLE
CORE-629: Fix memory corruption issues

### DIFF
--- a/bitcoin/BRPeer.c
+++ b/bitcoin/BRPeer.c
@@ -99,7 +99,6 @@ typedef struct {
     uint32_t magicNumber;
     char host[INET6_ADDRSTRLEN];
     BRPeerStatus status;
-    int waitingForNetwork;
     volatile int needsFilterUpdate;
     uint64_t nonce, feePerKb;
     char *useragent;
@@ -982,7 +981,7 @@ static double _peerGetMempoolTime (BRPeerContext *ctx) {
 }
 
 
-static void *_peerThreadRoutine(void *arg)
+static void *_peerThreadConnectRoutine(void *arg)
 {
     BRPeer *peer = arg;
     BRPeerContext *ctx = arg;
@@ -1111,6 +1110,22 @@ static void *_peerThreadRoutine(void *arg)
     return NULL; // detached threads don't need to return a value
 }
 
+static void *_peerThreadDisconnectRoutine(void *arg) {
+    BRPeer *peer = arg;
+    BRPeerContext *ctx = arg;
+    
+    pthread_cleanup_push(ctx->threadCleanup, ctx->info);
+
+    peer_log(peer, "waiting-disconnected");
+
+    assert (0 == array_count(ctx->pongCallback));
+    assert (NULL == ctx->mempoolCallback);
+
+    if (ctx->disconnected) ctx->disconnected(ctx->info, 0);
+    pthread_cleanup_pop(1);
+    return NULL; // detached threads don't need to return a value
+}
+
 static void _dummyThreadCleanup(void *info)
 {
 }
@@ -1223,35 +1238,31 @@ void BRPeerConnect(BRPeer *peer)
     pthread_attr_t attr;
 
     pthread_mutex_lock(&ctx->lock);
-    if (ctx->status == BRPeerStatusDisconnected || ctx->waitingForNetwork) {
-        ctx->status = BRPeerStatusConnecting;
-    
+    if (ctx->status == BRPeerStatusDisconnected || ctx->status == BRPeerStatusWaiting) {
         if (ctx->networkIsReachable && ! ctx->networkIsReachable(ctx->info)) { // delay until network is reachable
-            if (! ctx->waitingForNetwork) peer_log(peer, "waiting for network reachability");
-            ctx->waitingForNetwork = 1;
+            if (ctx->status != BRPeerStatusWaiting) peer_log(peer, "waiting for network reachability");
+            ctx->status = BRPeerStatusWaiting;
         }
         else {
             peer_log(peer, "connecting");
-            ctx->waitingForNetwork = 0;
+            ctx->status = BRPeerStatusConnecting;
             gettimeofday(&tv, NULL);
 
             // No race - set before the thread starts.
             ctx->disconnectTime = tv.tv_sec + (double)tv.tv_usec/1000000 + CONNECT_TIMEOUT;
 
             if (pthread_attr_init(&attr) != 0) {
-                // error = ENOMEM;
-                peer_log(peer, "error creating thread");
+                peer_log(peer, "error creating connect thread");
                 ctx->status = BRPeerStatusDisconnected;
-                //if (ctx->disconnected) ctx->disconnected(ctx->info, error);
+                assert (0);
             }
             else if (pthread_attr_setdetachstate(&attr, PTHREAD_CREATE_DETACHED) != 0 ||
                      pthread_attr_setstacksize(&attr, PTHREAD_STACK_SIZE) != 0 ||
-                     pthread_create(&ctx->thread, &attr, _peerThreadRoutine, peer) != 0) {
-                // error = EAGAIN;
-                peer_log(peer, "error creating thread");
+                     pthread_create(&ctx->thread, &attr, _peerThreadConnectRoutine, peer) != 0) {
+                peer_log(peer, "error creating connect thread");
                 pthread_attr_destroy(&attr);
                 ctx->status = BRPeerStatusDisconnected;
-                //if (ctx->disconnected) ctx->disconnected(ctx->info, error);
+                assert (0);
             }
         }
     }
@@ -1263,6 +1274,7 @@ void BRPeerDisconnect(BRPeer *peer)
 {
     BRPeerContext *ctx = (BRPeerContext *)peer;
     int socket = -1;
+    pthread_attr_t attr;
 
     if (_peerCheckAndGetSocket(ctx, &socket)) {
         pthread_mutex_lock(&ctx->lock);
@@ -1270,8 +1282,28 @@ void BRPeerDisconnect(BRPeer *peer)
         pthread_mutex_unlock(&ctx->lock);
 
         if (shutdown(socket, SHUT_RDWR) < 0) peer_log(peer, "%s", strerror(errno));
-        close(socket);
     }
+
+    pthread_mutex_lock(&ctx->lock);
+    if (ctx->status == BRPeerStatusWaiting) {
+        peer_log(peer, "disconnecting");
+        ctx->status = BRPeerStatusDisconnected;
+
+        if (pthread_attr_init(&attr) != 0) {
+            peer_log(peer, "error creating disconnect thread");
+            assert (0);
+        }
+        else if (pthread_attr_setdetachstate(&attr, PTHREAD_CREATE_DETACHED) != 0 ||
+                 pthread_attr_setstacksize(&attr, PTHREAD_STACK_SIZE) != 0 ||
+                 pthread_create(&ctx->thread, &attr, _peerThreadDisconnectRoutine, peer) != 0) {
+            peer_log(peer, "error creating disconnect thread");
+            pthread_attr_destroy(&attr);
+            assert (0);
+        }
+
+        ctx->status = BRPeerStatusDisconnected;
+    }
+    pthread_mutex_unlock(&ctx->lock);
 }
 
 // call this to (re)schedule a disconnect in the given number of seconds, or < 0 to cancel (useful for sync timeout)

--- a/bitcoin/BRPeer.h
+++ b/bitcoin/BRPeer.h
@@ -93,7 +93,8 @@ extern "C" {
 typedef enum {
     BRPeerStatusDisconnected = 0,
     BRPeerStatusConnecting,
-    BRPeerStatusConnected
+    BRPeerStatusConnected,
+    BRPeerStatusWaiting
 } BRPeerStatus;
 
 typedef struct {

--- a/bitcoin/BRPeerManager.c
+++ b/bitcoin/BRPeerManager.c
@@ -839,7 +839,7 @@ static void _peerDisconnected(void *info, int error)
         if (manager->connectFailureCount > MAX_CONNECT_FAILURES) manager->connectFailureCount = MAX_CONNECT_FAILURES;
     }
 
-    if (! manager->isConnected && manager->connectFailureCount == MAX_CONNECT_FAILURES) {
+    if (! manager->isConnected && manager->connectFailureCount >= MAX_CONNECT_FAILURES) {
         _BRPeerManagerSyncStopped(manager);
         
         // clear out stored peers so we get a fresh list from DNS on next connect attempt
@@ -1445,6 +1445,7 @@ static void _peerThreadCleanup(void *info)
 
     free(info);
     pthread_mutex_lock(&manager->lock);
+    assert (0 != manager->peerThreadCount);
     manager->peerThreadCount--;
     pthread_mutex_unlock(&manager->lock);
     if (manager->threadCleanup) manager->threadCleanup(manager->info);
@@ -1599,7 +1600,7 @@ void BRPeerManagerConnect(BRPeerManager *manager)
     for (size_t i = array_count(manager->connectedPeers); i > 0; i--) {
         BRPeer *p = manager->connectedPeers[i - 1];
 
-        if (BRPeerConnectStatus(p) == BRPeerStatusConnecting) BRPeerConnect(p);
+        if (BRPeerConnectStatus(p) == BRPeerStatusWaiting) BRPeerConnect(p);
     }
     
     if (array_count(manager->connectedPeers) < manager->maxConnectCount) {
@@ -1641,13 +1642,6 @@ void BRPeerManagerConnect(BRPeerManager *manager)
                                    _peerSetFeePerKb, _peerRequestedTx, _peerNetworkIsReachable, _peerThreadCleanup);
                 BRPeerSetEarliestKeyTime(info->peer, manager->earliestKeyTime);
                 BRPeerConnect(info->peer);
-
-                if (BRPeerConnectStatus(info->peer) == BRPeerStatusDisconnected) {
-                    pthread_mutex_unlock(&manager->lock);
-                    _peerDisconnected(info, ENOTCONN);
-                    pthread_mutex_lock(&manager->lock);
-                    manager->peerThreadCount--;
-                }
             }
         }
 
@@ -1679,7 +1673,7 @@ void BRPeerManagerDisconnect(BRPeerManager *manager)
         p = manager->connectedPeers[i - 1];
         manager->connectFailureCount = MAX_CONNECT_FAILURES; // prevent futher automatic reconnect attempts
         BRPeerDisconnect(p);
-        if (BRPeerConnectStatus(p) == BRPeerStatusConnecting) manager->peerThreadCount--; // waiting for network
+        while (BRPeerConnectStatus(p) == BRPeerStatusConnecting) BRPeerDisconnect(p);
     }
 
     peerThreadCount = manager->peerThreadCount;


### PR DESCRIPTION
I have some tests in `testBwm.c` that abuse the BRPeerManager (via the BRWalletManager). They call BRPeerManagerConnect and BRPeerManagerDisconnect, as well as BRPeerManagerDisconnect+BRPeerManagerFree. They also randomly set if the network is reachable or not.

Using these tests, I can reliably trigger user-after-frees on an ASAN build.

To get the discussion started on how to fix, I've got this PoC branch that "fixes" the issues. Fixes in quotations because this is probably not how we want to fix it.

Some of the issues/changes:
* `BRPeerManagerConnect` used to explicitly call `_peerDisconnected` after a race-y check against the BRPeer's thread; removed this
* Added asserts to capture pthread_create failures; these could/should be changed to the function returning success/failure and handling
* We close the BRPeer's socket in `BRPeerDisconnect`, but the BRPeer thread closes it too. We can't do that, as the file descriptor could possibly be reused. Since the BRPeer thread owns the socket (and has a close), removed the `close` in `BRPeerDisconnect`. Instead, just a `shutdown` is performed to signal our intent to close
* The BRPeerManager code sort of assumes that a BRPeer has a thread (pre-emptively increments peerThreadCount, only calls BRPeerFree in `_peerDisconnected`, etc.) but if the network is unreachable, no BRPeer thread is created. I removed the `waitingForNetwork` BRPeer field and rolled it into the status. On `BRPeerDisconnect`, if we never launched the thread (i.e. in the `BRPeerStatusWaiting` state), launch a thread that does the same actions a "real" BRPeer thread would do (i.e. call disconnect, do the thread cleanup).
* Added asserts to capture future issue with peer thread count "underflow"-ing
