### PR TITLE
CORE-661: Send blockUpdated event in Swift

### DIFF
--- a/Swift/BRCrypto/BRCryptoSystem.swift
+++ b/Swift/BRCrypto/BRCryptoSystem.swift
@@ -1191,8 +1191,7 @@ extension System {
                     walletManagerEvent = WalletManagerEvent.syncEnded(reason: reason)
 
                 case CRYPTO_WALLET_MANAGER_EVENT_BLOCK_HEIGHT_UPDATED:
-                    manager.network.height = event.u.blockHeight.value
-                    // No event?
+                    walletManagerEvent = WalletManagerEvent.blockUpdated(height: event.u.blockHeight.value)
 
                 default: precondition(false)
                 }


### PR DESCRIPTION
Created as a draft for now. Waiting to confirm BTC block height updates flow upwards in API case once BDB is back going.