### PR TITLE
CORE-564: In BREventHandler protect `handler->thread` access.

### DIFF
--- a/ethereum/event/BREvent.c
+++ b/ethereum/event/BREvent.c
@@ -291,6 +291,8 @@ extern void
 eventHandlerStop (BREventHandler handler) {
     pthread_mutex_lock(&handler->lock);
     if (PTHREAD_NULL != handler->thread) {
+        pthread_t thread = handler->thread;
+
         // Remove a timeout alarm, if it exists.
         if (ALARM_ID_NONE != handler->timeoutAlarmId) {
             alarmClockRemAlarm (alarmClock, handler->timeoutAlarmId);
@@ -311,7 +313,8 @@ eventHandlerStop (BREventHandler handler) {
         // we don't have a start/stop race.
         //
         pthread_cond_wait (&handler->threadExit, &handler->lock);
-
+        pthread_detach (thread);
+        
         // TODO: Empty the queue completely?  Or not?
         eventQueueDequeueWaitAbortReset (handler->queue);
         eventHandlerClear (handler);

--- a/ethereum/event/BREvent.c
+++ b/ethereum/event/BREvent.c
@@ -215,6 +215,7 @@ eventHandlerDestroy (BREventHandler handler) {
     assert (PTHREAD_NULL == handler->thread);
     pthread_mutex_unlock  (&handler->lock);
     pthread_mutex_destroy (&handler->lock);
+    pthread_cond_destroy (&handler->threadExit);
 
     // release memory
     eventQueueDestroy(handler->queue);


### PR DESCRIPTION
Maybe sufficient?