### PR TITLE
CORE-699: Add cryptoTransferGetAmountDirectedNet

### DIFF
--- a/crypto/BRCryptoTransfer.c
+++ b/crypto/BRCryptoTransfer.c
@@ -393,6 +393,33 @@ cryptoTransferGetAmountDirected (BRCryptoTransfer transfer) {
     return amount;
 }
 
+extern BRCryptoAmount
+cryptoTransferGetAmountDirectedNet (BRCryptoTransfer transfer) {
+    BRCryptoAmount amount = cryptoTransferGetAmountDirected (transfer);
+
+    // If the transfer->unit and transfer->unitForFee differ then there is no fee
+    if (cryptoUnitIsIdentical (transfer->unit, transfer->unitForFee))
+        return amount;
+
+    BRCryptoFeeBasis feeBasis = (NULL != transfer->feeBasisConfirmed
+                                 ? transfer->feeBasisConfirmed
+                                 : transfer->feeBasisEstimated);
+
+    // If there is no fee basis, then there is no fee
+    if (NULL == feeBasis)
+        return amount;
+
+    BRCryptoAmount fee       = cryptoFeeBasisGetFee (feeBasis);
+
+    // Simply subtract off the fee.
+    BRCryptoAmount amountNet = cryptoAmountSub (amount, fee);
+
+    cryptoAmountGive(fee);
+    cryptoAmountGive(amount);
+
+    return amountNet;
+}
+
 extern BRCryptoUnit
 cryptoTransferGetUnitForAmount (BRCryptoTransfer transfer) {
     return cryptoUnitTake (transfer->unit);

--- a/crypto/BRCryptoTransfer.h
+++ b/crypto/BRCryptoTransfer.h
@@ -140,6 +140,16 @@ extern "C" {
     cryptoTransferGetAmountDirected (BRCryptoTransfer transfer);
 
     /**
+     * Returns the transfers amount after considering the direction and fee
+     *
+     * @param transfer the transfer
+     *
+     * @return the signed, net amoount
+     */
+    extern BRCryptoAmount
+    cryptoTransferGetAmountDirectedNet (BRCryptoTransfer transfer);
+
+    /**
      * Returns the transfer's fee.  Note that the `fee` and the `amount` may be in different
      * currencies.
      *

--- a/crypto/BRCryptoWallet.c
+++ b/crypto/BRCryptoWallet.c
@@ -188,7 +188,7 @@ static BRCryptoAmount cryptoWalletGenerateBalance(BRCryptoWallet wallet) {
     BRCryptoAmount total = cryptoAmountCreateInteger(0, wallet->unit);
     for (size_t index = 0; index < array_count(wallet->transfers); index++) {
         BRCryptoTransfer transfer = wallet->transfers[index];
-        BRCryptoAmount amountDirected = cryptoTransferGetAmountDirected(transfer);
+        BRCryptoAmount amountDirected = cryptoTransferGetAmountDirectedNet(transfer);
         BRCryptoAmount nextTotal = cryptoAmountAdd(total, amountDirected);
         cryptoAmountGive(amountDirected);
         cryptoAmountGive(total);


### PR DESCRIPTION
Implement `cryptoWalletGenerateBalance()` - used exclusively for a GEN wallet’s balance - with `cryptoTransferGetAmountDirectedNet()`.