### PR TITLE
CORE-624: Extend GEN architecture

### DIFF
--- a/crypto/BRCryptoPrivate.h
+++ b/crypto/BRCryptoPrivate.h
@@ -435,6 +435,12 @@ extern "C" {
     cryptoWalletManagerHandleTransferGEN (BRCryptoWalletManager cwm,
                                           BRGenericTransfer transferGeneric);
 
+    private_extern void
+    cryptoWalletManagerSetTransferStateGEN (BRCryptoWalletManager cwm,
+                                            BRCryptoWallet wallet,
+                                            BRCryptoTransfer transfer,
+                                            BRGenericTransferState newGenericState);
+
     // TODO:  Used in crytoWallet estimate fee (actually no - don't hold `CWM` there....
     extern void
     cryptoWalletManagerSignalWalletEvent (BRCryptoWalletManager cwm,

--- a/crypto/BRCryptoTransfer.c
+++ b/crypto/BRCryptoTransfer.c
@@ -675,7 +675,9 @@ cryptoTransferHasETH (BRCryptoTransfer transfer,
 private_extern BRCryptoBoolean
 cryptoTransferHasGEN (BRCryptoTransfer transfer,
                       BRGenericTransfer gen) {
-    return AS_CRYPTO_BOOLEAN (BLOCK_CHAIN_TYPE_GEN == transfer->type && gen == transfer->u.gen);
+    return AS_CRYPTO_BOOLEAN (BLOCK_CHAIN_TYPE_GEN == transfer->type &&
+                              genericHashEqual (genTransferGetHash(gen),
+                                                genTransferGetHash(transfer->u.gen)));
 }
 
 static int
@@ -690,7 +692,8 @@ cryptoTransferEqualAsETH (BRCryptoTransfer t1, BRCryptoTransfer t2) {
 
 static int
 cryptoTransferEqualAsGEN (BRCryptoTransfer t1, BRCryptoTransfer t2) {
-    return (t1->u.gen == t2->u.gen);
+    return genericHashEqual (genTransferGetHash(t1->u.gen),
+                             genTransferGetHash(t2->u.gen));
 }
 
 extern BRCryptoBoolean

--- a/crypto/BRCryptoTransfer.c
+++ b/crypto/BRCryptoTransfer.c
@@ -529,7 +529,7 @@ cryptoTransferGetDirection (BRCryptoTransfer transfer) {
 
         case BLOCK_CHAIN_TYPE_GEN:
             switch (genTransferGetDirection (transfer->u.gen)) {
-                case GENERiC_TRANSFER_SENT:      return CRYPTO_TRANSFER_SENT;
+                case GENERIC_TRANSFER_SENT:      return CRYPTO_TRANSFER_SENT;
                 case GENERIC_TRANSFER_RECEIVED:  return CRYPTO_TRANSFER_RECEIVED;
                 case GENERIC_TRANSFER_RECOVERED: return CRYPTO_TRANSFER_RECOVERED;
             }

--- a/crypto/BRCryptoWalletManagerClient.c
+++ b/crypto/BRCryptoWalletManagerClient.c
@@ -2018,9 +2018,12 @@ cwmAnnounceGetTransactionsItemGEN (BRCryptoWalletManager cwm,
     //
     // genManagerAnnounceTransfer (cwm->u.gen, callbackState->rid, transfer);
     if (transfers != NULL) {
+        pthread_mutex_lock (&cwm->lock);
         for (size_t index = 0; index < array_count (transfers); index++) {
             cryptoWalletManagerHandleTransferGEN (cwm, transfers[index]);
         }
+        pthread_mutex_unlock (&cwm->lock);
+
         // The wallet manager takes ownership of the actual transfers - so just
         // delete the array of pointers
         array_free(transfers);

--- a/crypto/BRCryptoWalletManagerClient.c
+++ b/crypto/BRCryptoWalletManagerClient.c
@@ -2008,7 +2008,10 @@ cwmAnnounceGetTransactionsItemGEN (BRCryptoWalletManager cwm,
     cwm = cryptoWalletManagerTake (cwm);
 
     // Fundamentally, the `transfer` must allow for determining the `wallet`
-    BRArrayOf(BRGenericTransfer) transfers = genManagerRecoverTransfersFromRawTransaction (cwm->u.gen, transaction, transactionLength);
+    BRArrayOf(BRGenericTransfer) transfers = genManagerRecoverTransfersFromRawTransaction (cwm->u.gen,
+                                                                                           transaction, transactionLength,
+                                                                                           timestamp,
+                                                                                           blockHeight);
     // Announce to GWM.  Note: the equivalent BTC+ETH announce transaction is going to
     // create BTC+ETH wallet manager + wallet + transfer events that we'll handle by incorporating
     // the BTC+ETH transfer into 'crypto'.  However, GEN does not generate similar events.
@@ -2120,6 +2123,33 @@ cwmAnnounceGetTransfersComplete (OwnershipKept BRCryptoWalletManager cwm,
     free (callbackState);
 }
 
+static void
+cwmAnnounceSubmitTransferResultGEN (OwnershipKept BRCryptoWalletManager cwm,
+                                    OwnershipKept BRCryptoCWMClientCallbackState callbackState,
+                                    int error) {
+    assert (cwm); assert(callbackState);
+    assert (CWM_CALLBACK_TYPE_GEN_SUBMIT_TRANSACTION == callbackState->type);
+    // Assume cwm taken already;
+
+    genManagerAnnounceSubmit (cwm->u.gen,
+                              callbackState->rid,
+                              callbackState->u.genWithTransaction.tid,
+                              error);
+
+    BRCryptoWallet   wallet   = cryptoWalletManagerFindWalletAsGEN (cwm, callbackState->u.genWithTransaction.wid);
+    BRCryptoTransfer transfer = (NULL == wallet ? NULL : cryptoWalletFindTransferAsGEN (wallet, callbackState->u.genWithTransaction.tid));
+
+    // TODO: Assert on these?
+    if (NULL != wallet && NULL != transfer) {
+        cryptoWalletManagerSetTransferStateGEN (cwm,
+                                                wallet,
+                                                transfer,
+                                                (error
+                                                 ? genTransferStateCreateErrored (GENERIC_TRANSFER_SUBMIT_ERROR_ONE)
+                                                 : genTransferStateCreateOther (GENERIC_TRANSFER_STATE_SUBMITTED)));
+    }
+}
+
 extern void
 cwmAnnounceSubmitTransferSuccess (OwnershipKept BRCryptoWalletManager cwm,
                                   OwnershipGiven BRCryptoCWMClientCallbackState callbackState) {
@@ -2136,10 +2166,7 @@ cwmAnnounceSubmitTransferSuccess (OwnershipKept BRCryptoWalletManager cwm,
     }
 
     else if (CWM_CALLBACK_TYPE_GEN_SUBMIT_TRANSACTION == callbackState->type && BLOCK_CHAIN_TYPE_GEN == cwm->type) {
-        genManagerAnnounceSubmit (cwm->u.gen,
-                                  callbackState->rid,
-                                  callbackState->u.genWithTransaction.tid,
-                                  0);
+        cwmAnnounceSubmitTransferResultGEN (cwm, callbackState, 0);
     }
 
     cryptoWalletManagerGive (cwm);
@@ -2193,11 +2220,7 @@ cwmAnnounceSubmitTransferFailure (OwnershipKept BRCryptoWalletManager cwm,
                                    callbackState->rid);
 
     } else if (CWM_CALLBACK_TYPE_GEN_SUBMIT_TRANSACTION == callbackState->type && BLOCK_CHAIN_TYPE_GEN == cwm->type) {
-        genManagerAnnounceSubmit (cwm->u.gen,
-                                  callbackState->rid,
-                                  callbackState->u.genWithTransaction.tid,
-                                  EIO);
-
+        cwmAnnounceSubmitTransferResultGEN (cwm, callbackState, EIO);
     } else {
         assert (0);
     }

--- a/crypto/BRCryptoWalletManagerClient.c
+++ b/crypto/BRCryptoWalletManagerClient.c
@@ -2151,6 +2151,9 @@ cwmAnnounceSubmitTransferResultGEN (OwnershipKept BRCryptoWalletManager cwm,
                                                  ? genTransferStateCreateErrored (GENERIC_TRANSFER_SUBMIT_ERROR_ONE)
                                                  : genTransferStateCreateOther (GENERIC_TRANSFER_STATE_SUBMITTED)));
     }
+
+    if (NULL != wallet)   cryptoWalletGive(wallet);
+    if (NULL != transfer) cryptoTransferGive(transfer);
 }
 
 extern void

--- a/generic/BRGeneric.c
+++ b/generic/BRGeneric.c
@@ -220,6 +220,12 @@ genWalletGetAddress (BRGenericWallet wid) {
     return NULL;
 }
 
+extern int
+genWalletHasAddress (BRGenericWallet wallet,
+                     BRGenericAddress address) {
+    return wallet->handlers.hasAddress (wallet->ref, address->ref);
+}
+
 extern BRGenericFeeBasis
 genWalletGetDefaultFeeBasis (BRGenericWallet wid) {
     return wid->defaultFeeBasis;

--- a/generic/BRGeneric.c
+++ b/generic/BRGeneric.c
@@ -170,7 +170,8 @@ genTransferGetFeeBasis (BRGenericTransfer transfer) {
 
 extern BRGenericTransferDirection
 genTransferGetDirection (BRGenericTransfer transfer) {
-    return transfer->handlers.direction (transfer->ref);
+//    return transfer->direction;
+    return GENERIC_TRANSFER_SENT;
 }
 
 extern BRGenericHash

--- a/generic/BRGeneric.c
+++ b/generic/BRGeneric.c
@@ -131,7 +131,17 @@ genAddressRelease (BRGenericAddress address) {
 
 // MARK: - Transfer
 
-IMPLEMENT_GENERIC_TYPE(Transfer, transfer)
+private_extern BRGenericTransfer
+genTransferAllocAndInit (const char *type,
+                         BRGenericTransferRef ref) {
+    BRGenericTransfer transfer = calloc (1, sizeof (struct BRGenericTransferRecord));
+    transfer->type = type;
+    transfer->handlers = genHandlerLookup (type)->transfer;
+    transfer->ref = ref;
+    transfer->state = genTransferStateCreateOther (GENERIC_TRANSFER_STATE_CREATED);
+    transfer->direction = GENERIC_TRANSFER_RECOVERED;
+    return transfer;
+}
 
 extern void
 genTransferRelease (BRGenericTransfer transfer) {
@@ -170,13 +180,23 @@ genTransferGetFeeBasis (BRGenericTransfer transfer) {
 
 extern BRGenericTransferDirection
 genTransferGetDirection (BRGenericTransfer transfer) {
-//    return transfer->direction;
-    return GENERIC_TRANSFER_SENT;
+    return transfer->direction;
 }
 
 extern BRGenericHash
 genTransferGetHash (BRGenericTransfer transfer) {
     return transfer->handlers.hash (transfer->ref);
+}
+
+extern BRGenericTransferState
+genTransferGetState (BRGenericTransfer transfer) {
+    return transfer->state;
+}
+
+extern void
+genTransferSetState (BRGenericTransfer transfer,
+                     BRGenericTransferState state) {
+    transfer->state = state;
 }
 
 extern uint8_t *
@@ -243,11 +263,21 @@ genWalletCreateTransfer (BRGenericWallet wallet,
                          BRGenericAddress target, // TODO: BRGenericAddress - ownership given
                          UInt256 amount,
                          BRGenericFeeBasis estimatedFeeBasis) {
-    return genTransferAllocAndInit (wallet->type,
-                                    wallet->handlers.createTransfer (wallet->ref,
-                                                                     target->ref,
-                                                                     amount,
-                                                                     estimatedFeeBasis));
+    BRGenericTransfer transfer = genTransferAllocAndInit (wallet->type,
+                                                          wallet->handlers.createTransfer (wallet->ref,
+                                                                                           target->ref,
+                                                                                           amount,
+                                                                                           estimatedFeeBasis));
+    int isSource = 1;
+    int isTarget = genWalletHasAddress (wallet, target);
+
+    transfer->direction = (isSource && isTarget
+                           ? GENERIC_TRANSFER_RECOVERED
+                           : (isSource
+                              ? GENERIC_TRANSFER_SENT
+                              : GENERIC_TRANSFER_RECEIVED));
+
+    return transfer;
 }
 
 extern UInt256

--- a/generic/BRGeneric.h
+++ b/generic/BRGeneric.h
@@ -137,6 +137,10 @@ extern "C" {
     extern BRGenericAddress
     genWalletGetAddress (BRGenericWallet wid);
 
+    extern int
+    genWalletHasAddress (BRGenericWallet wallet,
+                         BRGenericAddress address);
+
     extern BRGenericFeeBasis
     genWalletGetDefaultFeeBasis (BRGenericWallet wid);
 

--- a/generic/BRGeneric.h
+++ b/generic/BRGeneric.h
@@ -115,6 +115,13 @@ extern "C" {
     extern BRGenericHash
     genTransferGetHash (BRGenericTransfer transfer);
 
+    extern BRGenericTransferState
+    genTransferGetState (BRGenericTransfer transfer);
+
+    extern void
+    genTransferSetState (BRGenericTransfer transfer,
+                         BRGenericTransferState state);
+
     extern uint8_t *
     genTransferSerialize (BRGenericTransfer transfer, size_t *bytesCount);
 
@@ -225,7 +232,9 @@ extern "C" {
     extern BRArrayOf(BRGenericTransfer)
     genManagerRecoverTransfersFromRawTransaction (BRGenericManager gwm,
                                                   uint8_t *bytes,
-                                                  size_t   bytesCount);
+                                                  size_t   bytesCount,
+                                                  uint64_t timestamp,
+                                                  uint64_t blockHeight);
 
     extern int
     genManagerSignTransfer (BRGenericManager gwm,

--- a/generic/BRGenericBase.h
+++ b/generic/BRGenericBase.h
@@ -103,7 +103,7 @@ extern "C" {
 
     // MARK: Generic Transfer Direction
     typedef enum {
-        GENERiC_TRANSFER_SENT,
+        GENERIC_TRANSFER_SENT,
         GENERIC_TRANSFER_RECEIVED,
         GENERIC_TRANSFER_RECOVERED
     } BRGenericTransferDirection;

--- a/generic/BRGenericHandlers.h
+++ b/generic/BRGenericHandlers.h
@@ -109,6 +109,9 @@ extern "C" {
     typedef BRGenericWalletRef (*BRGenericWalletCreate) (BRGenericAccountRef account);
     typedef void (*BRGenericWalletFree) (BRGenericWalletRef wallet);
     typedef UInt256 (*BRGenericWalletGetBalance) (BRGenericWalletRef wallet);
+    typedef int (*BRGenericWalletHasAddress) (BRGenericWalletRef wallet,
+                                              BRGenericAddressRef address);
+
     // Unneeded?
     typedef BRGenericTransferRef (*BRGenericWalletCreateTransfer) (BRGenericWalletRef wallet,
                                                                    BRGenericAddressRef target,
@@ -124,6 +127,7 @@ extern "C" {
         BRGenericWalletFree free;
         BRGenericWalletGetBalance balance;
         // set balance
+        BRGenericWalletHasAddress hasAddress;
         // ...
         BRGenericWalletCreateTransfer createTransfer; // Unneeded.
         BRGenericWalletEstimateFeeBasis estimateFeeBasis;

--- a/generic/BRGenericHandlers.h
+++ b/generic/BRGenericHandlers.h
@@ -87,7 +87,6 @@ extern "C" {
     typedef UInt256 (*BRGenericTransferGetAmount) (BRGenericTransferRef transfer);
     typedef UInt256 (*BRGenericTransferGetFee) (BRGenericTransferRef transfer);
     typedef BRGenericFeeBasis (*BRGenericTransferGetFeeBasis) (BRGenericTransferRef transfer);
-    typedef BRGenericTransferDirection (*BRGenericTransferGetDirection) (BRGenericTransferRef transfer);
     typedef BRGenericHash (*BRGenericTransferGetHash) (BRGenericTransferRef transfer);
     typedef uint8_t * (*BRGenericTransferGetSerialization) (BRGenericTransferRef transfer, size_t *bytesCount);
 
@@ -99,7 +98,6 @@ extern "C" {
         BRGenericTransferGetAmount amount;
         BRGenericTransferGetFee fee;
         BRGenericTransferGetFeeBasis feeBasis;
-        BRGenericTransferGetDirection direction;
         BRGenericTransferGetHash hash;
         BRGenericTransferGetSerialization getSerialization;
     } BRGenericTransferHandlers;

--- a/generic/BRGenericManager.c
+++ b/generic/BRGenericManager.c
@@ -284,6 +284,7 @@ genManagerRecoverTransfersFromRawTransaction (BRGenericManager gwm,
                                               size_t   bytesCount,
                                               uint64_t timestamp,
                                               uint64_t blockHeight) {
+    pthread_mutex_lock (&gwm->lock);
     BRArrayOf(BRGenericTransferRef) refs = gwm->handlers->manager.transfersRecoverFromRawTransaction (bytes, bytesCount);
     BRArrayOf(BRGenericTransfer) objs;
     array_new (objs, array_count(refs));
@@ -296,11 +297,13 @@ genManagerRecoverTransfersFromRawTransaction (BRGenericManager gwm,
                                                              GENERIC_TRANSFER_FEE_UNKNOWN));
         array_add (objs, obj);
     }
+    pthread_mutex_unlock (&gwm->lock);
     return objs;
 }
 
 extern BRArrayOf(BRGenericTransfer)
 genManagerLoadTransfers (BRGenericManager gwm) {
+    pthread_mutex_lock (&gwm->lock);
     BRArrayOf(BRGenericTransferRef) refs = gwm->handlers->manager.fileServiceLoadTransfers (gwm, gwm->fileService);
     BRArrayOf(BRGenericTransfer) objs;
     array_new (objs, array_count(refs));
@@ -308,6 +311,7 @@ genManagerLoadTransfers (BRGenericManager gwm) {
         BRGenericTransfer obj = genTransferAllocAndInit (gwm->handlers->type, refs[index]);
         array_add (objs, obj);
     }
+    pthread_mutex_unlock (&gwm->lock);
     return objs;
 
 }

--- a/generic/BRGenericPrivate.h
+++ b/generic/BRGenericPrivate.h
@@ -46,7 +46,18 @@ DECLARE_GENERIC_TYPE(Account)
 
 DECLARE_GENERIC_TYPE(Address)
 
-DECLARE_GENERIC_TYPE(Transfer)
+struct BRGenericTransferRecord {
+    const char *type;
+    BRGenericTransferHandlers handlers;
+    BRGenericTransferRef ref;
+    BRGenericTransferState state;
+    BRGenericTransferDirection direction;
+};
+
+private_extern BRGenericTransfer
+genTransferAllocAndInit (const char *type,
+                         BRGenericTransferRef ref);
+
 
 struct BRGenericWalletRecord {
     const char *type;

--- a/generic/BRGenericRipple.c
+++ b/generic/BRGenericRipple.c
@@ -370,7 +370,6 @@ struct BRGenericHandersRecord genericRippleHandlersRecord = {
         genericRippleTransferGetAmount,
         genericRippleTransferGetFee,
         genericRippleTransferGetFeeBasis,
-        NULL,
         genericRippleTransferGetHash,
         genericRippleTransferGetSerialization,
     },

--- a/generic/BRGenericRipple.c
+++ b/generic/BRGenericRipple.c
@@ -191,6 +191,13 @@ genericRippleWalletGetBalance (BRGenericWalletRef wallet) {
     return createUInt256 (rippleWalletGetBalance ((BRRippleWallet) wallet));
 }
 
+static int
+genericRippleWalletHasAddress (BRGenericWalletRef wallet,
+                               BRGenericAddressRef address) {
+    return rippleWalletHasAddress ((BRRippleWallet) wallet,
+                                   (BRRippleAddress) address);
+}
+
 static BRGenericTransferRef
 genericRippleWalletCreateTransfer (BRGenericWalletRef wallet,
                                    BRGenericAddressRef target,
@@ -372,6 +379,7 @@ struct BRGenericHandersRecord genericRippleHandlersRecord = {
         genericRippleWalletCreate,
         genericRippleWalletFree,
         genericRippleWalletGetBalance,
+        genericRippleWalletHasAddress,
         genericRippleWalletCreateTransfer,
         genericRippleWalletEstimateFeeBasis
     },

--- a/ripple/BRRippleAccount.c
+++ b/ripple/BRRippleAccount.c
@@ -157,6 +157,12 @@ extern BRRippleAddress rippleAccountGetAddress(BRRippleAccount account)
     return rippleAddressClone (account->address);
 }
 
+extern int
+rippleAccountHasAddress (BRRippleAccount account,
+                         BRRippleAddress address) {
+    return rippleAddressEqual (account->address, address);
+}
+
 extern uint8_t *rippleAccountGetSerialization (BRRippleAccount account, size_t *bytesCount) {
     assert (NULL != bytesCount);
     assert (NULL != account);

--- a/ripple/BRRippleAccount.h
+++ b/ripple/BRRippleAccount.h
@@ -108,6 +108,10 @@ rippleAccountSignTransaction(BRRippleAccount account, BRRippleTransaction transa
 extern BRRippleAddress
 rippleAccountGetAddress(BRRippleAccount account);
 
+extern int
+rippleAccountHasAddress (BRRippleAccount account,
+                         BRRippleAddress address);
+
 // Serialize `account`; return `bytes` and set `bytesCount`
 extern uint8_t * /* caller must free - using "free" function */
 rippleAccountGetSerialization (BRRippleAccount account, size_t *bytesCount);

--- a/ripple/BRRippleWallet.c
+++ b/ripple/BRRippleWallet.c
@@ -71,6 +71,12 @@ rippleWalletGetTargetAddress (BRRippleWallet wallet)
     return rippleAccountGetPrimaryAddress(wallet->account);
 }
 
+extern int
+rippleWalletHasAddress (BRRippleWallet wallet,
+                        BRRippleAddress address) {
+    return rippleAccountHasAddress (wallet->account, address);
+}
+
 extern BRRippleUnitDrops
 rippleWalletGetBalance (BRRippleWallet wallet)
 {

--- a/ripple/BRRippleWallet.h
+++ b/ripple/BRRippleWallet.h
@@ -63,6 +63,10 @@ rippleWalletGetSourceAddress (BRRippleWallet wallet);
 extern BRRippleAddress // caller owns object, must free with rippleAddressFree
 rippleWalletGetTargetAddress (BRRippleWallet wallet);
 
+extern int
+rippleWalletHasAddress (BRRippleWallet wallet,
+                        BRRippleAddress address);
+
 /**
  * Return the ripple balance for this wallet
  *


### PR DESCRIPTION
Add BRGenericTransferDirection.
Add genWalletHasAddress() to support genTransferGetDirection()

Add BRGenericTransferState.
When recovering a GEN Transfer use the 'timestamp + blockHeight' values to fill out the transfer's state.  Update the GEN Transfer state on 'signed' and 'submitted'.

Compare GEN transfers based on the hash; don't extend wallet transfers unless the GEN hashes differ.

Add some ripple function for 'HasAddress'