### PR TITLE
CORE-715: Update BlockChainDB Subscription JSON types

### DIFF
--- a/Java/CoreCrypto/src/androidTest/java/com/breadwallet/corecrypto/HelpersAIT.java
+++ b/Java/CoreCrypto/src/androidTest/java/com/breadwallet/corecrypto/HelpersAIT.java
@@ -176,10 +176,11 @@ class HelpersAIT {
     /* package */
     static final OkHttpClient DEFAULT_HTTP_CLIENT = new OkHttpClient();
 
-    private static String DEFAULT_TOKEN = "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzUxMiJ9." +
-            "eyJzdWIiOiJkZWI2M2UyOC0wMzQ1LTQ4ZjYtOWQxNy1jZTgwY2JkNjE3Y2IiLCJicmQ" +
-            "6Y3QiOiJjbGkiLCJleHAiOjkyMjMzNzIwMzY4NTQ3NzUsImlhdCI6MTU2Njg2MzY0OX0." +
-            "FvLLDUSk1p7iFLJfg2kA-vwhDWTDulVjdj8YpFgnlE62OBFCYt4b3KeTND_qAhLynLKbGJ1UDpMMihsxtfvA0A";
+    private static String DEFAULT_TOKEN = "eyJhbGciOiJFUzI1NiIsInR5cCI6IkpXVCJ9." +
+            "eyJzdWIiOiJjNzQ5NTA2ZS02MWUzLTRjM2UtYWNiNS00OTY5NTM2ZmRhMTAiLCJpYXQiOjE1N" +
+            "zI1NDY1MDAuODg3LCJleHAiOjE4ODAxMzA1MDAuODg3LCJicmQ6Y3QiOiJ1c3IiLCJicmQ6Y2" +
+            "xpIjoiZGViNjNlMjgtMDM0NS00OGY2LTlkMTctY2U4MGNiZDYxN2NiIn0." +
+            "460_GdAWbONxqOhWL5TEbQ7uEZi3fSNrl0E_Zg7MAg570CVcgO7rSMJvAPwaQtvIx1XFK_QZjcoNULmB8EtOdg";
 
     /* package */
     static BlockchainDb createDefaultBlockchainDbWithToken() {

--- a/Java/Crypto/src/main/java/com/breadwallet/crypto/blockchaindb/BlockchainDb.java
+++ b/Java/Crypto/src/main/java/com/breadwallet/crypto/blockchaindb/BlockchainDb.java
@@ -28,6 +28,8 @@ import com.breadwallet.crypto.blockchaindb.models.bdb.Block;
 import com.breadwallet.crypto.blockchaindb.models.bdb.Blockchain;
 import com.breadwallet.crypto.blockchaindb.models.bdb.Currency;
 import com.breadwallet.crypto.blockchaindb.models.bdb.Subscription;
+import com.breadwallet.crypto.blockchaindb.models.bdb.SubscriptionCurrency;
+import com.breadwallet.crypto.blockchaindb.models.bdb.SubscriptionEndpoint;
 import com.breadwallet.crypto.blockchaindb.models.bdb.Transaction;
 import com.breadwallet.crypto.blockchaindb.models.bdb.Transfer;
 import com.breadwallet.crypto.blockchaindb.models.brd.EthLog;
@@ -162,15 +164,20 @@ public class BlockchainDb {
         subscriptionApi.getSubscription(id, handler);
     }
 
-    public void createSubscription(Subscription subscription, CompletionHandler<Subscription, QueryError> handler) {
-        subscriptionApi.createSubscription(subscription, handler);
+    public void getSubscriptions(CompletionHandler<List<Subscription>, QueryError> handler) {
+        subscriptionApi.getSubscriptions(handler);
+    }
+
+    public void createSubscription(String deviceId, SubscriptionEndpoint endpoint, List<SubscriptionCurrency> currencies,
+                                   CompletionHandler<Subscription, QueryError> handler) {
+        subscriptionApi.createSubscription(deviceId, endpoint, currencies, handler);
     }
 
     public void updateSubscription(Subscription subscription, CompletionHandler<Subscription, QueryError> handler) {
         subscriptionApi.updateSubscription(subscription, handler);
     }
 
-    public void deleteSubscription(String id, CompletionHandler<Subscription, QueryError> handler) {
+    public void deleteSubscription(String id, CompletionHandler<Void, QueryError> handler) {
         subscriptionApi.deleteSubscription(id, handler);
     }
 

--- a/Java/Crypto/src/main/java/com/breadwallet/crypto/blockchaindb/apis/bdb/BdbApiClient.java
+++ b/Java/Crypto/src/main/java/com/breadwallet/crypto/blockchaindb/apis/bdb/BdbApiClient.java
@@ -167,15 +167,14 @@ public class BdbApiClient {
     // Delete (crdD)
 
     /* package */
-    <T> void sendDeleteWithId(String resource, String id, Multimap<String, String> params,
-                              ObjectResponseParser<T> parser,
-                              CompletionHandler<T, QueryError> handler) {
+    void sendDeleteWithId(String resource, String id, Multimap<String, String> params,
+                          CompletionHandler<Void, QueryError> handler) {
         makeAndSendRequest(
                 Arrays.asList(resource, id),
                 params,
                 null,
                 "DELETE",
-                new RootObjectResponseHandler<>(parser, handler));
+                new EmptyResponseHandler(handler));
     }
 
     private <T> void makeAndSendRequest(String url,

--- a/Java/Crypto/src/main/java/com/breadwallet/crypto/blockchaindb/apis/bdb/SubscriptionApi.java
+++ b/Java/Crypto/src/main/java/com/breadwallet/crypto/blockchaindb/apis/bdb/SubscriptionApi.java
@@ -9,8 +9,12 @@ package com.breadwallet.crypto.blockchaindb.apis.bdb;
 
 import com.breadwallet.crypto.blockchaindb.errors.QueryError;
 import com.breadwallet.crypto.blockchaindb.models.bdb.Subscription;
+import com.breadwallet.crypto.blockchaindb.models.bdb.SubscriptionCurrency;
+import com.breadwallet.crypto.blockchaindb.models.bdb.SubscriptionEndpoint;
 import com.breadwallet.crypto.utility.CompletionHandler;
 import com.google.common.collect.ImmutableMultimap;
+
+import java.util.List;
 
 public class SubscriptionApi {
 
@@ -29,13 +33,14 @@ public class SubscriptionApi {
 
             @Override
             public void handleError(QueryError error) {
-                createSubscription(subscription, handler);
+                createSubscription(subscription.getDevice(), subscription.getEndpoint(), subscription.getCurrencies(), handler);
             }
         });
     }
 
-    public void createSubscription(Subscription subscription, CompletionHandler<Subscription, QueryError> handler) {
-        jsonClient.sendPost("subscriptions", ImmutableMultimap.of(), Subscription.asJson(subscription),
+    public void createSubscription(String deviceId, SubscriptionEndpoint endpoint, List<SubscriptionCurrency> currencies,
+                                   CompletionHandler<Subscription, QueryError> handler) {
+        jsonClient.sendPost("subscriptions", ImmutableMultimap.of(), Subscription.asJson(deviceId, endpoint, currencies),
                 Subscription::asSubscription, handler);
     }
 
@@ -43,12 +48,16 @@ public class SubscriptionApi {
         jsonClient.sendGetWithId("subscriptions", id, ImmutableMultimap.of(), Subscription::asSubscription, handler);
     }
 
+    public void getSubscriptions(CompletionHandler<List<Subscription>, QueryError> handler) {
+        jsonClient.sendGetForArray("subscriptions", ImmutableMultimap.of(), Subscription::asSubscriptions, handler);
+    }
+
     public void updateSubscription(Subscription subscription, CompletionHandler<Subscription, QueryError> handler) {
         jsonClient.sendPutWithId("subscriptions", subscription.getId(), ImmutableMultimap.of(),
                 Subscription.asJson(subscription), Subscription::asSubscription, handler);
     }
 
-    public void deleteSubscription(String id, CompletionHandler<Subscription, QueryError> handler) {
-        jsonClient.sendDeleteWithId("subscriptions", id, ImmutableMultimap.of(), Subscription::asSubscription, handler);
+    public void deleteSubscription(String id, CompletionHandler<Void, QueryError> handler) {
+        jsonClient.sendDeleteWithId("subscriptions", id, ImmutableMultimap.of(), handler);
     }
 }

--- a/Java/Crypto/src/main/java/com/breadwallet/crypto/blockchaindb/models/bdb/Subscription.java
+++ b/Java/Crypto/src/main/java/com/breadwallet/crypto/blockchaindb/models/bdb/Subscription.java
@@ -10,8 +10,12 @@ package com.breadwallet.crypto.blockchaindb.models.bdb;
 import com.google.common.base.Optional;
 import com.google.common.collect.ImmutableMap;
 
+import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
+
+import java.util.ArrayList;
+import java.util.List;
 
 public class Subscription {
 
@@ -25,29 +29,63 @@ public class Subscription {
             if (!optionalEndpoint.isPresent()) return Optional.absent();
             SubscriptionEndpoint endpoint= optionalEndpoint.get();
 
-            return Optional.of(new Subscription(id, device, endpoint));
+            JSONArray jsonCurrencies = json.getJSONArray("currencies");
+            Optional<List<SubscriptionCurrency>> optionalCurrencies = SubscriptionCurrency.asSubscriptionCurrencies(jsonCurrencies);
+            if (!optionalCurrencies.isPresent()) return Optional.absent();
+            List<SubscriptionCurrency> currencies = optionalCurrencies.get();
+
+            return Optional.of(new Subscription(id, device, endpoint, currencies));
 
         } catch (JSONException e) {
             return Optional.absent();
         }
     }
 
+    public static Optional<List<Subscription>> asSubscriptions(JSONArray json){
+        List<Subscription> subscriptions = new ArrayList<>();
+        for (int i = 0; i < json.length(); i++) {
+            JSONObject subscriptionObject = json.optJSONObject(i);
+            if (subscriptionObject == null) {
+                return Optional.absent();
+            }
+
+            Optional<Subscription> optionalSubscriptionCurrency = asSubscription(subscriptionObject);
+            if (!optionalSubscriptionCurrency.isPresent()) {
+                return Optional.absent();
+            }
+
+            subscriptions.add(optionalSubscriptionCurrency.get());
+        }
+        return Optional.of(subscriptions);
+    }
+
     public static JSONObject asJson(Subscription subscription) {
         return new JSONObject(ImmutableMap.of(
                 "id", subscription.id,
                 "device_id", subscription.device,
-                "endpoint", SubscriptionEndpoint.asJson(subscription.endpoint)
+                "endpoint", SubscriptionEndpoint.asJson(subscription.endpoint),
+                "currencies", SubscriptionCurrency.asJson(subscription.currencies)
+        ));
+    }
+
+    public static JSONObject asJson(String deviceId, SubscriptionEndpoint endpoint, List<SubscriptionCurrency> currencies) {
+        return new JSONObject(ImmutableMap.of(
+                "device_id", deviceId,
+                "endpoint", SubscriptionEndpoint.asJson(endpoint),
+                "currencies", SubscriptionCurrency.asJson(currencies)
         ));
     }
 
     private final String id;
     private final String device;
     private final SubscriptionEndpoint endpoint;
+    private final List<SubscriptionCurrency> currencies;
 
-    public Subscription(String id, String device, SubscriptionEndpoint endpoint) {
+    public Subscription(String id, String device, SubscriptionEndpoint endpoint, List<SubscriptionCurrency> currencies) {
         this.id = id;
         this.device = device;
         this.endpoint = endpoint;
+        this.currencies = currencies;
     }
 
     public String getId() {
@@ -60,5 +98,9 @@ public class Subscription {
 
     public SubscriptionEndpoint getEndpoint() {
         return endpoint;
+    }
+
+    public List<SubscriptionCurrency> getCurrencies() {
+        return currencies;
     }
 }

--- a/Java/Crypto/src/main/java/com/breadwallet/crypto/blockchaindb/models/bdb/SubscriptionCurrency.java
+++ b/Java/Crypto/src/main/java/com/breadwallet/crypto/blockchaindb/models/bdb/SubscriptionCurrency.java
@@ -1,0 +1,99 @@
+/*
+ * Created by Michael Carrara <michael.carrara@breadwallet.com> on 11/1/19.
+ * Copyright (c) 2019 Breadwinner AG.  All right reserved.
+*
+ * See the LICENSE file at the project root for license information.
+ * See the CONTRIBUTORS file at the project root for a list of contributors.
+ */
+package com.breadwallet.crypto.blockchaindb.models.bdb;
+
+import com.google.common.base.Optional;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.primitives.UnsignedInteger;
+
+import org.json.JSONArray;
+import org.json.JSONException;
+import org.json.JSONObject;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+public class SubscriptionCurrency {
+
+    public static Optional<SubscriptionCurrency> asSubscriptionCurrency(JSONObject json) {
+        try {
+            String currency_id = json.getString("currency_id");
+
+            JSONArray jsonAddresses = json.getJSONArray("addresses");
+            List<String> addresses = new ArrayList<>(jsonAddresses.length());
+            for (int i = 0; i < jsonAddresses.length(); i++) addresses.add(jsonAddresses.getString(i));
+
+            JSONArray jsonEvents = json.getJSONArray("events");
+            Optional<List<SubscriptionEvent>> optionalEvents = SubscriptionEvent.asSubscriptionEvents(jsonEvents);
+            if (!optionalEvents.isPresent()) return Optional.absent();
+            List<SubscriptionEvent> events = optionalEvents.get();
+
+            return Optional.of(new SubscriptionCurrency(currency_id, addresses, events));
+
+        } catch (JSONException e) {
+            return Optional.absent();
+        }
+    }
+
+    public static Optional<List<SubscriptionCurrency>> asSubscriptionCurrencies(JSONArray json){
+        List<SubscriptionCurrency> subscriptionCurrencies = new ArrayList<>();
+        for (int i = 0; i < json.length(); i++) {
+            JSONObject subscriptionCurrencyObject = json.optJSONObject(i);
+            if (subscriptionCurrencyObject == null) {
+                return Optional.absent();
+            }
+
+            Optional<SubscriptionCurrency> optionalSubscriptionCurrency = asSubscriptionCurrency(subscriptionCurrencyObject);
+            if (!optionalSubscriptionCurrency.isPresent()) {
+                return Optional.absent();
+            }
+
+            subscriptionCurrencies.add(optionalSubscriptionCurrency.get());
+        }
+        return Optional.of(subscriptionCurrencies);
+    }
+
+    public static JSONObject asJson(SubscriptionCurrency currency) {
+        return new JSONObject(ImmutableMap.of(
+                    "currency_id", currency.currencyId,
+                    "addresses", currency.addresses,
+                    "events", SubscriptionEvent.asJson(currency.events)
+            ));
+    }
+
+    public static JSONArray asJson(List<SubscriptionCurrency> currencies) {
+        JSONArray array = new JSONArray();
+        for (SubscriptionCurrency currency: currencies) {
+            array.put(asJson(currency));
+        }
+        return array;
+    }
+
+    private final String currencyId;
+    private final List<String> addresses;
+    private final List<SubscriptionEvent> events;
+
+    public SubscriptionCurrency(String currencyId, List<String> addresses, List<SubscriptionEvent> events) {
+        this.currencyId = currencyId;
+        this.addresses = addresses;
+        this.events = events;
+    }
+
+    public String getCurrencyId() {
+        return currencyId;
+    }
+
+    public List<String> getAddresses() {
+        return addresses;
+    }
+
+    public List<SubscriptionEvent> getEvents() {
+        return events;
+    }
+}

--- a/Java/Crypto/src/main/java/com/breadwallet/crypto/blockchaindb/models/bdb/SubscriptionEvent.java
+++ b/Java/Crypto/src/main/java/com/breadwallet/crypto/blockchaindb/models/bdb/SubscriptionEvent.java
@@ -1,0 +1,96 @@
+/*
+ * Created by Michael Carrara <michael.carrara@breadwallet.com> on 11/1/19.
+ * Copyright (c) 2019 Breadwinner AG.  All right reserved.
+*
+ * See the LICENSE file at the project root for license information.
+ * See the CONTRIBUTORS file at the project root for a list of contributors.
+ */
+package com.breadwallet.crypto.blockchaindb.models.bdb;
+
+import android.support.annotation.Nullable;
+
+import com.google.common.base.Optional;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.primitives.UnsignedInteger;
+
+import org.json.JSONArray;
+import org.json.JSONException;
+import org.json.JSONObject;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+public class SubscriptionEvent {
+
+    public static Optional<SubscriptionEvent> asSubscriptionEvent(JSONObject json) {
+        try {
+            String name = json.getString("name");
+
+            return Optional.of(new SubscriptionEvent(name, Collections.emptyList()));
+
+        } catch (JSONException e) {
+            return Optional.absent();
+        }
+    }
+
+    public static Optional<List<SubscriptionEvent>> asSubscriptionEvents(JSONArray json){
+        List<SubscriptionEvent> subscriptionEvents = new ArrayList<>();
+        for (int i = 0; i < json.length(); i++) {
+            JSONObject subscriptionEventObject = json.optJSONObject(i);
+            if (subscriptionEventObject == null) {
+                return Optional.absent();
+            }
+
+            Optional<SubscriptionEvent> optionalSubscriptionEvent = SubscriptionEvent.asSubscriptionEvent(subscriptionEventObject);
+            if (!optionalSubscriptionEvent.isPresent()) {
+                return Optional.absent();
+            }
+
+            subscriptionEvents.add(optionalSubscriptionEvent.get());
+        }
+        return Optional.of(subscriptionEvents);
+    }
+
+    public static JSONObject asJson(SubscriptionEvent event) {
+        switch (event.name) {
+            case "submitted":
+                return new JSONObject(ImmutableMap.of(
+                        "name", event.name
+                ));
+            case "confirmed":
+                List<Long> confirmations = new ArrayList<>(event.confirmations.size());
+                for (UnsignedInteger confirmation: event.confirmations) confirmations.add(confirmation.longValue());
+
+                return new JSONObject(ImmutableMap.of(
+                        "name", event.name,
+                        "confirmations", confirmations
+                ));
+            default: throw new IllegalStateException("Invalid name");
+        }
+    }
+
+    public static JSONArray asJson(List<SubscriptionEvent> events) {
+        JSONArray array = new JSONArray();
+        for (SubscriptionEvent event: events) {
+            array.put(asJson(event));
+        }
+        return array;
+    }
+
+    private final String name;
+    private final List<UnsignedInteger> confirmations;
+
+    public SubscriptionEvent(String name, @Nullable List<UnsignedInteger> confirmations) {
+        this.name = name;
+        this.confirmations = confirmations;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public Optional<List<UnsignedInteger>> getConfirmations() {
+        return Optional.fromNullable(confirmations);
+    }
+}

--- a/Java/CryptoDemo/build.gradle
+++ b/Java/CryptoDemo/build.gradle
@@ -22,13 +22,13 @@ android {
             debuggable true
             jniDebuggable true
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
-            buildConfigField 'String', 'BDB_AUTH_TOKEN', '"eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJkZWI2M2UyOC0wMzQ1LTQ4ZjYtOWQxNy1jZTgwY2JkNjE3Y2IiLCJicmQ6Y3QiOiJjbGkiLCJleHAiOjkyMjMzNzIwMzY4NTQ3NzUsImlhdCI6MTU2Njg2MzY0OX0.FvLLDUSk1p7iFLJfg2kA-vwhDWTDulVjdj8YpFgnlE62OBFCYt4b3KeTND_qAhLynLKbGJ1UDpMMihsxtfvA0A"'
+            buildConfigField 'String', 'BDB_AUTH_TOKEN', '"eyJhbGciOiJFUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJjNzQ5NTA2ZS02MWUzLTRjM2UtYWNiNS00OTY5NTM2ZmRhMTAiLCJpYXQiOjE1NzI1NDY1MDAuODg3LCJleHAiOjE4ODAxMzA1MDAuODg3LCJicmQ6Y3QiOiJ1c3IiLCJicmQ6Y2xpIjoiZGViNjNlMjgtMDM0NS00OGY2LTlkMTctY2U4MGNiZDYxN2NiIn0.460_GdAWbONxqOhWL5TEbQ7uEZi3fSNrl0E_Zg7MAg570CVcgO7rSMJvAPwaQtvIx1XFK_QZjcoNULmB8EtOdg"'
 
         }
         debug {
             debuggable true
             jniDebuggable true
-            buildConfigField 'String', 'BDB_AUTH_TOKEN', '"eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJkZWI2M2UyOC0wMzQ1LTQ4ZjYtOWQxNy1jZTgwY2JkNjE3Y2IiLCJicmQ6Y3QiOiJjbGkiLCJleHAiOjkyMjMzNzIwMzY4NTQ3NzUsImlhdCI6MTU2Njg2MzY0OX0.FvLLDUSk1p7iFLJfg2kA-vwhDWTDulVjdj8YpFgnlE62OBFCYt4b3KeTND_qAhLynLKbGJ1UDpMMihsxtfvA0A"'
+            buildConfigField 'String', 'BDB_AUTH_TOKEN', '"eyJhbGciOiJFUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJjNzQ5NTA2ZS02MWUzLTRjM2UtYWNiNS00OTY5NTM2ZmRhMTAiLCJpYXQiOjE1NzI1NDY1MDAuODg3LCJleHAiOjE4ODAxMzA1MDAuODg3LCJicmQ6Y3QiOiJ1c3IiLCJicmQ6Y2xpIjoiZGViNjNlMjgtMDM0NS00OGY2LTlkMTctY2U4MGNiZDYxN2NiIn0.460_GdAWbONxqOhWL5TEbQ7uEZi3fSNrl0E_Zg7MAg570CVcgO7rSMJvAPwaQtvIx1XFK_QZjcoNULmB8EtOdg"'
         }
     }
 

--- a/Swift/BRCrypto/common/BRBlockChainDB.swift
+++ b/Swift/BRCrypto/common/BRBlockChainDB.swift
@@ -681,7 +681,7 @@ public class BlockChainDB {
         makeSubscriptionRequest (
             path: "subscriptions",
             data: [
-                // Can use asJSON(Subscription) because that will include the 'id'
+                // We can not use asJSON(Subscription) because that will include the 'id'
                 "device_id"       : subscription.device,
                 "endpoint"        : BlockChainDB.Model.asJSON (subscriptionEndpoint: subscription.endpoint),
                 "currencies"      : subscription.currencies.map { BlockChainDB.Model.asJSON (subscriptionCurrency: $0) }],

--- a/Swift/BRCryptoTests/BRBlockChainDBTest.swift
+++ b/Swift/BRCryptoTests/BRBlockChainDBTest.swift
@@ -283,8 +283,6 @@ class BRBlockChainDBTest: XCTestCase {
 
             // Depending on the 'Bearer Authorization Token' we might have subscriptions.  So
             // don't be so picky on how many 'subs' we have.
-            // XCTAssert (subs.isEmpty)
-
             subscriptionCountObserved = subs.count;
             self.expectation.fulfill();
         }
@@ -317,9 +315,6 @@ class BRBlockChainDBTest: XCTestCase {
             guard case let .success (subs) = res
                 else { XCTAssert (false); return }
 
-            // Depending on the 'Bearer Authorization Token' we might have subscriptions.  So
-            // don't be so picky on how many 'subs' we have.
-            // XCTAssert (subs.isEmpty)
             XCTAssertEqual(subs.count, 1 + subscriptionCountObserved)
             self.expectation.fulfill();
         }
@@ -352,9 +347,6 @@ class BRBlockChainDBTest: XCTestCase {
             guard case let .success (subs) = res
                 else { XCTAssert (false); return }
             
-            // Depending on the 'Bearer Authorization Token' we might have subscriptions.  So
-            // don't be so picky on how many 'subs' we have.
-            // XCTAssert (subs.isEmpty)
             XCTAssertEqual(subs.count, subscriptionCountObserved)
             self.expectation.fulfill();
         }

--- a/Swift/BRCryptoTests/BRBlockChainDBTest.swift
+++ b/Swift/BRCryptoTests/BRBlockChainDBTest.swift
@@ -103,7 +103,8 @@ class BRBlockChainDBTest: XCTestCase {
         expectation = XCTestExpectation (description: "transfers")
 
         let blockchainId = "bitcoin-testnet"
-        db.getTransfers (blockchainId: blockchainId, addresses: ["mvnSpXB1Vizfg3uodBx418APVK1jQXScvW"]) { (res: Result<[BlockChainDB.Model.Transfer], BlockChainDB.QueryError>) in
+        db.getTransfers (blockchainId: blockchainId, addresses: ["mvnSpXB1Vizfg3uodBx418APVK1jQXScvW"]) {
+            (res: Result<[BlockChainDB.Model.Transfer], BlockChainDB.QueryError>) in
             guard case let .success (transfers) = res
                 else { XCTAssert(false); return }
 
@@ -248,5 +249,115 @@ class BRBlockChainDBTest: XCTestCase {
 
      func testSubscription () {
 
+        let deviceId = UIDevice.current.identifierForVendor!.uuidString
+
+        /// environment : { unknown, production, development }
+        /// kind        : { unknown, apns, fcm, ... }
+        /// value       : For apns/fcm this will be the registration token, apns should be hex-encoded
+        let endpoint =  (environment: "development",
+                         kind: "apns",
+                         value: "apns registration token")
+
+        let currencies: [BlockChainDB.Model.SubscriptionCurrency] = [
+            (addresses: [
+                "2NEpHgLvBJqGFVwQPUA3AQPjpE5gNWhETfT",
+                "mvnSpXB1Vizfg3uodBx418APVK1jQXScvW"
+                ],
+             currencyId: "bitcoin-testnet:__native__",
+             events: [
+                (name: "confirmed", confirmations: [1])
+                ])
+        ]
+
+        var subscription: BlockChainDB.Model.Subscription =
+            (id: "ignore",
+             device: deviceId,
+             endpoint: endpoint,
+             currencies: currencies)
+
+        var subscriptionCountObserved: Int  = 0;
+        expectation = XCTestExpectation (description: "subscription get all")
+        db.getSubscriptions { (res: Result<[BlockChainDB.Model.Subscription], BlockChainDB.QueryError>) in
+            guard case let .success (subs) = res
+                else { XCTAssert (false); return }
+
+            // Depending on the 'Bearer Authorization Token' we might have subscriptions.  So
+            // don't be so picky on how many 'subs' we have.
+            // XCTAssert (subs.isEmpty)
+
+            subscriptionCountObserved = subs.count;
+            self.expectation.fulfill();
+        }
+        wait (for: [expectation], timeout: 10)
+
+        expectation = XCTestExpectation (description: "subscription create")
+        db.createSubscription(subscription) { (res: Result<BlockChainDB.Model.Subscription, BlockChainDB.QueryError>) in
+            guard case let .success (sub) = res
+                else { XCTAssert (false); return }
+
+            self.expectation.fulfill()
+            subscription = sub
+        }
+        wait (for: [expectation], timeout: 10)
+
+        expectation = XCTestExpectation (description: "subscription get")
+        db.getSubscription(id: subscription.id) { (res: Result<BlockChainDB.Model.Subscription, BlockChainDB.QueryError>) in
+            guard case let .success (sub) = res
+                else { XCTAssert(false); return }
+
+            XCTAssertEqual(sub.id,  subscription.id)
+            XCTAssertEqual(sub.device, subscription.device)
+            // ...
+            self.expectation.fulfill()
+        }
+        wait (for: [expectation], timeout: 10)
+
+        expectation = XCTestExpectation (description: "subscription get all too")
+        db.getSubscriptions { (res: Result<[BlockChainDB.Model.Subscription], BlockChainDB.QueryError>) in
+            guard case let .success (subs) = res
+                else { XCTAssert (false); return }
+
+            // Depending on the 'Bearer Authorization Token' we might have subscriptions.  So
+            // don't be so picky on how many 'subs' we have.
+            // XCTAssert (subs.isEmpty)
+            XCTAssertEqual(subs.count, 1 + subscriptionCountObserved)
+            self.expectation.fulfill();
+        }
+        wait (for: [expectation], timeout: 10)
+
+        expectation = XCTestExpectation (description: "subscription update")
+        subscription.currencies = [
+            (addresses: ["2NEpHgLvBJqGFVwQPUA3AQPjpE5gNWhETfT"],
+              currencyId: "bitcoin-testnet:__native__",
+              events: [(name: "confirmed", confirmations: [1])])
+        ]
+        db.updateSubscription (subscription) { (res: Result<BlockChainDB.Model.Subscription, BlockChainDB.QueryError>) in
+            guard case let .success (sub) = res
+                else { XCTAssert(false); return }
+            XCTAssertTrue(sub.currencies.count == subscription.currencies.count)
+            self.expectation.fulfill()
+        }
+        wait (for: [expectation], timeout: 10)
+
+        expectation = XCTestExpectation (description: "subscription delete")
+        db.deleteSubscription(id: subscription.id) { (res: Result<Void, BlockChainDB.QueryError>) in
+            guard case .success = res
+                else { XCTAssert(false); return }
+            self.expectation.fulfill()
+        }
+        wait (for: [expectation], timeout: 10)
+        
+        expectation = XCTestExpectation (description: "subscription get all tre")
+        db.getSubscriptions { (res: Result<[BlockChainDB.Model.Subscription], BlockChainDB.QueryError>) in
+            guard case let .success (subs) = res
+                else { XCTAssert (false); return }
+            
+            // Depending on the 'Bearer Authorization Token' we might have subscriptions.  So
+            // don't be so picky on how many 'subs' we have.
+            // XCTAssert (subs.isEmpty)
+            XCTAssertEqual(subs.count, subscriptionCountObserved)
+            self.expectation.fulfill();
+        }
+        wait (for: [expectation], timeout: 10)
     }
 }


### PR DESCRIPTION
Fill out the unit tests.  Update the JWT token.

This does not address subscriptions in the Crypto interface; only connectivity to the BDB.

Requires Java changes.