### PR TITLE
CORE-539: SystemCallbackCoordinator need not be public

### DIFF
--- a/Swift/BRCrypto/BRCryptoSystem.swift
+++ b/Swift/BRCrypto/BRCryptoSystem.swift
@@ -1062,7 +1062,7 @@ public typealias SystemEventHandler = (System, SystemEvent) -> Void
 ///
 /// A SystemCallbackCoordinator coordinates callbacks for non-event based announcement interfaces.
 ///
-public final class SystemCallbackCoordinator {
+internal final class SystemCallbackCoordinator {
     enum Handler {
         case walletFeeEstimate (Wallet.EstimateFeeHandler)
     }


### PR DESCRIPTION
Confirmed that IOS does not touch SystemCallbackCoordinator.