### PR TITLE
CORE-658: Add syncRecommended event

### DIFF
--- a/Java/CoreCrypto/src/main/java/com/breadwallet/corecrypto/Utilities.java
+++ b/Java/CoreCrypto/src/main/java/com/breadwallet/corecrypto/Utilities.java
@@ -105,15 +105,6 @@ final class Utilities {
     }
 
     /* package */
-    static BRCryptoWalletState walletStateToCrypto(WalletState state) {
-        switch (state) {
-            case CREATED: return BRCryptoWalletState.CRYPTO_WALLET_STATE_CREATED;
-            case DELETED: return BRCryptoWalletState.CRYPTO_WALLET_STATE_DELETED;
-            default: throw new IllegalArgumentException("Unsupported state");
-        }
-    }
-
-    /* package */
     static WalletState walletStateFromCrypto(BRCryptoWalletState state) {
         switch (state) {
             case CRYPTO_WALLET_STATE_CREATED: return WalletState.CREATED;
@@ -201,6 +192,15 @@ final class Utilities {
             case FROM_LAST_CONFIRMED_SEND: return BRSyncDepth.SYNC_DEPTH_FROM_LAST_CONFIRMED_SEND;
             case FROM_LAST_TRUSTED_BLOCK:  return BRSyncDepth.SYNC_DEPTH_FROM_LAST_TRUSTED_BLOCK;
             case FROM_CREATION:            return BRSyncDepth.SYNC_DEPTH_FROM_CREATION;
+            default: throw new IllegalArgumentException("Unsupported depth");
+        }
+    }
+
+    static WalletManagerSyncDepth syncDepthFromCrypto(BRSyncDepth depth) {
+        switch (depth) {
+            case SYNC_DEPTH_FROM_LAST_CONFIRMED_SEND: return WalletManagerSyncDepth.FROM_LAST_CONFIRMED_SEND;
+            case SYNC_DEPTH_FROM_LAST_TRUSTED_BLOCK:  return WalletManagerSyncDepth.FROM_LAST_TRUSTED_BLOCK;
+            case SYNC_DEPTH_FROM_CREATION:            return WalletManagerSyncDepth.FROM_CREATION;
             default: throw new IllegalArgumentException("Unsupported depth");
         }
     }

--- a/Java/CoreNative/src/main/java/com/breadwallet/corenative/crypto/BRCryptoWalletManagerEvent.java
+++ b/Java/CoreNative/src/main/java/com/breadwallet/corenative/crypto/BRCryptoWalletManagerEvent.java
@@ -7,6 +7,7 @@
  */
 package com.breadwallet.corenative.crypto;
 
+import com.breadwallet.corenative.support.BRSyncDepth;
 import com.breadwallet.corenative.support.BRSyncStoppedReason;
 import com.sun.jna.Pointer;
 import com.sun.jna.Structure;
@@ -25,6 +26,7 @@ public class BRCryptoWalletManagerEvent extends Structure {
         public wallet_struct wallet;
         public syncContinues_struct syncContinues;
         public syncStopped_struct syncStopped;
+        public syncRecommended_struct syncRecommended;
         public blockHeight_struct blockHeight;
 
         public static class state_struct extends Structure {
@@ -150,6 +152,40 @@ public class BRCryptoWalletManagerEvent extends Structure {
             }
         }
 
+        public static class syncRecommended_struct extends Structure {
+
+            public int depthEnum;
+
+            public syncRecommended_struct() {
+                super();
+            }
+
+            protected List<String> getFieldOrder() {
+                return Arrays.asList("depthEnum");
+            }
+
+            public syncRecommended_struct(int depth) {
+                super();
+                this.depthEnum = depth;
+            }
+
+            public syncRecommended_struct(Pointer peer) {
+                super(peer);
+            }
+
+            public BRSyncDepth depth() {
+                return BRSyncDepth.fromCore(depthEnum);
+            }
+
+            public static class ByReference extends syncRecommended_struct implements Structure.ByReference {
+
+            }
+
+            public static class ByValue extends syncRecommended_struct implements Structure.ByValue {
+
+            }
+        }
+
         public static class blockHeight_struct extends Structure {
 
             public long value;
@@ -206,6 +242,12 @@ public class BRCryptoWalletManagerEvent extends Structure {
             super();
             this.syncStopped = syncStopped;
             setType(syncStopped_struct.class);
+        }
+
+        public u_union(syncRecommended_struct syncRecommended) {
+            super();
+            this.syncRecommended = syncRecommended;
+            setType(syncRecommended_struct.class);
         }
 
         public u_union(blockHeight_struct blockHeight) {
@@ -267,6 +309,10 @@ public class BRCryptoWalletManagerEvent extends Structure {
                 break;
             case CRYPTO_WALLET_MANAGER_EVENT_SYNC_STOPPED:
                 u.setType(u_union.syncStopped_struct.class);
+                u.read();
+                break;
+            case CRYPTO_WALLET_MANAGER_EVENT_SYNC_RECOMMENDED:
+                u.setType(u_union.syncRecommended_struct.class);
                 u.read();
                 break;
             case CRYPTO_WALLET_MANAGER_EVENT_WALLET_ADDED:

--- a/Java/CoreNative/src/main/java/com/breadwallet/corenative/crypto/BRCryptoWalletManagerEventType.java
+++ b/Java/CoreNative/src/main/java/com/breadwallet/corenative/crypto/BRCryptoWalletManagerEventType.java
@@ -72,6 +72,13 @@ public enum BRCryptoWalletManagerEventType {
         }
     },
 
+    CRYPTO_WALLET_MANAGER_EVENT_SYNC_RECOMMENDED {
+        @Override
+        public int toCore() {
+            return CRYPTO_WALLET_MANAGER_EVENT_SYNC_RECOMMENDED_VALUE;
+        }
+    },
+
     CRYPTO_WALLET_MANAGER_EVENT_BLOCK_HEIGHT_UPDATED {
         @Override
         public int toCore() {
@@ -88,7 +95,8 @@ public enum BRCryptoWalletManagerEventType {
     private static final int CRYPTO_WALLET_MANAGER_EVENT_SYNC_STARTED_VALUE         = 6;
     private static final int CRYPTO_WALLET_MANAGER_EVENT_SYNC_CONTINUES_VALUE       = 7;
     private static final int CRYPTO_WALLET_MANAGER_EVENT_SYNC_STOPPED_VALUE         = 8;
-    private static final int CRYPTO_WALLET_MANAGER_EVENT_BLOCK_HEIGHT_UPDATED_VALUE = 9;
+    private static final int CRYPTO_WALLET_MANAGER_EVENT_SYNC_RECOMMENDED_VALUE     = 9;
+    private static final int CRYPTO_WALLET_MANAGER_EVENT_BLOCK_HEIGHT_UPDATED_VALUE = 10;
 
     public static BRCryptoWalletManagerEventType fromCore(int nativeValue) {
         switch (nativeValue) {
@@ -101,6 +109,7 @@ public enum BRCryptoWalletManagerEventType {
             case CRYPTO_WALLET_MANAGER_EVENT_SYNC_STARTED_VALUE:         return CRYPTO_WALLET_MANAGER_EVENT_SYNC_STARTED;
             case CRYPTO_WALLET_MANAGER_EVENT_SYNC_CONTINUES_VALUE:       return CRYPTO_WALLET_MANAGER_EVENT_SYNC_CONTINUES;
             case CRYPTO_WALLET_MANAGER_EVENT_SYNC_STOPPED_VALUE:         return CRYPTO_WALLET_MANAGER_EVENT_SYNC_STOPPED;
+            case CRYPTO_WALLET_MANAGER_EVENT_SYNC_RECOMMENDED_VALUE:     return CRYPTO_WALLET_MANAGER_EVENT_SYNC_RECOMMENDED;
             case CRYPTO_WALLET_MANAGER_EVENT_BLOCK_HEIGHT_UPDATED_VALUE: return CRYPTO_WALLET_MANAGER_EVENT_BLOCK_HEIGHT_UPDATED;
             default: throw new IllegalArgumentException("Invalid core value");
         }

--- a/Java/Crypto/src/main/java/com/breadwallet/crypto/events/walletmanager/DefaultWalletManagerEventVisitor.java
+++ b/Java/Crypto/src/main/java/com/breadwallet/crypto/events/walletmanager/DefaultWalletManagerEventVisitor.java
@@ -47,6 +47,11 @@ public abstract class DefaultWalletManagerEventVisitor<T> implements WalletManag
     }
 
     @Nullable
+    public T visit(WalletManagerSyncRecommendedEvent event) {
+        return null;
+    }
+
+    @Nullable
     public T visit(WalletManagerWalletAddedEvent event) {
         return null;
     }

--- a/Java/Crypto/src/main/java/com/breadwallet/crypto/events/walletmanager/WalletManagerEventVisitor.java
+++ b/Java/Crypto/src/main/java/com/breadwallet/crypto/events/walletmanager/WalletManagerEventVisitor.java
@@ -23,6 +23,8 @@ public interface WalletManagerEventVisitor<T> {
 
     T visit(WalletManagerSyncStoppedEvent event);
 
+    T visit(WalletManagerSyncRecommendedEvent event);
+
     T visit(WalletManagerWalletAddedEvent event);
 
     T visit(WalletManagerWalletChangedEvent event);

--- a/Java/Crypto/src/main/java/com/breadwallet/crypto/events/walletmanager/WalletManagerSyncRecommendedEvent.java
+++ b/Java/Crypto/src/main/java/com/breadwallet/crypto/events/walletmanager/WalletManagerSyncRecommendedEvent.java
@@ -1,0 +1,29 @@
+/*
+ * Created by Michael Carrara <michael.carrara@breadwallet.com> on 10/11/19.
+ * Copyright (c) 2019 Breadwinner AG.  All right reserved.
+*
+ * See the LICENSE file at the project root for license information.
+ * See the CONTRIBUTORS file at the project root for a list of contributors.
+ */
+package com.breadwallet.crypto.events.walletmanager;
+
+import com.breadwallet.crypto.WalletManagerSyncDepth;
+import com.breadwallet.crypto.WalletManagerSyncStoppedReason;
+
+public final class WalletManagerSyncRecommendedEvent implements WalletManagerEvent {
+
+    private final WalletManagerSyncDepth depth;
+
+    public WalletManagerSyncRecommendedEvent(WalletManagerSyncDepth depth) {
+        this.depth = depth;
+    }
+
+    public WalletManagerSyncDepth getDepth() {
+        return depth;
+    }
+
+    @Override
+    public <T> T accept(WalletManagerEventVisitor<T> visitor) {
+        return visitor.visit(this);
+    }
+}

--- a/Swift/BRCrypto/BRCryptoSystem.swift
+++ b/Swift/BRCrypto/BRCryptoSystem.swift
@@ -1190,6 +1190,10 @@ extension System {
                     let reason = WalletManagerSyncStoppedReason(core: event.u.syncStopped.reason)
                     walletManagerEvent = WalletManagerEvent.syncEnded(reason: reason)
 
+                case CRYPTO_WALLET_MANAGER_EVENT_SYNC_RECOMMENDED:
+                    let depth = WalletManagerSyncDepth(core: event.u.syncRecommended.depth)
+                    walletManagerEvent = WalletManagerEvent.syncRecommended(depth: depth)
+
                 case CRYPTO_WALLET_MANAGER_EVENT_BLOCK_HEIGHT_UPDATED:
                     manager.network.height = event.u.blockHeight.value
                     // No event?

--- a/Swift/BRCrypto/BRCryptoWalletManager.swift
+++ b/Swift/BRCrypto/BRCryptoWalletManager.swift
@@ -700,6 +700,7 @@ public enum WalletManagerEvent {
     case syncStarted
     case syncProgress (timestamp: Date?, percentComplete: Float)
     case syncEnded (reason: WalletManagerSyncStoppedReason)
+    case syncRecommended (depth: WalletManagerSyncDepth)
 
     /// An event capturing a change in the block height of the network associated with a
     /// WalletManager. Developers should listen for this event when making use of

--- a/Swift/BRCryptoTests/BRCryptoDebugSupport.swift
+++ b/Swift/BRCryptoTests/BRCryptoDebugSupport.swift
@@ -78,6 +78,8 @@ extension WalletManagerEvent: MatchableEvent {
         case (.syncStarted, .syncStarted): return true
         case (let .syncProgress (progress1), let .syncProgress (progress2)):
             return !strict || (progress1 == progress2)
+        case (let .syncRecommended (depth), let .syncRecommended (depth)):
+            return !strict || (depth == depth)
         case (let .syncEnded (error1), let .syncEnded (error2)):
             return !strict || (error1 == error2)
         case (let .blockUpdated (height1), let .blockUpdated (height2)):

--- a/Swift/BRCryptoTests/BRCryptoDebugSupport.swift
+++ b/Swift/BRCryptoTests/BRCryptoDebugSupport.swift
@@ -78,8 +78,8 @@ extension WalletManagerEvent: MatchableEvent {
         case (.syncStarted, .syncStarted): return true
         case (let .syncProgress (progress1), let .syncProgress (progress2)):
             return !strict || (progress1 == progress2)
-        case (let .syncRecommended (depth), let .syncRecommended (depth)):
-            return !strict || (depth == depth)
+        case (let .syncRecommended (depth1), let .syncRecommended (depth2)):
+            return !strict || (depth1 == depth2)
         case (let .syncEnded (error1), let .syncEnded (error2)):
             return !strict || (error1 == error2)
         case (let .blockUpdated (height1), let .blockUpdated (height2)):

--- a/bitcoin/BRWalletManager.h
+++ b/bitcoin/BRWalletManager.h
@@ -212,6 +212,7 @@ typedef enum {
     BITCOIN_WALLET_MANAGER_SYNC_STARTED,
     BITCOIN_WALLET_MANAGER_SYNC_PROGRESS,
     BITCOIN_WALLET_MANAGER_SYNC_STOPPED,
+    BITCOIN_WALLET_MANAGER_SYNC_RECOMMENDED,
     BITCOIN_WALLET_MANAGER_BLOCK_HEIGHT_UPDATED
 } BRWalletManagerEventType;
 
@@ -225,6 +226,9 @@ typedef struct {
         struct {
             BRSyncStoppedReason reason;
         } syncStopped;
+        struct {
+            BRSyncDepth depth;
+        } syncRecommended;
         struct {
             BRDisconnectReason reason;
         } disconnected;

--- a/bitcoin/BRWalletManagerEvent.c
+++ b/bitcoin/BRWalletManagerEvent.c
@@ -86,12 +86,13 @@ typedef struct {
     struct BREventRecord base;
     BRWalletManager manager;
     UInt256 hash;
+    int recommendRescan;
 } BRWalletManagerWalletTxDeletedEvent;
 
 static void
 bwmSignalTxDeletedDispatcher (BREventHandler ignore,
                               BRWalletManagerWalletTxDeletedEvent *event) {
-    bwmHandleTxDeleted(event->manager, event->hash);
+    bwmHandleTxDeleted(event->manager, event->hash,  event->recommendRescan);
 }
 
 static BREventType bwmSignalTxDeletedEventType = {
@@ -102,9 +103,10 @@ static BREventType bwmSignalTxDeletedEventType = {
 
 extern void
 bwmSignalTxDeleted (BRWalletManager manager,
-                    UInt256 hash) {
+                    UInt256 hash,
+                    int recommendRescan) {
     BRWalletManagerWalletTxDeletedEvent message =
-    { { NULL, &bwmSignalTxDeletedEventType}, manager, hash};
+    { { NULL, &bwmSignalTxDeletedEventType}, manager, hash, recommendRescan};
     eventHandlerSignalEvent (manager->handler, (BREvent*) &message);
 }
 

--- a/bitcoin/BRWalletManagerPrivate.h
+++ b/bitcoin/BRWalletManagerPrivate.h
@@ -100,11 +100,13 @@ bwmSignalTxUpdated (BRWalletManager manager,
 
 extern void
 bwmHandleTxDeleted (BRWalletManager manager,
-                    UInt256 hash);
+                    UInt256 hash,
+                    int recommendRescan);
 
 extern void
 bwmSignalTxDeleted (BRWalletManager manager,
-                    UInt256 hash);
+                    UInt256 hash,
+                    int recommendRescan);
 
 /// Mark: - WalletManager Events
 

--- a/crypto/BRCryptoWalletManager.c
+++ b/crypto/BRCryptoWalletManager.c
@@ -622,7 +622,7 @@ cryptoWalletManagerConnect (BRCryptoWalletManager cwm,
                 address = cryptoPeerGetAddrAsInt(peer);
                 port = cryptoPeerGetPort (peer);
             }
-            
+
             // Calling `SetFixedPeer` will 100% disconnect.  We could avoid calling SetFixedPeer
             // if we kept a reference to `peer` and checked if it differs.
             BRWalletManagerSetFixedPeer (cwm->u.btc, address, port);
@@ -975,6 +975,9 @@ BRCryptoWalletManagerEventTypeString (BRCryptoWalletManagerEventType t) {
 
         case CRYPTO_WALLET_MANAGER_EVENT_SYNC_STOPPED:
         return "CRYPTO_WALLET_MANAGER_EVENT_SYNC_STOPPED";
+
+        case CRYPTO_WALLET_MANAGER_EVENT_SYNC_RECOMMENDED:
+        return "CRYPTO_WALLET_MANAGER_EVENT_SYNC_RECOMMENDED";
 
         case CRYPTO_WALLET_MANAGER_EVENT_BLOCK_HEIGHT_UPDATED:
         return "CRYPTO_WALLET_MANAGER_EVENT_BLOCK_HEIGHT_UPDATED";

--- a/crypto/BRCryptoWalletManager.h
+++ b/crypto/BRCryptoWalletManager.h
@@ -61,6 +61,7 @@ extern "C" {
         CRYPTO_WALLET_MANAGER_EVENT_SYNC_STARTED,
         CRYPTO_WALLET_MANAGER_EVENT_SYNC_CONTINUES,
         CRYPTO_WALLET_MANAGER_EVENT_SYNC_STOPPED,
+        CRYPTO_WALLET_MANAGER_EVENT_SYNC_RECOMMENDED,
 
         CRYPTO_WALLET_MANAGER_EVENT_BLOCK_HEIGHT_UPDATED,
     } BRCryptoWalletManagerEventType;
@@ -89,6 +90,10 @@ extern "C" {
             struct {
                 BRSyncStoppedReason reason;
             } syncStopped;
+
+            struct {
+                BRSyncDepth depth;
+            } syncRecommended;
 
             struct {
                 uint64_t value;

--- a/crypto/BRCryptoWalletManagerClient.c
+++ b/crypto/BRCryptoWalletManagerClient.c
@@ -267,6 +267,15 @@ cwmWalletManagerEventAsBTC (BRWalletManagerClientContext context,
             cryptoWalletManagerSetState (cwm, state);
             break;
         }
+        case BITCOIN_WALLET_MANAGER_SYNC_RECOMMENDED: {
+            cwmEvent = (BRCryptoWalletManagerEvent) {
+                CRYPTO_WALLET_MANAGER_EVENT_SYNC_RECOMMENDED,
+                { .syncRecommended = {
+                    event.u.syncRecommended.depth,
+                }}
+            };
+            break;
+        }
         case BITCOIN_WALLET_MANAGER_BLOCK_HEIGHT_UPDATED: {
             cwmEvent = (BRCryptoWalletManagerEvent) {
                 CRYPTO_WALLET_MANAGER_EVENT_BLOCK_HEIGHT_UPDATED,

--- a/crypto/testCrypto.c
+++ b/crypto/testCrypto.c
@@ -454,7 +454,7 @@ CWMEventEqual (CWMEvent *e1, CWMEvent *e2) {
                         success = CRYPTO_TRUE == cryptoWalletEqual (e1->u.m.event.u.wallet.value, e2->u.m.event.u.wallet.value);
                         break;
                     case CRYPTO_WALLET_MANAGER_EVENT_SYNC_CONTINUES:
-                        // Do we want to check for this?
+                    case CRYPTO_WALLET_MANAGER_EVENT_SYNC_RECOMMENDED:
                     case CRYPTO_WALLET_MANAGER_EVENT_BLOCK_HEIGHT_UPDATED:
                         // Do we want to check for this?
                     default:


### PR DESCRIPTION
I included a depth in the sync recommended event. Should allow consumers to kick off a sync, if they deem the are in a state to do so, without having to determine where to start. Should give us flexibility in case other blockchains ever wanted to recommend a sync.