### PR TITLE
CORE-684: In Core Ripple, Define BRRippleAddress.[ch]

### DIFF
--- a/Swift/BRCore.xcodeproj/project.pbxproj
+++ b/Swift/BRCore.xcodeproj/project.pbxproj
@@ -284,6 +284,8 @@
 		3CF7683422E5F6DB0007BBDA /* BRCryptoKey.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3CF7683322E5F6DB0007BBDA /* BRCryptoKey.swift */; };
 		3CFEFE2322BC3AF20044153D /* BRCryptoWalletManagerClient.c in Sources */ = {isa = PBXBuildFile; fileRef = 3CFEFE2122BC3AF20044153D /* BRCryptoWalletManagerClient.c */; };
 		3CFEFE2422BC3AF20044153D /* BRCryptoWalletManagerClient.c in Sources */ = {isa = PBXBuildFile; fileRef = 3CFEFE2122BC3AF20044153D /* BRCryptoWalletManagerClient.c */; };
+		C30E2248235E42AD00E584AC /* BRRippleAddress.c in Sources */ = {isa = PBXBuildFile; fileRef = C30E2246235E42AC00E584AC /* BRRippleAddress.c */; };
+		C30E224A235E81F200E584AC /* BRRippleAddress.c in Sources */ = {isa = PBXBuildFile; fileRef = C30E2246235E42AC00E584AC /* BRRippleAddress.c */; };
 		C3169686232283A200743E45 /* BRRippleTransfer.c in Sources */ = {isa = PBXBuildFile; fileRef = C3169685232283A200743E45 /* BRRippleTransfer.c */; };
 		C31696892322B0A800743E45 /* BRRippleUtils.c in Sources */ = {isa = PBXBuildFile; fileRef = C31696872322B0A800743E45 /* BRRippleUtils.c */; };
 		C316968B2322F17500743E45 /* BRRippleUtils.c in Sources */ = {isa = PBXBuildFile; fileRef = C31696872322B0A800743E45 /* BRRippleUtils.c */; };
@@ -714,6 +716,8 @@
 		3CFEFE2022BC3AF20044153D /* BRCryptoWalletManagerPrivate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = BRCryptoWalletManagerPrivate.h; sourceTree = "<group>"; };
 		3CFEFE2122BC3AF20044153D /* BRCryptoWalletManagerClient.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = BRCryptoWalletManagerClient.c; sourceTree = "<group>"; };
 		3CFEFE2222BC3AF20044153D /* BRCryptoWalletManagerClient.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = BRCryptoWalletManagerClient.h; sourceTree = "<group>"; };
+		C30E2246235E42AC00E584AC /* BRRippleAddress.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = BRRippleAddress.c; sourceTree = "<group>"; };
+		C30E2247235E42AC00E584AC /* BRRippleAddress.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = BRRippleAddress.h; sourceTree = "<group>"; };
 		C316968423218C2300743E45 /* BRRippleTransfer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = BRRippleTransfer.h; sourceTree = "<group>"; };
 		C3169685232283A200743E45 /* BRRippleTransfer.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = BRRippleTransfer.c; sourceTree = "<group>"; };
 		C31696872322B0A800743E45 /* BRRippleUtils.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = BRRippleUtils.c; sourceTree = "<group>"; };
@@ -1306,6 +1310,8 @@
 			isa = PBXGroup;
 			children = (
 				3C812EBE2266675E0007D335 /* BRRipple.h */,
+				C30E2246235E42AC00E584AC /* BRRippleAddress.c */,
+				C30E2247235E42AC00E584AC /* BRRippleAddress.h */,
 				C3C864A0227B8CFE0055120E /* BRRippleAccount.h */,
 				C3C453E3226E4862004CC0C7 /* BRRippleAccount.c */,
 				C3C453E0226E2C62004CC0C7 /* BRRippleBase.h */,
@@ -1894,6 +1900,7 @@
 				3C6B173C2131CE12003C313B /* BREthereumAddress.c in Sources */,
 				3C6B173D2131CE12003C313B /* BREthereumSignature.c in Sources */,
 				3CF0FC9121657D7B000DE3FE /* BREthereumData.c in Sources */,
+				C30E224A235E81F200E584AC /* BRRippleAddress.c in Sources */,
 				3C6B173E2131CE12003C313B /* BREthereumTransaction.c in Sources */,
 				3C6B173F2131CE12003C313B /* BREthereumBloomFilter.c in Sources */,
 				3C9B8DEE22BD52940060C3A9 /* BRGenericHandlers.c in Sources */,
@@ -2106,6 +2113,7 @@
 				3C386DD320C6F6070065E355 /* BREthereumEWMClient.c in Sources */,
 				3C9B8DE922BD52940060C3A9 /* BRGeneric.c in Sources */,
 				3C9B8DED22BD52940060C3A9 /* BRGenericHandlers.c in Sources */,
+				C30E2248235E42AD00E584AC /* BRRippleAddress.c in Sources */,
 				3CAB60E620AF8D1A00810CE4 /* BRWallet.c in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/generic/BRGenericRipple.c
+++ b/generic/BRGenericRipple.c
@@ -41,11 +41,7 @@ genericRippleAccountFree (void *account) {
 static BRGenericAddress
 genericRippleAccountGetAddress (void *account) {
     BRRippleAccount ripple = account;
-    BRRippleAddress address = rippleAccountGetAddress(ripple);
-
-    BRRippleAddress *result = malloc (sizeof (BRRippleAddress));
-    memcpy (result, address.bytes, sizeof (BRRippleAddress));
-    return result;
+    return rippleAccountGetAddress(ripple);
 }
 
 static uint8_t *
@@ -253,12 +249,17 @@ genericRippleWalletManagerRecoverTransfer (const char *hash,
                                            uint64_t blockHeight) {
     BRRippleUnitDrops amountDrops;
     sscanf(amount, "%llu", &amountDrops);
-    BRRippleAddress toAddress = rippleAddressCreate(to);
-    BRRippleAddress fromAddress = rippleAddressCreate(from);
+    BRRippleAddress toAddress   = rippleAddressCreateFromString(to);
+    BRRippleAddress fromAddress = rippleAddressCreateFromString(from);
     // Convert the hash string to bytes
     BRRippleTransactionHash txId;
     decodeHex(txId.bytes, sizeof(txId.bytes), hash, strlen(hash));
-    return rippleTransferCreate(fromAddress, toAddress, amountDrops, txId, timestamp, blockHeight);
+    BRRippleTransfer result = rippleTransferCreate(fromAddress, toAddress, amountDrops, txId, timestamp, blockHeight);
+
+    rippleAddressFree (toAddress);
+    rippleAddressFree (fromAddress);
+
+    return result;
 }
 
 static BRArrayOf(BRGenericTransfer)
@@ -310,15 +311,7 @@ genericRippleFeeBasisFree (BRGenericFeeBasis feeBasis) {
 
 static BRGenericAddress
 genericRippleNetworkAddressCreate (const char* address) {
-    BRRippleAddress *genericAddress = calloc(1, sizeof(BRRippleAddress));
-    int bytesWritten = rippleAddressStringToAddress(address, genericAddress);
-    if (bytesWritten > 0) {
-        return genericAddress;
-    } else {
-        // Invalid address
-        free(genericAddress);
-        return NULL;
-    }
+    return rippleAddressCreateFromString (address);
 }
 
 static void

--- a/ripple/BRRippleAccount.c
+++ b/ripple/BRRippleAccount.c
@@ -154,7 +154,7 @@ extern void rippleAccountSetLastLedgerSequence(BRRippleAccount account,
 extern BRRippleAddress rippleAccountGetAddress(BRRippleAccount account)
 {
     assert(account);
-    return(account->address);
+    return rippleAddressClone (account->address);
 }
 
 extern uint8_t *rippleAccountGetSerialization (BRRippleAccount account, size_t *bytesCount) {
@@ -186,7 +186,7 @@ extern BRRippleAddress rippleAccountGetPrimaryAddress (BRRippleAccount account)
 {
     // Currently we only have the primary address - so just return it
     assert(account);
-    return account->address;
+    return rippleAddressClone (account->address);
 }
 
 extern size_t

--- a/ripple/BRRippleAccount.c
+++ b/ripple/BRRippleAccount.c
@@ -23,6 +23,8 @@
 #include "BRRippleAccount.h"
 #include "BRRippleSignature.h"
 #include "BRRippleBase58.h"
+#include "BRRippleAddress.h"
+
 //#include "BRBase58.h"
 
 #define RIPPLE_ADDRESS_PARAMS  ((BRAddressParams) { BITCOIN_PUBKEY_PREFIX, BITCOIN_SCRIPT_PREFIX, BITCOIN_PRIVKEY_PREFIX, BITCOIN_BECH32_PREFIX })
@@ -31,14 +33,8 @@
 
 #define WORD_LIST_LENGTH 2048
 
-uint8_t feeAddressBytes[20] = {
-    0x42, 0x52, 0x44, 0x5F, 0x5F, 0x66, 0x65, 0x65,
-    0x5F, 0x5F, 0x42, 0x52, 0x44, 0x00, 0x00, 0x00,
-    0x00, 0x00, 0x00, 0x00
-};
-
 struct BRRippleAccountRecord {
-    BRRippleAddress raw; // The 20 byte account id
+    BRRippleAddress address;
 
     // The public key - needed when sending 
     BRKey publicKey;  // BIP44: 'Master Public Key 'M' (264 bits) - 8
@@ -87,36 +83,6 @@ static BRKey deriveRippleKeyFromSeed (UInt512 seed, uint32_t index, bool cleanPr
     return key;
 }
 
-extern char * createRippleAddressString (BRRippleAddress address, int useChecksum)
-{
-    char *string = calloc (1, 36);
-
-    // Check for our special case __fee__ address
-    // See the note in BRRippleAcount.h with respect to the feeAddressBytes
-    if (memcmp(address.bytes, feeAddressBytes, sizeof(feeAddressBytes)) == 0) {
-        strcpy(string, "__fee__");
-    } else {
-        // The process is this:
-        // 1. Prepend the Ripple address indicator (0) to the 20 bytes
-        // 2. Do a douple sha265 hash on the bytes
-        // 3. Use the first 4 bytes of the hash as checksum and append to the bytes
-        uint8_t input[25];
-        input[0] = 0; // Ripple address type
-        memcpy(&input[1], address.bytes, 20);
-        uint8_t hash[32];
-        BRSHA256_2(hash, input, 21);
-        memcpy(&input[21], hash, 4);
-
-        // Now base58 encode the result
-        rippleEncodeBase58(string, 35, input, 25);
-        // NOTE: once the following function is "approved" we can switch to using it
-        // and remove the base58 function above
-        // static const char rippleAlphabet[] = "rpshnaf39wBUDNEGHJKLM4PQRST7VWXYZ2bcdeCg65jkm8oFqi1tuvAxyz";
-        // BRBase58EncodeEx(string, 36, input, 25, rippleAlphabet);
-    }
-    return string;
-}
-
 static BRRippleAccount createAccountObject(BRKey * key)
 {
     if (0 == key->compressed) {
@@ -133,8 +99,7 @@ static BRRippleAccount createAccountObject(BRKey * key)
     mem_clean(&account->publicKey.secret, sizeof(account->publicKey.secret));
 
     // Create the raw bytes for the 20 byte account id
-    UInt160 hash = BRKeyHash160(&account->publicKey);
-    memcpy(account->raw.bytes, hash.u8, 20);
+    account->address = rippleAddressCreateFromKey(&account->publicKey);
 
     return account;
 }
@@ -188,9 +153,8 @@ extern void rippleAccountSetLastLedgerSequence(BRRippleAccount account,
 
 extern BRRippleAddress rippleAccountGetAddress(BRRippleAccount account)
 {
-    BRRippleAddress address;
-    memcpy(address.bytes, account->raw.bytes, sizeof(address.bytes));
-    return(address);
+    assert(account);
+    return(account->address);
 }
 
 extern uint8_t *rippleAccountGetSerialization (BRRippleAccount account, size_t *bytesCount) {
@@ -203,23 +167,6 @@ extern uint8_t *rippleAccountGetSerialization (BRRippleAccount account, size_t *
     return bytes;
 }
 
-extern int rippleAccountGetAddressString(BRRippleAccount account, char * rippleAddress, int length)
-{
-    // Create the ripple address string
-    char *address = createRippleAddressString(account->raw, 1);
-    if (address) {
-        int addressLength = (int)strlen(address);
-        // Copy the address if we have enough room in the buffer
-        if (length > addressLength) {
-            strcpy(rippleAddress, address);
-        }
-        free(address);
-        return(addressLength + 1); // string length plus terminating byte
-    } else {
-        return 0;
-    }
-}
-
 extern BRKey rippleAccountGetPublicKey(BRRippleAccount account)
 {
     // Before returning this - make sure there is no private key.
@@ -230,15 +177,16 @@ extern BRKey rippleAccountGetPublicKey(BRRippleAccount account)
 
 extern void rippleAccountFree(BRRippleAccount account)
 {
-    // Currently there is not any allocated memory inside the account
-    // so just delete the account itself
+    assert(account);
+    if (account->address) rippleAddressFree(account->address);
     free(account);
 }
 
 extern BRRippleAddress rippleAccountGetPrimaryAddress (BRRippleAccount account)
 {
     // Currently we only have the primary address - so just return it
-    return account->raw;
+    assert(account);
+    return account->address;
 }
 
 extern size_t
@@ -265,74 +213,3 @@ rippleAccountSignTransaction(BRRippleAccount account, BRRippleTransaction transa
 
     return tx_size;
 }
-
-extern int rippleAddressStringToAddress(const char* input, BRRippleAddress *address)
-{
-    // The ripple address "string" is a base58 encoded string
-    // using the ripple base58 alphabet.  After decoding the address
-    // the output lookes like this
-    // [ 0, 20-bytes, 4-byte checksum ] for a total of 25 bytes
-    // In the ripple alphabet "r" maps to 0 which is why the first byte is 0
-    assert(address);
-
-    // Decode the
-    uint8_t bytes[25];
-    //int length = BRBase58DecodeEx(NULL, 0, input, rippleAlphabet);
-    int length = rippleDecodeBase58(input, NULL);
-    if (length != 25) {
-        // Since ripple addresses are created from 20 byte account IDs the
-        // needed space to covert it back has to be 25 bytes.
-        // LOG message?
-        return 0;
-    }
-
-    // We got the correct length so go ahead and decode.
-    rippleDecodeBase58(input, bytes);
-    //BRBase58DecodeEx(bytes, 25, input, rippleAlphabet);
-
-    // We need to do a checksum on all but the last 4 bytes.
-    // From trial and error is appears that the checksum is just
-    // sha256(sha256(first21bytes))
-    uint8_t md32[32];
-    BRSHA256_2(md32, &bytes[0], 21);
-    // Compare the first 4 bytes of the sha hash to the last 4 bytes
-    // of the decoded bytes (i.e. starting a byte 21)
-    if (0 == memcmp(md32, &bytes[21], 4)) {
-        // The checksum has passed so copy the 20 bytes that form the account id
-        // to our ripple address structure.
-        // i.e. strip off the 1 bytes token and the 4 byte checksum
-        memcpy(address->bytes, &bytes[1], 20);
-        return 20;
-    } else {
-        // Checksum does not match - do we log this somewhere
-    }
-    return 0;
-}
-
-extern BRRippleAddress
-rippleAddressCreate(const char * rippleAddressString)
-{
-    BRRippleAddress address;
-    memset(address.bytes, 0x00, sizeof(address.bytes));
-    // 1 special case so far - the __fee__ address.
-    // See the note in BRRippleAcount.h with respect to the feeAddressBytes
-    if (strcmp(rippleAddressString, "__fee__") == 0) {
-        memcpy(address.bytes, feeAddressBytes, sizeof(feeAddressBytes));
-    } else {
-        // Work backwards from this ripple address (string) to what is
-        // known as the acount ID (20 bytes)
-        rippleAddressStringToAddress(rippleAddressString, &address);
-    }
-    return address;
-}
-
-extern int // 1 if equal
-rippleAddressEqual (BRRippleAddress a1, BRRippleAddress a2) {
-    return 0 == memcmp (a1.bytes, a2.bytes, 20);
-}
-
-extern char *
-rippleAddressAsString (BRRippleAddress address) {
-    return createRippleAddressString(address, 1);
-}
-

--- a/ripple/BRRippleAccount.h
+++ b/ripple/BRRippleAccount.h
@@ -14,12 +14,6 @@
 #include "BRRippleTransaction.h"
 #include "BRKey.h"
 
-// We cannot do the normal conversion from bytes
-// to ripple address for the __fee__ address. So
-// instead we convert it to these hard-coded bytes
-// (and back again when needed) - defined in BRRippleAccount.c
-extern uint8_t feeAddressBytes[20];
-
 typedef struct BRRippleAccountRecord *BRRippleAccount;
 
 /**
@@ -104,7 +98,13 @@ extern void rippleAccountSetLastLedgerSequence(BRRippleAccount account,
 extern size_t
 rippleAccountSignTransaction(BRRippleAccount account, BRRippleTransaction transaction, UInt512 seed);
 
-// Accessor function for the account address (Ripple ID)
+/**
+ * Get the account address
+ *
+ * @param account   - the account
+ *
+ * @return address  - a ripple address, caller owns object and must free with rippleAddressFree
+ */
 extern BRRippleAddress
 rippleAccountGetAddress(BRRippleAccount account);
 
@@ -116,6 +116,8 @@ rippleAccountGetSerialization (BRRippleAccount account, size_t *bytesCount);
  * Get the account's primary address
  *
  * @param account the account
+ *
+ * @return address  - a ripple address, caller owns object and must free with rippleAddressFree
  */
 extern BRRippleAddress rippleAccountGetPrimaryAddress (BRRippleAccount account);
 

--- a/ripple/BRRippleAccount.h
+++ b/ripple/BRRippleAccount.h
@@ -112,43 +112,6 @@ rippleAccountGetAddress(BRRippleAccount account);
 extern uint8_t * /* caller must free - using "free" function */
 rippleAccountGetSerialization (BRRippleAccount account, size_t *bytesCount);
 
-/*
- * Get the string version of the ripple address
- *
- * @param account        handle of a valid account object
- * @param rippleAddress  pointer to char buffer to hold the address
- * @param length         length of the rippleAddress buffer
- *
- * @return               number of bytes copied to rippleAddress + 1 (for terminating byte)
- *                       otherwise return the number of bytes needed to store the address
- *                       including the 0 termination byte
- */
-extern int rippleAccountGetAddressString(BRRippleAccount account,
-                                         char * rippleAddress, /* memory owned by caller */
-                                         int length);
-
-/**
- * Create a BRRippleAddress from the ripple string
- *
- * @param rippleAddres  address in the form r41...
- *
- * @return address      BRRippleAddres
- */
-extern BRRippleAddress
-rippleAddressCreate(const char * rippleAddressString);
-
-/**
- * Compare 2 ripple addresses
- *
- * @param a1  first address
- * @param a2  second address
- *
- * @return 1 - if addresses are equal
- *         0 - if not equal
- */
-extern int
-rippleAddressEqual (BRRippleAddress a1, BRRippleAddress a2);
-
 /**
  * Get the account's primary address
  *
@@ -157,14 +120,5 @@ rippleAddressEqual (BRRippleAddress a1, BRRippleAddress a2);
 extern BRRippleAddress rippleAccountGetPrimaryAddress (BRRippleAccount account);
 
 extern BRKey rippleAccountGetPublicKey(BRRippleAccount account);
-
-/**
- * Attempt to create a BRRippleAddress from this string
- *
- * @param input    the string address
- * @param address  pointer to a BRRippleAddress
- * @return the number of bytes written to "address"
- */
-extern int rippleAddressStringToAddress(const char* input, BRRippleAddress *address);
 
 #endif

--- a/ripple/BRRippleAddress.c
+++ b/ripple/BRRippleAddress.c
@@ -1,0 +1,189 @@
+//
+//  BRRippleAddress.c
+//  Core
+//
+//  Created by Carl Cherry on Oct. 21, 2019.
+//  Copyright © 2019 Breadwinner AG. All rights reserved.
+//
+//  See the LICENSE file at the project root for license information.
+//  See the CONTRIBUTORS file at the project root for a list of contributors.
+//
+
+#include "BRRippleAddress.h"
+#include "BRRippleBase58.h"
+#include "support/BRCrypto.h"
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <assert.h>
+#include <memory.h>
+
+// A Ripple Address - 20 bytes
+#define ADDRESS_BYTES   (20)
+
+struct BRRippleAddressRecord {
+    uint8_t bytes[ADDRESS_BYTES];
+};
+
+uint8_t feeAddressBytes[20] = {
+    0x42, 0x52, 0x44, 0x5F, 0x5F, 0x66, 0x65, 0x65,
+    0x5F, 0x5F, 0x42, 0x52, 0x44, 0x00, 0x00, 0x00,
+    0x00, 0x00, 0x00, 0x00
+};
+
+extern void rippleAddressFree (BRRippleAddress address)
+{
+    if (address) free(address);
+}
+
+BRRippleAddress rippleAddressCreateFeeAddress()
+{
+    BRRippleAddress address = calloc(1, sizeof(struct BRRippleAddressRecord));
+    memcpy(address->bytes, feeAddressBytes, ADDRESS_BYTES);
+    return address;
+}
+
+extern char * rippleAddressAsString (BRRippleAddress address)
+{
+    assert(address);
+    char *string = calloc (1, 36);
+
+    // Check for our special case __fee__ address
+    // See the note above with respect to the feeAddressBytes
+    if (memcmp(address->bytes, feeAddressBytes, sizeof(feeAddressBytes)) == 0) {
+        strcpy(string, "__fee__");
+    } else {
+        // The process is this:
+        // 1. Prepend the Ripple address indicator (0) to the 20 bytes
+        // 2. Do a douple sha265 hash on the bytes
+        // 3. Use the first 4 bytes of the hash as checksum and append to the bytes
+        uint8_t input[25];
+        input[0] = 0; // Ripple address type
+        memcpy(&input[1], address->bytes, 20);
+        uint8_t hash[32];
+        BRSHA256_2(hash, input, 21);
+        memcpy(&input[21], hash, 4);
+
+        // Now base58 encode the result
+        rippleEncodeBase58(string, 35, input, 25);
+        // NOTE: once the following function is "approved" we can switch to using it
+        // and remove the base58 function above
+        // static const char rippleAlphabet[] = "rpshnaf39wBUDNEGHJKLM4PQRST7VWXYZ2bcdeCg65jkm8oFqi1tuvAxyz";
+        // BRBase58EncodeEx(string, 36, input, 25, rippleAlphabet);
+    }
+    return string;
+}
+
+extern BRRippleAddress // caller must free memory with rippleAddressFree
+rippleAddressCreateFromKey (BRKey *publicKey)
+{
+    BRRippleAddress address = calloc(1, sizeof(struct BRRippleAddressRecord));
+    UInt160 hash = BRKeyHash160(publicKey);
+    memcpy(address->bytes, hash.u8, 20);
+    return address;
+}
+
+extern BRRippleAddress // caller must free memory with rippleAddressFree
+rippleAddressCreateFromBytes (uint8_t * buffer, int bufferSize)
+{
+    assert(buffer);
+    assert(bufferSize == ADDRESS_BYTES);
+    BRRippleAddress address = calloc(1, sizeof(struct BRRippleAddressRecord));
+    memcpy(address->bytes, buffer, bufferSize);
+    return address;
+}
+
+BRRippleAddress rippleAddressStringToAddress(const char* input)
+{
+    // The ripple address "string" is a base58 encoded string
+    // using the ripple base58 alphabet.  After decoding the address
+    // the output lookes like this
+    // [ 0, 20-bytes, 4-byte checksum ] for a total of 25 bytes
+    // In the ripple alphabet "r" maps to 0 which is why the first byte is 0
+
+    // Decode the string input
+    uint8_t bytes[25];
+    //int length = BRBase58DecodeEx(NULL, 0, input, rippleAlphabet);
+    int length = rippleDecodeBase58(input, NULL);
+    if (length != 25) {
+        // Since ripple addresses are created from 20 byte account IDs the
+        // needed space to covert it back has to be 25 bytes.
+        // LOG message?
+        return 0;
+    }
+
+    // We got the correct length so go ahead and decode.
+    rippleDecodeBase58(input, bytes);
+    //BRBase58DecodeEx(bytes, 25, input, rippleAlphabet);
+
+    // We need to do a checksum on all but the last 4 bytes.
+    // From trial and error is appears that the checksum is just
+    // sha256(sha256(first21bytes))
+    uint8_t md32[32];
+    BRSHA256_2(md32, &bytes[0], 21);
+    // Compare the first 4 bytes of the sha hash to the last 4 bytes
+    // of the decoded bytes (i.e. starting a byte 21)
+    if (0 == memcmp(md32, &bytes[21], 4)) {
+        // The checksum has passed so copy the 20 bytes that form the account id
+        // to our ripple address structure.
+        // i.e. strip off the 1 bytes token and the 4 byte checksum
+        return rippleAddressCreateFromBytes(&bytes[1], 20);
+    } else {
+        // Checksum does not match - do we log this somewhere
+        return NULL;
+    }
+    return NULL;
+}
+
+extern BRRippleAddress
+rippleAddressCreateFromString(const char * rippleAddressString)
+{
+    // 1 special case so far - the __fee__ address.
+    // See the note in BRRippleAcount.h with respect to the feeAddressBytes
+    if (strcmp(rippleAddressString, "__fee__") == 0) {
+        return rippleAddressCreateFeeAddress ();
+    } else {
+        // Work backwards from this ripple address (string) to what is
+        // known as the acount ID (20 bytes)
+        return rippleAddressStringToAddress (rippleAddressString);
+    }
+}
+
+extern int // 1 if equal
+rippleAddressEqual (BRRippleAddress a1, BRRippleAddress a2) {
+    return 0 == memcmp (a1->bytes, a2->bytes, 20);
+}
+
+extern int
+rippleAddressIsFeeAddress (BRRippleAddress address)
+{
+    assert(address);
+    if (memcmp(address->bytes, feeAddressBytes, sizeof(feeAddressBytes)) == 0) {
+        return 1;
+    } else {
+        return 0;
+    }
+}
+
+extern int
+rippleAddressGetRawSize (BRRippleAddress address)
+{
+    return ADDRESS_BYTES;
+}
+
+extern void rippleAddressGetRawBytes (BRRippleAddress address, uint8_t *buffer, int bufferSize)
+{
+    assert(buffer);
+    assert(bufferSize >= ADDRESS_BYTES);
+    memcpy(buffer, address->bytes, ADDRESS_BYTES);
+}
+
+extern BRRippleAddress rippleAddressClone (BRRippleAddress address)
+{
+    if (address) {
+        BRRippleAddress clone = calloc(1, sizeof(struct BRRippleAddressRecord));
+        *clone = *address;
+        return clone;
+    }
+    return NULL;
+}

--- a/ripple/BRRippleAddress.h
+++ b/ripple/BRRippleAddress.h
@@ -1,0 +1,129 @@
+//
+//  BRRippleAddress.h
+//  Core
+//
+//  Created by Carl Cherry on Oct. 21, 2019.
+//  Copyright © 2019 Breadwinner AG. All rights reserved.
+//
+//  See the LICENSE file at the project root for license information.
+//  See the CONTRIBUTORS file at the project root for a list of contributors.
+//
+#ifndef BRRippleAddress_h
+#define BRRippleAddress_h
+
+#include "support/BRKey.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef struct BRRippleAddressRecord *BRRippleAddress;
+
+/**
+ * Get the ripple address string representation of the address
+ *
+ * @param address   - a BRRippleAddress
+ *
+ * @return pointer to allocated buffer holding the null terminated string
+ */
+extern char * // Caller must free using the "free" function
+rippleAddressAsString (BRRippleAddress address);
+
+/**
+ * Create a ripple address from a valid public key
+ *
+ * @param key   - a BRKey with the public key set
+ *
+ * @return address  - a BRRippleAddress object
+ */
+extern BRRippleAddress // caller must free memory with rippleAddressFree
+rippleAddressCreateFromKey (BRKey *publicKey);
+
+/**
+ * Create a ripple address from a valid ripple address string
+ *
+ * @param address   - ripple address string in the "r..." format
+ *
+ * @return address  - a BRRippleAddress object
+ */
+extern BRRippleAddress
+rippleAddressCreateFromString(const char * rippleAddressString);
+
+/**
+ * Create a ripple address from the raw bytes (20 for ripple)
+ *
+ * @param buffer     - raw address bytes
+ * @param bufferSize - size of the buffer, must be 20
+ *
+ * @return address  - a BRRippleAddress object
+ */
+extern BRRippleAddress // caller must free memory with rippleAddressFree
+rippleAddressCreateFromBytes (uint8_t * buffer, int bufferSize);
+
+/**
+ * Free the memory associated with a BRRippleAddress
+ *
+ * @param address   - a BRRippleAddress
+ *
+ * @return void
+ */
+extern void
+rippleAddressFree (BRRippleAddress address);
+
+/**
+ * Check is this address is the
+ *
+ * @param address   - a BRRippleAddress
+ *
+ * @return 1 if this is the "Fee" address, 0 if not
+ */
+extern int
+rippleAddressIsFeeAddress (BRRippleAddress address);
+
+/**
+ * Get the size of the raw bytes for this address
+ *
+ * @param address   - a BRRippleAddress
+ *
+ * @return size of the raw bytes
+ */
+extern int
+rippleAddressGetRawSize (BRRippleAddress address);
+
+/**
+ * Get the raw bytes for this address
+ *
+ * @param address    - a BRRippleAddress
+ * @param buffer     - a buffer to hold the raw bytes
+ * @param bufferSize - size of the buffer, obtained via rippleAddressGetRawSize
+ *
+ * @return void
+ */
+extern void rippleAddressGetRawBytes (BRRippleAddress address, uint8_t *buffer, int bufferSize);
+
+/**
+ * Copy a BRRippleAddress
+ *
+ * @param address   - a BRRippleAddress
+ *
+ * @return copy     - an exact copy of the specified address
+ */
+extern BRRippleAddress rippleAddressClone (BRRippleAddress address);
+
+/**
+ * Compare 2 ripple addresses
+ *
+ * @param a1  first address
+ * @param a2  second address
+ *
+ * @return 1 - if addresses are equal
+ *         0 - if not equal
+ */
+extern int // 1 if equal
+rippleAddressEqual (BRRippleAddress a1, BRRippleAddress a2);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* BRRippleAddress_h */

--- a/ripple/BRRippleBase.h
+++ b/ripple/BRRippleBase.h
@@ -14,16 +14,6 @@
 #include <string.h>
 #include <assert.h>
 
-#define ADDRESS_BYTES   (20)
-
-// A Ripple Address - 20 bytes
-typedef struct {
-    uint8_t bytes[ADDRESS_BYTES];
-} BRRippleAddress;
-
-extern char *
-rippleAddressAsString (BRRippleAddress address);
-
 // Even though we only support the Payment type - plan for
 // the future
 typedef enum {

--- a/ripple/BRRippleTransaction.c
+++ b/ripple/BRRippleTransaction.c
@@ -135,13 +135,13 @@ rippleTransactionCreate(BRRippleAddress sourceAddress,
     // Common fields
     transaction->feeBasis = feeBasis;
     transaction->fee = 0; // Don't know it yet
-    transaction->sourceAddress = sourceAddress;
+    transaction->sourceAddress = rippleAddressClone (sourceAddress);
     transaction->transactionType = RIPPLE_TX_TYPE_PAYMENT;
     transaction->flags = 0x80000000; // tfFullyCanonicalSig
     transaction->lastLedgerSequence = 0;
 
     // Payment information
-    transaction->payment.targetAddress = targetAddress;
+    transaction->payment.targetAddress = rippleAddressClone (targetAddress);
     transaction->payment.amount.currencyType = 0; // XRP
     transaction->payment.amount.amount.u64Amount = amount; // XRP only
     
@@ -406,12 +406,12 @@ extern BRRippleFlags rippleTransactionGetFlags(BRRippleTransaction transaction)
 extern BRRippleAddress rippleTransactionGetSource(BRRippleTransaction transaction)
 {
     assert(transaction);
-    return transaction->sourceAddress;
+    return rippleAddressClone (transaction->sourceAddress);
 }
 extern BRRippleAddress rippleTransactionGetTarget(BRRippleTransaction transaction)
 {
     assert(transaction);
-    return transaction->payment.targetAddress;
+    return rippleAddressClone (transaction->payment.targetAddress);
 }
 
 extern BRKey rippleTransactionGetPublicKey(BRRippleTransaction transaction)

--- a/ripple/BRRippleTransaction.c
+++ b/ripple/BRRippleTransaction.c
@@ -155,6 +155,13 @@ extern void rippleTransactionFree(BRRippleTransaction transaction)
 {
     assert(transaction);
 
+    if (transaction->payment.targetAddress) {
+        rippleAddressFree(transaction->payment.targetAddress);
+    }
+    if (transaction->sourceAddress) {
+        rippleAddressFree(transaction->sourceAddress);
+    }
+
     if (transaction->signedBytes) {
         rippleSerializedTransactionRecordFree(&transaction->signedBytes);
         transaction->signedBytes = NULL;
@@ -243,6 +250,9 @@ rippleTransactionSerializeImpl (BRRippleTransaction transaction,
 {
     assert(transaction);
     assert(transaction->transactionType == RIPPLE_TX_TYPE_PAYMENT);
+    // NOTE - the address fields will hold a BRRippleAddress pointer BUT
+    // they are owned by the the transaction or transfer so we don't need
+    // to worry about the memory.
     BRRippleField fields[10];
 
     transaction->fee = calculateFee(transaction);
@@ -554,6 +564,8 @@ rippleTransactionCreateFromBytes(uint8_t *bytes, int length)
             // An array of Memos
             transaction->memos = field->memos;
         }
+        // NOTE - the deserialization process created BRRippleAddress objects
+        // but in the call above to getFieldInfo the transaction object now owns the memory
     }
     array_free(fieldArray);
 

--- a/ripple/BRRippleTransaction.h
+++ b/ripple/BRRippleTransaction.h
@@ -15,6 +15,7 @@
 #include "BRRippleFeeBasis.h"
 #include "BRKey.h"
 #include "support/BRSet.h"
+#include "BRRippleAddress.h"
 
 typedef struct BRRippleTransactionRecord *BRRippleTransaction;
 

--- a/ripple/BRRippleTransaction.h
+++ b/ripple/BRRippleTransaction.h
@@ -106,8 +106,12 @@ extern BRRippleUnitDrops rippleTransactionGetAmount(BRRippleTransaction transact
 extern BRRippleSequence rippleTransactionGetSequence(BRRippleTransaction transaction);
 extern BRRippleFlags rippleTransactionGetFlags(BRRippleTransaction transaction);
 extern BRRippleLastLedgerSequence rippleTransactionGetLastLedgerSequence(BRRippleTransaction transaction);
-extern BRRippleAddress rippleTransactionGetSource(BRRippleTransaction transaction);
-extern BRRippleAddress rippleTransactionGetTarget(BRRippleTransaction transaction);
+
+extern BRRippleAddress // caller owns object, must free with rippleAddressFree
+rippleTransactionGetSource(BRRippleTransaction transaction);
+extern BRRippleAddress // caller owns object, must free with rippleAddressFree
+rippleTransactionGetTarget(BRRippleTransaction transaction);
+
 extern BRKey rippleTransactionGetPublicKey(BRRippleTransaction transaction);
 
 extern UInt256 rippleTransactionGetInvoiceID(BRRippleTransaction transaction);

--- a/ripple/BRRippleTransfer.c
+++ b/ripple/BRRippleTransfer.c
@@ -26,8 +26,8 @@ rippleTransferCreate(BRRippleAddress from, BRRippleAddress to,
                      uint64_t timestamp, uint64_t blockHeight)
 {
     BRRippleTransfer transfer = calloc (1, sizeof (struct BRRippleTransferRecord));
-    transfer->sourceAddress = from;
-    transfer->targetAddress = to;
+    transfer->sourceAddress = rippleAddressClone (from);
+    transfer->targetAddress = rippleAddressClone (to);
     transfer->amount = amount;
     transfer->transactionId = hash;
     transfer->timestamp = timestamp;
@@ -41,15 +41,13 @@ rippleTransferCreateNew(BRRippleAddress from, BRRippleAddress to,
                      BRRippleUnitDrops amount)
 {
     BRRippleTransfer transfer = calloc (1, sizeof (struct BRRippleTransferRecord));
-    transfer->sourceAddress = from;
-    transfer->targetAddress = to;
+    transfer->sourceAddress = rippleAddressClone (from);
+    transfer->targetAddress = rippleAddressClone (to);
     transfer->amount = amount;
     BRRippleFeeBasis feeBasis; // NOTE - hard code for DEMO purposes
     feeBasis.pricePerCostFactor = 10;
     feeBasis.costFactor = 1;
-    BRRippleAddress fromClone = rippleAddressClone (from);
-    BRRippleAddress toClone = rippleAddressClone (to);
-    transfer->transaction = rippleTransactionCreate(fromClone, toClone, amount, feeBasis);
+    transfer->transaction = rippleTransactionCreate(from, to, amount, feeBasis);
     return transfer;
 }
 
@@ -84,12 +82,12 @@ extern BRRippleUnitDrops rippleTransferGetAmount(BRRippleTransfer transfer)
 extern BRRippleAddress rippleTransferGetSource(BRRippleTransfer transfer)
 {
     assert(transfer);
-    return transfer->sourceAddress;
+    return rippleAddressClone (transfer->sourceAddress);
 }
 extern BRRippleAddress rippleTransferGetTarget(BRRippleTransfer transfer)
 {
     assert(transfer);
-    return transfer->targetAddress;
+    return rippleAddressClone (transfer->targetAddress);
 }
 
 extern BRRippleUnitDrops rippleTransferGetFee(BRRippleTransfer transfer)

--- a/ripple/BRRippleTransfer.c
+++ b/ripple/BRRippleTransfer.c
@@ -47,13 +47,17 @@ rippleTransferCreateNew(BRRippleAddress from, BRRippleAddress to,
     BRRippleFeeBasis feeBasis; // NOTE - hard code for DEMO purposes
     feeBasis.pricePerCostFactor = 10;
     feeBasis.costFactor = 1;
-    transfer->transaction = rippleTransactionCreate(from, to, amount, feeBasis);
+    BRRippleAddress fromClone = rippleAddressClone (from);
+    BRRippleAddress toClone = rippleAddressClone (to);
+    transfer->transaction = rippleTransactionCreate(fromClone, toClone, amount, feeBasis);
     return transfer;
 }
 
 extern void rippleTransferFree(BRRippleTransfer transfer)
 {
     assert(transfer);
+    if (transfer->sourceAddress) rippleAddressFree (transfer->sourceAddress);
+    if (transfer->targetAddress) rippleAddressFree (transfer->targetAddress);
     if (transfer->transaction) {
         rippleTransactionFree(transfer->transaction);
     }
@@ -94,7 +98,7 @@ extern BRRippleUnitDrops rippleTransferGetFee(BRRippleTransfer transfer)
     // See the note in BRRippleAcount.h with respect to the feeAddressBytes
     // If the "target" address is set to the feeAddressBytes then return the
     // amount on this transfer - otherwise return 0.
-    if (memcmp(transfer->targetAddress.bytes, feeAddressBytes, sizeof(transfer->targetAddress.bytes)) == 0) {
+    if (1 == rippleAddressIsFeeAddress(transfer->targetAddress)) {
         return transfer->amount;
     } else {
         return (BRRippleUnitDrops)0L;

--- a/ripple/BRRippleTransfer.h
+++ b/ripple/BRRippleTransfer.h
@@ -34,8 +34,12 @@ extern BRRippleTransactionHash rippleTransferGetTransactionId(BRRippleTransfer t
 extern BRRippleUnitDrops rippleTransferGetFee(BRRippleTransfer transfer);
 extern BRRippleUnitDrops rippleTransferGetAmount(BRRippleTransfer transfer);
 extern BRRippleUnitDrops rippleTransferGetFee(BRRippleTransfer transfer);
-extern BRRippleAddress rippleTransferGetSource(BRRippleTransfer transfer);
-extern BRRippleAddress rippleTransferGetTarget(BRRippleTransfer transfer);
+
+extern BRRippleAddress // caller owns object, must free with rippleAddressFree
+rippleTransferGetSource(BRRippleTransfer transfer);
+
+extern BRRippleAddress // caller owns object, must free with rippleAddressFree
+rippleTransferGetTarget(BRRippleTransfer transfer);
 
 extern BRRippleTransaction rippleTransferGetTransaction(BRRippleTransfer transfer);
 

--- a/ripple/BRRippleTransfer.h
+++ b/ripple/BRRippleTransfer.h
@@ -13,6 +13,7 @@
 
 #include "BRRippleBase.h"
 #include "BRRippleTransaction.h"
+#include "BRRippleAddress.h"
 
 typedef struct BRRippleTransferRecord *BRRippleTransfer;
 

--- a/ripple/BRRippleWallet.c
+++ b/ripple/BRRippleWallet.c
@@ -14,7 +14,9 @@
 #include "support/BRArray.h"
 #include "BRRipplePrivateStructs.h"
 #include "BRRippleFeeBasis.h"
+#include "BRRippleAddress.h"
 #include <stdio.h>
+
 //
 // Wallet
 //
@@ -97,11 +99,11 @@ static bool rippleTransferEqual(BRRippleTransfer t1, BRRippleTransfer t2) {
         // Hash is the same - compare the source
         BRRippleAddress source1 = rippleTransferGetSource(t1);
         BRRippleAddress source2 = rippleTransferGetSource(t2);
-        if (memcmp(source1.bytes, source2.bytes, sizeof(source1.bytes)) == 0) {
+        if (1 == rippleAddressEqual(source1, source2)) {
             // OK - compare the target
             BRRippleAddress target1 = rippleTransferGetTarget(t1);
             BRRippleAddress target2 = rippleTransferGetTarget(t2);
-            if (memcmp(target1.bytes, target2.bytes, sizeof(target1.bytes)) == 0) {
+            if (1 == rippleAddressEqual(target1, target2)) {
                 return true;
             }
         }
@@ -131,7 +133,7 @@ extern void rippleWalletAddTransfer(BRRippleWallet wallet, BRRippleTransfer tran
         BRRippleUnitDrops amount = rippleTransferGetAmount(transfer);
         BRRippleAddress accountAddress = rippleAccountGetAddress(wallet->account);
         BRRippleAddress source = rippleTransferGetSource(transfer);
-        if (memcmp(accountAddress.bytes, source.bytes, sizeof(accountAddress.bytes)) == 0) {
+        if (1 == rippleAddressEqual(accountAddress, source)) {
             wallet->balance = wallet->balance - amount;
         } else {
             wallet->balance = wallet->balance + amount;

--- a/ripple/BRRippleWallet.h
+++ b/ripple/BRRippleWallet.h
@@ -47,7 +47,7 @@ rippleWalletFree (BRRippleWallet wallet);
  *
  * @return address  ripple address associated with this account
  */
-extern BRRippleAddress
+extern BRRippleAddress // caller owns object, must free with rippleAddressFree
 rippleWalletGetSourceAddress (BRRippleWallet wallet);
 
 
@@ -60,7 +60,7 @@ rippleWalletGetSourceAddress (BRRippleWallet wallet);
  *
  * @return address  ripple address associated with this account
  */
-extern BRRippleAddress
+extern BRRippleAddress // caller owns object, must free with rippleAddressFree
 rippleWalletGetTargetAddress (BRRippleWallet wallet);
 
 /**


### PR DESCRIPTION
Added the BRRippleAddress files and functions
Modified the other classes to use address functions
Modified the unit test
**NOTE:** whenever BRRippleAddress objects are going "in" or "out" of one of our objects (wallet, transfer, etc) they are copied.  The caller always continues to own any BRRippleAddress they create or ask for so it is clear they must clean them up.
**NOTE:** did not change anything in the generic folder