### PR TITLE
CORE-558: In Core Crypto, Migrate Block Blobs w/ Correct Bytes.

### DIFF
--- a/Swift/BRCrypto/BRCryptoSystem.swift
+++ b/Swift/BRCrypto/BRCryptoSystem.swift
@@ -1923,7 +1923,7 @@ extension System {
                 else { throw MigrateError.block }
 
             var flags  = blob.flags
-            var hashes = blob.hashes
+            var hashes = blob.hashes.flatMap { $0 }  // [[UInt8 ...] ...] => [UInt8 ... ...]
             let hashesCount = blob.hashes.count
 
             let hash: UInt256 = blob.hash.withUnsafeBytes { $0.load (as: UInt256.self) }


### PR DESCRIPTION
Confirmed w/ Ehsan in a debugging session.