### PR TITLE
CORE-720: Add Java-specific BRCoreKey::encryptNative migration function

### DIFF
--- a/Java/CoreCrypto/src/androidTest/java/com/breadwallet/corecrypto/HelpersAIT.java
+++ b/Java/CoreCrypto/src/androidTest/java/com/breadwallet/corecrypto/HelpersAIT.java
@@ -94,6 +94,21 @@ class HelpersAIT {
     // System
 
     /* package */
+    static System createAndConfigureSystem(File dataDir) {
+        String storagePath = dataDir.getAbsolutePath();
+        Account account = HelpersAIT.createDefaultAccount();
+        SystemListener listener = new DefaultSystemListener() {};
+        BlockchainDb query = HelpersAIT.createDefaultBlockchainDbWithToken();
+        ScheduledExecutorService executor = Executors.newSingleThreadScheduledExecutor();
+        com.breadwallet.corecrypto.System system = com.breadwallet.corecrypto.System.create(executor, listener, account, false, storagePath, query);
+
+        system.configure(Collections.emptyList());
+        Uninterruptibles.sleepUninterruptibly(5, TimeUnit.SECONDS);
+
+        return system;
+    }
+
+    /* package */
     static System createAndConfigureSystemWithListener(File dataDir, SystemListener listener) {
         String storagePath = dataDir.getAbsolutePath();
         Account account = HelpersAIT.createDefaultAccount();

--- a/Java/CoreCrypto/src/androidTest/java/com/breadwallet/corecrypto/SystemAIT.java
+++ b/Java/CoreCrypto/src/androidTest/java/com/breadwallet/corecrypto/SystemAIT.java
@@ -12,7 +12,7 @@ import org.junit.Before;
 import org.junit.Test;
 
 import java.io.File;
-import java.util.Arrays;
+import java.nio.charset.StandardCharsets;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
@@ -20,7 +20,10 @@ import java.util.concurrent.TimeUnit;
 
 import com.breadwallet.corecrypto.HelpersAIT.RecordingSystemListener;
 import com.breadwallet.crypto.AddressScheme;
+import com.breadwallet.crypto.Coder;
+import com.breadwallet.crypto.Cipher;
 import com.breadwallet.crypto.Currency;
+import com.breadwallet.crypto.Key;
 import com.breadwallet.crypto.Network;
 import com.breadwallet.crypto.System;
 import com.breadwallet.crypto.Unit;
@@ -40,6 +43,7 @@ import com.google.common.primitives.UnsignedInteger;
 import com.google.common.primitives.UnsignedLong;
 import com.google.common.util.concurrent.Uninterruptibles;
 
+import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotEquals;
@@ -103,6 +107,156 @@ public class SystemAIT {
         assertTrue(fooBase.isPresent());
         assertEquals(UnsignedInteger.ZERO, fooBase.get().getDecimals());
         assertEquals("fooi", fooBase.get().getSymbol());
+    }
+
+    @Test
+    public void testSystemMigrateBRCoreKeyCiphertext() {
+        System system = HelpersAIT.createAndConfigureSystem(coreDataDir);
+
+        // Setup the expected data
+
+        Coder coder = Coder.createForAlgorithm(Coder.Algorithm.HEX);
+
+        byte[] authenticateData = new byte[0];
+
+        Optional<byte[]> maybeNonce12 = coder.decode(
+                "00000000ed41e4e70e000000");
+        assertTrue(maybeNonce12.isPresent());
+        byte[] nonce12 = maybeNonce12.get();
+
+        Optional<byte[]> maybeCiphertext = coder.decode(
+                "1e611714327192ec8454f1e05b1437fa4e56c77ab132d31925c1834f7ed67b7b14d93bdde51b43d38" +
+                        "11b2f22a23ca86287ce130740633f0680207137dabae3faa778c4b45ab692eea527902237ee1cfb9" +
+                        "97217e9df27e8d9131609d2e96745f1dac6c54b180621bacbb00845fe4183c1192d8f45cc267de7e" +
+                        "4ab943dfd73080ae5a3f1dd7c2ea2cc3a009a405154544938c22972744aa62e631c32e9ea7eaa687" +
+                        "ccbc244c6b97d9d69644d4b74805837c5ca3caedd63");
+        assertTrue(maybeCiphertext.isPresent());
+        byte[] ciphertext = maybeCiphertext.get();
+
+        Optional<byte[]> maybeExpectedPlaintext = coder.decode(
+                "425a6839314159265359a70ea17800004e5f80400010077ff02c2001003f679c0a200072229ea7a86" +
+                        "41a6d47a81a00f5340d53d348f54f4c2479266a7a9e9a9ea3432d1f1618e7e529ecd56e5203e90c3" +
+                        "48494fd7b98217b4b525b1c41335aee41453c8c121998a4cc2ef5856afa62e6b82358d48acd52866" +
+                        "cc671180b0f2f83aa5c891bb8c043bd254cfd2054b5930bd1910328ea5235866bf4ff8bb9229c284" +
+                        "8538750bc00");
+        assertTrue(maybeExpectedPlaintext.isPresent());
+        byte[] expectedPlaintext = maybeExpectedPlaintext.get();
+
+        // Test with paper key
+
+        {
+            byte[] pk = "truly flame one position follow sponsor frost oval tuna swallow situate talk".getBytes(StandardCharsets.UTF_8);
+            Optional<? extends Key> maybeCryptoEncodedKey = Key.createForBIP32ApiAuth(pk, HelpersAIT.BIP39_WORDS_EN);
+            assertTrue(maybeCryptoEncodedKey.isPresent());
+            Key key = maybeCryptoEncodedKey.get();
+
+            // Migrate using the crypto address params key
+
+            Optional<byte[]> maybeMigratedCiphertext = system.migrateBRCoreKeyCiphertext(key, nonce12, authenticateData, ciphertext);
+            assertTrue(maybeMigratedCiphertext.isPresent());
+            byte[] migratedCiphertext = maybeMigratedCiphertext.get();
+
+            // Decrypt using the crypto address params key
+
+            Cipher cipher = Cipher.createForChaCha20Poly1305(key, nonce12, authenticateData);
+            Optional<byte[]> maybeDecryptedPlaintext = cipher.decrypt(migratedCiphertext);
+            assertTrue(maybeDecryptedPlaintext.isPresent());
+            byte[] decryptedPlaintext = maybeDecryptedPlaintext.get();
+
+            // Verify correct decryption
+
+            assertArrayEquals(expectedPlaintext, decryptedPlaintext);
+        }
+
+        // Test with a private key string encoded using CRYPTO_ADDRESS_PARAMS
+
+        byte[] cryptoAddressParamsMigratedCiphertext;
+        {
+            // Load the correct key encoded with the crypto address params
+
+            byte[] ks = "T7GNuCG4XzHaPGhmUTVGvTnHZodVTrV7KKj1K1vVwTcNcSADqnb5".getBytes(StandardCharsets.UTF_8);
+            Optional<? extends Key> maybeCryptoEncodedKey = Key.createFromPrivateKeyString(ks);
+            assertTrue(maybeCryptoEncodedKey.isPresent());
+            Key key = maybeCryptoEncodedKey.get();
+
+            // Migrate using the crypto address params key
+
+            Optional<byte[]> maybeMigratedCiphertext = system.migrateBRCoreKeyCiphertext(key, nonce12, authenticateData, ciphertext);
+            assertTrue(maybeMigratedCiphertext.isPresent());
+            cryptoAddressParamsMigratedCiphertext = maybeMigratedCiphertext.get();
+
+            // Decrypt using the crypto address params key
+
+            Cipher cipher = Cipher.createForChaCha20Poly1305(key, nonce12, authenticateData);
+            Optional<byte[]> maybeDecryptedPlaintext = cipher.decrypt(cryptoAddressParamsMigratedCiphertext);
+            assertTrue(maybeDecryptedPlaintext.isPresent());
+            byte[] decryptedPlaintext = maybeDecryptedPlaintext.get();
+
+            // Verify correct decryption
+
+            assertArrayEquals(expectedPlaintext, decryptedPlaintext);
+        }
+
+        // Test with a private key string encoded using BITCOIN_ADDRESS_PARAMS
+
+        byte[] mainnetAddressParamsMigratedCiphertext;
+        {
+            // Load the correct key encoded with the bitcoin address params
+
+            byte[] ks = "cRo6vMxjZg1EmsYAKEMY5RjyFBHb4DZua9yDZdkTsc6DMHhv8Unr".getBytes(StandardCharsets.UTF_8);
+            Optional<? extends Key> maybeCryptoEncodedKey = Key.createFromPrivateKeyString(ks);
+            assertTrue(maybeCryptoEncodedKey.isPresent());
+            Key key = maybeCryptoEncodedKey.get();
+
+            // Migrate using the crypto address params key
+
+            Optional<byte[]> maybeMigratedCiphertext = system.migrateBRCoreKeyCiphertext(key, nonce12, authenticateData, ciphertext);
+            assertTrue(maybeMigratedCiphertext.isPresent());
+            mainnetAddressParamsMigratedCiphertext = maybeMigratedCiphertext.get();
+
+            // Decrypt using the crypto address params key
+
+            Cipher cipher = Cipher.createForChaCha20Poly1305(key, nonce12, authenticateData);
+            Optional<byte[]> maybeDecryptedPlaintext = cipher.decrypt(mainnetAddressParamsMigratedCiphertext);
+            assertTrue(maybeDecryptedPlaintext.isPresent());
+            byte[] decryptedPlaintext = maybeDecryptedPlaintext.get();
+
+            // Verify correct decryption
+
+            assertArrayEquals(expectedPlaintext, decryptedPlaintext);
+        }
+
+        // Confirm that migrated ciphertext is the same, regardless of private key encoding
+
+        assertArrayEquals(cryptoAddressParamsMigratedCiphertext, mainnetAddressParamsMigratedCiphertext);
+
+        {
+            // Load the incorrect uncompressed key
+
+            byte[] ks = "5Kb8kLf9zgWQnogidDA76MzPL6TsZZY36hWXMssSzNydYXYB9KF".getBytes(StandardCharsets.UTF_8);
+            Optional<? extends Key> maybeCryptoEncodedKey = Key.createFromPrivateKeyString(ks);
+            assertTrue(maybeCryptoEncodedKey.isPresent());
+            Key key = maybeCryptoEncodedKey.get();
+
+            // Migrate and fail
+
+            Optional<byte[]> maybeMigratedCiphertext = system.migrateBRCoreKeyCiphertext(key, nonce12, authenticateData, ciphertext);
+            assertFalse(maybeMigratedCiphertext.isPresent());
+        }
+
+        {
+            // Load the incorrect uncompressed key
+
+            byte[] ks = "KyvGbxRUoofdw3TNydWn2Z78dBHSy2odn1d3wXWN2o3SAtccFNJL".getBytes(StandardCharsets.UTF_8);
+            Optional<? extends Key> maybeCryptoEncodedKey = Key.createFromPrivateKeyString(ks);
+            assertTrue(maybeCryptoEncodedKey.isPresent());
+            Key key = maybeCryptoEncodedKey.get();
+
+            // Migrate and fail
+
+            Optional<byte[]> maybeMigratedCiphertext = system.migrateBRCoreKeyCiphertext(key, nonce12, authenticateData, ciphertext);
+            assertFalse(maybeMigratedCiphertext.isPresent());
+        }
     }
 
     @Test

--- a/Java/CoreCrypto/src/main/java/com/breadwallet/corecrypto/Cipher.java
+++ b/Java/CoreCrypto/src/main/java/com/breadwallet/corecrypto/Cipher.java
@@ -17,6 +17,12 @@ import static com.google.common.base.Preconditions.checkNotNull;
 final class Cipher implements com.breadwallet.crypto.Cipher {
 
     /* package */
+    static Optional<byte[]> migrateBRCoreKeyCiphertext(com.breadwallet.crypto.Key key, byte[] nonce12, byte[] authenticatedData,
+                                                       byte[] ciphertext) {
+        return Cipher.createForChaCha20Poly1305(key, nonce12, authenticatedData).migrateBRCoreKeyCiphertext(ciphertext);
+    }
+
+    /* package */
     static Cipher createForAesEcb(byte[] key) {
         BRCryptoCipher cipher = BRCryptoCipher.createAesEcb(key).orNull();
         checkNotNull(cipher);
@@ -24,11 +30,11 @@ final class Cipher implements com.breadwallet.crypto.Cipher {
     }
 
     /* package */
-    static Cipher createForChaCha20Poly1305(com.breadwallet.crypto.Key key, byte[] nonce12, byte[] ad) {
+    static Cipher createForChaCha20Poly1305(com.breadwallet.crypto.Key key, byte[] nonce12, byte[] authenticatedData) {
         BRCryptoCipher cipher = BRCryptoCipher.createChaCha20Poly1305(
                 Key.from(key).getBRCryptoKey(),
                 nonce12,
-                ad)
+                authenticatedData)
                 .orNull();
         checkNotNull(cipher);
         return Cipher.create(cipher);
@@ -67,5 +73,9 @@ final class Cipher implements com.breadwallet.crypto.Cipher {
     @Override
     public Optional<byte[]> decrypt(byte[] data) {
         return core.decrypt(data);
+    }
+
+    private Optional<byte[]> migrateBRCoreKeyCiphertext(byte[] data) {
+        return core.migrateBRCoreKeyCiphertext(data);
     }
 }

--- a/Java/CoreCrypto/src/main/java/com/breadwallet/corecrypto/System.java
+++ b/Java/CoreCrypto/src/main/java/com/breadwallet/corecrypto/System.java
@@ -589,6 +589,14 @@ final class System implements com.breadwallet.crypto.System {
     }
 
     @Override
+    public Optional<byte[]> migrateBRCoreKeyCiphertext(com.breadwallet.crypto.Key key,
+                                                       byte[] nonce12,
+                                                       byte[] authenticatedData,
+                                                       byte[] ciphertext) {
+        return Cipher.migrateBRCoreKeyCiphertext(key, nonce12, authenticatedData, ciphertext);
+    }
+
+    @Override
     public boolean migrateRequired(com.breadwallet.crypto.Network network) {
         String code = network.getCurrency().getCode().toLowerCase(Locale.ROOT);
         return Currency.CODE_AS_BCH.equals(code) || Currency.CODE_AS_BTC.equals(code);

--- a/Java/CoreNative/src/main/java/com/breadwallet/corenative/CryptoLibraryDirect.java
+++ b/Java/CoreNative/src/main/java/com/breadwallet/corenative/CryptoLibraryDirect.java
@@ -362,6 +362,8 @@ public final class CryptoLibraryDirect {
     public static native int cryptoCipherEncrypt(Pointer cipher, byte[] dst, SizeT dstLen, byte[] src, SizeT srcLen);
     public static native SizeT cryptoCipherDecryptLength(Pointer cipher, byte[] src, SizeT srcLen);
     public static native int cryptoCipherDecrypt(Pointer cipher, byte[] dst, SizeT dstLen, byte[] src, SizeT srcLen);
+    public static native SizeT cryptoCipherMigrateBRCoreKeyCiphertextLength(Pointer cipher, byte[] src, SizeT srcLen);
+    public static native int cryptoCipherMigrateBRCoreKeyCiphertext(Pointer cipher, byte[] dst, SizeT dstLen, byte[] src, SizeT srcLen);
     public static native void cryptoCipherGive(Pointer cipher);
 
     // crypto/BRCryptoCoder.h

--- a/Java/CoreNative/src/main/java/com/breadwallet/corenative/CryptoLibraryDirect.java
+++ b/Java/CoreNative/src/main/java/com/breadwallet/corenative/CryptoLibraryDirect.java
@@ -362,7 +362,6 @@ public final class CryptoLibraryDirect {
     public static native int cryptoCipherEncrypt(Pointer cipher, byte[] dst, SizeT dstLen, byte[] src, SizeT srcLen);
     public static native SizeT cryptoCipherDecryptLength(Pointer cipher, byte[] src, SizeT srcLen);
     public static native int cryptoCipherDecrypt(Pointer cipher, byte[] dst, SizeT dstLen, byte[] src, SizeT srcLen);
-    public static native SizeT cryptoCipherMigrateBRCoreKeyCiphertextLength(Pointer cipher, byte[] src, SizeT srcLen);
     public static native int cryptoCipherMigrateBRCoreKeyCiphertext(Pointer cipher, byte[] dst, SizeT dstLen, byte[] src, SizeT srcLen);
     public static native void cryptoCipherGive(Pointer cipher);
 

--- a/Java/CoreNative/src/main/java/com/breadwallet/corenative/crypto/BRCryptoCipher.java
+++ b/Java/CoreNative/src/main/java/com/breadwallet/corenative/crypto/BRCryptoCipher.java
@@ -75,6 +75,18 @@ public class BRCryptoCipher extends PointerType {
         return result == BRCryptoBoolean.CRYPTO_TRUE ? Optional.of(output) : Optional.absent();
     }
 
+    public Optional<byte[]> migrateBRCoreKeyCiphertext(byte[] input) {
+        Pointer thisPtr = this.getPointer();
+
+        SizeT length = CryptoLibraryDirect.cryptoCipherMigrateBRCoreKeyCiphertextLength(thisPtr, input, new SizeT(input.length));
+        int lengthAsInt = Ints.checkedCast(length.longValue());
+        if (0 == lengthAsInt) return Optional.absent();
+
+        byte[] output = new byte[lengthAsInt];
+        int result = CryptoLibraryDirect.cryptoCipherMigrateBRCoreKeyCiphertext(thisPtr, output, new SizeT(output.length), input, new SizeT(input.length));
+        return result == BRCryptoBoolean.CRYPTO_TRUE ? Optional.of(output) : Optional.absent();
+    }
+
     public void give() {
         Pointer thisPtr = this.getPointer();
 

--- a/Java/CoreNative/src/main/java/com/breadwallet/corenative/crypto/BRCryptoCipher.java
+++ b/Java/CoreNative/src/main/java/com/breadwallet/corenative/crypto/BRCryptoCipher.java
@@ -78,8 +78,7 @@ public class BRCryptoCipher extends PointerType {
     public Optional<byte[]> migrateBRCoreKeyCiphertext(byte[] input) {
         Pointer thisPtr = this.getPointer();
 
-        SizeT length = CryptoLibraryDirect.cryptoCipherMigrateBRCoreKeyCiphertextLength(thisPtr, input, new SizeT(input.length));
-        int lengthAsInt = Ints.checkedCast(length.longValue());
+        int lengthAsInt = input.length;
         if (0 == lengthAsInt) return Optional.absent();
 
         byte[] output = new byte[lengthAsInt];

--- a/Java/Crypto/src/main/java/com/breadwallet/crypto/System.java
+++ b/Java/Crypto/src/main/java/com/breadwallet/crypto/System.java
@@ -185,8 +185,42 @@ public interface System {
 
     boolean supportsWalletManagerMode(Network network, WalletManagerMode mode);
 
+    /**
+     * If migration is required, return the currency code; otherwise, return nil.
+     *
+     * Note: it is not an error not to migrate.
+     */
+    boolean migrateRequired(Network network);
+
+    /**
+     * Migrate the storage for a network given transaction, block and peer blobs.
+     *
+     * Support for persistent storage migration to allow prior App versions to migrate their SQLite
+     * database representations of BTC/BTC transations, blocks and peers into 'Generic Crypto' - where
+     * these entities are persistently
+     *
+     * The provided blobs must be consistent with `network`.  For exmaple, if `network` represents BTC or BCH
+     * then the blobs must be of type {@link TransactionBlob.Btc}; otherwise a MigrateError is thrown.
+     */
     void migrateStorage (Network network, List<TransactionBlob> transactionBlobs, List<BlockBlob> blockBlobs,
                          List<PeerBlob> peerBlobs) throws MigrateError;
 
-    boolean migrateRequired(Network network);
+
+    /**
+     * Re-encrypt ciphertext blobs that were encrypted using the BRCoreKey::encryptNative routine.
+     *
+     * The ciphertext will be decrypted using the previous decryption routine. The plaintext from that
+     * operation will be encrypted using the current {@link Cipher#encrypt(byte[])} routine with a
+     * {@link Cipher#createForChaCha20Poly1305(Key, byte[], byte[])} cipher. That updated ciphertext
+     * is then returned and should be used to immediately overwrite the old ciphertext blob so that
+     * it can be properly decrypted using the {@link Cipher#decrypt(byte[])} routine going forward.
+     *
+     * @param key The cipher key
+     * @param nonce12 The 12 byte nonce data
+     * @param authenticatedData The authenticated data
+     * @param ciphertext The ciphertext to update the encryption on
+     *
+     * @return The updated ciphertext, if decryption and re-encryption succeeds; absent otherwise.
+     */
+    Optional<byte[]> migrateBRCoreKeyCiphertext(Key key, byte[] nonce12, byte[] authenticatedData, byte[] ciphertext);
 }

--- a/Swift/BRCrypto/common/BRCryptoCipher.swift
+++ b/Swift/BRCrypto/common/BRCryptoCipher.swift
@@ -80,7 +80,7 @@ public final class CoreCipher: Cipher {
 
     public func decrypt (data source: Data) -> Data? {
         return source.withUnsafeBytes { (sourceBytes: UnsafeRawBufferPointer) -> Data? in
-            let sourceAddr  = sourceBytes.baseAddress?.assumingMemoryBound(to: Int8.self)
+            let sourceAddr  = sourceBytes.baseAddress?.assumingMemoryBound(to: UInt8.self)
             let sourceCount = sourceBytes.count
 
             let targetCount = cryptoCipherDecryptLength(self.core, sourceAddr, sourceCount)

--- a/crypto/BRCryptoCipher.c
+++ b/crypto/BRCryptoCipher.c
@@ -445,48 +445,6 @@ cryptoCipherDecryptForMigrate (BRCryptoCipher cipher,
     return result;
 }
 
-extern size_t
-cryptoCipherMigrateBRCoreKeyCiphertextLength (BRCryptoCipher cipher,
-                                              const uint8_t *originalCiphertext,
-                                              size_t originalCiphertextLen) {
-    // calculate the length of the plaintext using the modified decryption routine
-    size_t plaintextLen = cryptoCipherDecryptForMigrateLength (cipher,
-                                                               originalCiphertext,
-                                                               originalCiphertextLen);
-    if (0 == plaintextLen) {
-        return 0;
-    }
-
-    // allocate the plaintext buffer
-    uint8_t *plaintext = (uint8_t *) malloc (plaintextLen);
-    if (NULL == plaintext) {
-        return 0;
-    }
-
-    // decrypt the original ciphertext using the modified decryption routine
-    BRCryptoBoolean decryptResult = cryptoCipherDecryptForMigrate (cipher,
-                                                                   plaintext,
-                                                                   plaintextLen,
-                                                                   originalCiphertext,
-                                                                   originalCiphertextLen);
-    if (CRYPTO_TRUE != decryptResult) {
-        memset (plaintext, 0, plaintextLen);
-        free (plaintext);
-        return 0;
-    }
-
-    // calculate the length of the migrated ciphertext using the current encryption routine
-    size_t ciphertextLen = cryptoCipherEncryptLength (cipher,
-                                                      plaintext,
-                                                      plaintextLen);
-
-    // release the cipher and plaintext memory
-    memset (plaintext, 0, plaintextLen);
-    free (plaintext);
-
-    return ciphertextLen;
-}
-
 extern BRCryptoBoolean
 cryptoCipherMigrateBRCoreKeyCiphertext (BRCryptoCipher cipher,
                                         uint8_t *migratedCiphertext,

--- a/crypto/BRCryptoCipher.c
+++ b/crypto/BRCryptoCipher.c
@@ -247,7 +247,7 @@ cryptoCipherEncrypt (BRCryptoCipher cipher,
 
 extern size_t
 cryptoCipherDecryptLength (BRCryptoCipher cipher,
-                           const char *src,
+                           const uint8_t *src,
                            size_t srcLen) {
     // - src CAN be NULL, if srcLen is 0
     if (NULL == src && 0 != srcLen) {
@@ -299,7 +299,7 @@ extern BRCryptoBoolean
 cryptoCipherDecrypt (BRCryptoCipher cipher,
                      uint8_t *dst,
                      size_t dstLen,
-                     const char *src,
+                     const uint8_t *src,
                      size_t srcLen) {
     // - src CAN be NULL, if srcLen is 0
     // - dst MUST be non-NULL and sufficiently sized
@@ -353,6 +353,193 @@ cryptoCipherDecrypt (BRCryptoCipher cipher,
     }
 
     return result;
+}
+
+static size_t
+cryptoCipherDecryptForMigrateLength (BRCryptoCipher cipher,
+                                     const uint8_t *src,
+                                     size_t srcLen) {
+    // - src CAN be NULL, if srcLen is 0
+    if (NULL == src && 0 != srcLen) {
+        assert (0);
+        return 0;
+    }
+
+    size_t length = 0;
+
+    switch (cipher->type) {
+        case CRYPTO_CIPHER_CHACHA20_POLY1305: {
+            BRKey *coreKey  = cryptoKeyGetCore (cipher->u.chacha20.key);
+
+            uint8_t pubKeyBytes[65];
+            BRKeyPubKey(coreKey, pubKeyBytes, 65);
+
+            UInt256 secret;
+            BRSHA256(&secret, &pubKeyBytes[1], 32);
+
+            length = BRChacha20Poly1305AEADDecrypt (NULL,
+                                                    0,
+                                                    &secret,
+                                                    cipher->u.chacha20.nonce,
+                                                    src,
+                                                    srcLen,
+                                                    cipher->u.chacha20.ad,
+                                                    cipher->u.chacha20.adLen);
+            secret = UINT256_ZERO; (void) &secret;
+            break;
+        }
+        default: {
+            // for an unsupported algorithm, assert
+            assert (0);
+            break;
+        }
+    }
+
+    return length;
+}
+
+static BRCryptoBoolean
+cryptoCipherDecryptForMigrate (BRCryptoCipher cipher,
+                               uint8_t *dst,
+                               size_t dstLen,
+                               const uint8_t *src,
+                               size_t srcLen) {
+    // - src CAN be NULL, if srcLen is 0
+    // - dst MUST be non-NULL and sufficiently sized
+    if ((NULL == src && 0 != srcLen) ||
+        NULL == dst || dstLen < cryptoCipherDecryptLength (cipher, src, srcLen)) {
+        assert (0);
+        return CRYPTO_FALSE;
+    }
+
+    BRCryptoBoolean result = CRYPTO_FALSE;
+
+    switch (cipher->type) {
+        case CRYPTO_CIPHER_CHACHA20_POLY1305: {
+            BRKey *coreKey  = cryptoKeyGetCore (cipher->u.chacha20.key);
+
+            uint8_t pubKeyBytes[65];
+            BRKeyPubKey(coreKey, pubKeyBytes, 65);
+
+            UInt256 secret;
+            BRSHA256(&secret, &pubKeyBytes[1], 32);
+
+            result = AS_CRYPTO_BOOLEAN (BRChacha20Poly1305AEADDecrypt (dst,
+                                                                       dstLen,
+                                                                       &secret,
+                                                                       cipher->u.chacha20.nonce,
+                                                                       src,
+                                                                       srcLen,
+                                                                       cipher->u.chacha20.ad,
+                                                                       cipher->u.chacha20.adLen));
+            secret = UINT256_ZERO; (void) &secret;
+            break;
+        }
+        default: {
+            // for an unsupported algorithm, assert
+            assert (0);
+            break;
+        }
+    }
+
+    return result;
+}
+
+extern size_t
+cryptoCipherMigrateBRCoreKeyCiphertextLength (BRCryptoCipher cipher,
+                                              const uint8_t *originalCiphertext,
+                                              size_t originalCiphertextLen) {
+    // calculate the length of the plaintext using the modified decryption routine
+    size_t plaintextLen = cryptoCipherDecryptForMigrateLength (cipher,
+                                                               originalCiphertext,
+                                                               originalCiphertextLen);
+    if (0 == plaintextLen) {
+        return 0;
+    }
+
+    // allocate the plaintext buffer
+    uint8_t *plaintext = (uint8_t *) malloc (plaintextLen);
+    if (NULL == plaintext) {
+        return 0;
+    }
+
+    // decrypt the original ciphertext using the modified decryption routine
+    BRCryptoBoolean decryptResult = cryptoCipherDecryptForMigrate (cipher,
+                                                                   plaintext,
+                                                                   plaintextLen,
+                                                                   originalCiphertext,
+                                                                   originalCiphertextLen);
+    if (CRYPTO_TRUE != decryptResult) {
+        memset (plaintext, 0, plaintextLen);
+        free (plaintext);
+        return 0;
+    }
+
+    // calculate the length of the migrated ciphertext using the current encryption routine
+    size_t ciphertextLen = cryptoCipherEncryptLength (cipher,
+                                                      plaintext,
+                                                      plaintextLen);
+
+    // release the cipher and plaintext memory
+    memset (plaintext, 0, plaintextLen);
+    free (plaintext);
+
+    return ciphertextLen;
+}
+
+extern BRCryptoBoolean
+cryptoCipherMigrateBRCoreKeyCiphertext (BRCryptoCipher cipher,
+                                        uint8_t *migratedCiphertext,
+                                        size_t migratedCiphertextLen,
+                                        const uint8_t *originalCiphertext,
+                                        size_t originalCiphertextLen) {
+    // calculate the length of the plaintext using the modified decryption routine
+    size_t plaintextLen = cryptoCipherDecryptForMigrateLength (cipher,
+                                                               originalCiphertext,
+                                                               originalCiphertextLen);
+    if (0 == plaintextLen) {
+        return CRYPTO_FALSE;
+    }
+
+    // allocate the plaintext buffer
+    uint8_t *plaintext = (uint8_t *) malloc (plaintextLen);
+    if (NULL == plaintext) {
+        return CRYPTO_FALSE;
+    }
+
+    // decrypt the original ciphertext using the modified decryption routine
+    BRCryptoBoolean decryptResult = cryptoCipherDecryptForMigrate (cipher,
+                                                                   plaintext,
+                                                                   plaintextLen,
+                                                                   originalCiphertext,
+                                                                   originalCiphertextLen);
+    if (CRYPTO_TRUE != decryptResult) {
+        memset (plaintext, 0, plaintextLen);
+        free (plaintext);
+        return CRYPTO_FALSE;
+    }
+
+    // calculate the length of the migrated ciphertext using the current encryption routine
+    if (migratedCiphertextLen < cryptoCipherEncryptLength (cipher,
+                                                           plaintext,
+                                                           plaintextLen)) {
+        memset (plaintext, 0, plaintextLen);
+        free (plaintext);
+        return CRYPTO_FALSE;
+    }
+
+    // encrypt the plaintext using the current encryption routine
+    BRCryptoBoolean encryptResult = cryptoCipherEncrypt (cipher,
+                                                         migratedCiphertext,
+                                                         migratedCiphertextLen,
+                                                         plaintext,
+                                                         plaintextLen);
+
+    // release the cipher and plaintext memory
+    memset (plaintext, 0, plaintextLen);
+    free (plaintext);
+
+    return encryptResult;
 }
 
 IMPLEMENT_CRYPTO_GIVE_TAKE (BRCryptoCipher, cryptoCipher);

--- a/crypto/BRCryptoCipher.c
+++ b/crypto/BRCryptoCipher.c
@@ -372,11 +372,11 @@ cryptoCipherDecryptForMigrateLength (BRCryptoCipher cipher,
             BRKey *coreKey  = cryptoKeyGetCore (cipher->u.chacha20.key);
 
             uint8_t pubKeyBytes[65];
-            BRKeyPubKey(coreKey, pubKeyBytes, 65);
+            size_t pubKeyLen = BRKeyPubKey (coreKey, pubKeyBytes, sizeof(pubKeyBytes));
+            if (0 == pubKeyLen || pubKeyLen > sizeof(pubKeyBytes)) break;
 
             UInt256 secret;
-            BRSHA256(&secret, &pubKeyBytes[1], 32);
-
+            BRSHA256 (&secret, &pubKeyBytes[1], pubKeyLen - 1);
             length = BRChacha20Poly1305AEADDecrypt (NULL,
                                                     0,
                                                     &secret,
@@ -419,11 +419,11 @@ cryptoCipherDecryptForMigrate (BRCryptoCipher cipher,
             BRKey *coreKey  = cryptoKeyGetCore (cipher->u.chacha20.key);
 
             uint8_t pubKeyBytes[65];
-            BRKeyPubKey(coreKey, pubKeyBytes, 65);
+            size_t pubKeyLen = BRKeyPubKey (coreKey, pubKeyBytes, sizeof(pubKeyBytes));
+            if (0 == pubKeyLen || pubKeyLen > sizeof(pubKeyBytes)) break;
 
             UInt256 secret;
-            BRSHA256(&secret, &pubKeyBytes[1], 32);
-
+            BRSHA256 (&secret, &pubKeyBytes[1], pubKeyLen - 1);
             result = AS_CRYPTO_BOOLEAN (BRChacha20Poly1305AEADDecrypt (dst,
                                                                        dstLen,
                                                                        &secret,

--- a/crypto/BRCryptoCipher.h
+++ b/crypto/BRCryptoCipher.h
@@ -64,11 +64,6 @@ extern "C" {
                          const uint8_t *ciphertext,
                          size_t ciphertextLen);
 
-    extern size_t
-    cryptoCipherMigrateBRCoreKeyCiphertextLength (BRCryptoCipher cipher,
-                                                const uint8_t *originalCiphertext,
-                                                size_t originalCiphertextLen);
-
     extern BRCryptoBoolean
     cryptoCipherMigrateBRCoreKeyCiphertext (BRCryptoCipher cipher,
                                             uint8_t *migratedCiphertext,

--- a/crypto/BRCryptoCipher.h
+++ b/crypto/BRCryptoCipher.h
@@ -54,15 +54,27 @@ extern "C" {
 
     extern size_t
     cryptoCipherDecryptLength (BRCryptoCipher cipher,
-                               const char *ciphertext,
+                               const uint8_t *ciphertext,
                                size_t ciphertextLen);
 
     extern BRCryptoBoolean
     cryptoCipherDecrypt (BRCryptoCipher cipher,
                          uint8_t *plaintext,
                          size_t plaintextLen,
-                         const char *ciphertext,
+                         const uint8_t *ciphertext,
                          size_t ciphertextLen);
+
+    extern size_t
+    cryptoCipherMigrateBRCoreKeyCiphertextLength (BRCryptoCipher cipher,
+                                                const uint8_t *originalCiphertext,
+                                                size_t originalCiphertextLen);
+
+    extern BRCryptoBoolean
+    cryptoCipherMigrateBRCoreKeyCiphertext (BRCryptoCipher cipher,
+                                            uint8_t *migratedCiphertext,
+                                            size_t migratedCiphertextLen,
+                                            const uint8_t *originalCiphertext,
+                                            size_t originalCiphertextLen);
 
     DECLARE_CRYPTO_GIVE_TAKE (BRCryptoCipher, cryptoCipher);
 


### PR DESCRIPTION
For the Android guys, the call looks like (roughly):
```
byte[] ciphertext = system.migrateBRCoreKeyCiphertext(key, nonce, authenticatedData, ciphertext);
```