### PR TITLE
CORE-700: Add unit tests to hedera

### DIFF
--- a/hedera/BRHederaAccount.h
+++ b/hedera/BRHederaAccount.h
@@ -85,17 +85,6 @@ extern BRHederaAddress hederaAccountGetAddress (BRHederaAccount account);
  */
 extern BRHederaAddress hederaAccountGetPrimaryAddress (BRHederaAccount account);
 
-/**
- * Check if 2 Hedera addresses are equal
- *
- * @param address   - first address
- * @param address   - second address
- *
- * @return 1 if equal, 0 if not equal
- */
-extern int // 1 if equal
-hederaAddressEqual (BRHederaAddress a1, BRHederaAddress a2);
-
 extern uint8_t * // Caller owns memory and must delete calling "free"
 hederaAccountGetSerialization (BRHederaAccount account, size_t *bytesCount);
 

--- a/hedera/BRHederaTransaction.c
+++ b/hedera/BRHederaTransaction.c
@@ -84,6 +84,8 @@ hederaTransactionSignTransaction (BRHederaTransaction transaction,
         transaction->serializedSize = 0;
     }
 
+    transaction->fee = fee;
+
     // Generate the private key from the seed
     BRKey key = hederaKeyCreate (seed);
     unsigned char privateKey[64] = {0};


### PR DESCRIPTION
Add several unit tests to the BRHederaAddress code
as well as making the address code a bit more
robust with respect to parsing a string address.

1. Fix up any code related to the unit tests
2. Add some additional comments
3. Remove duplicate function declaration