### PR TITLE
CORE-717: Remove BTC/ETH includes from public crypto headers

### DIFF
--- a/crypto/BRCryptoAccount.h
+++ b/crypto/BRCryptoAccount.h
@@ -14,7 +14,6 @@
 #include <inttypes.h>
 #include "BRInt.h"
 #include "BRCryptoBase.h"
-#include "../ethereum/ewm/BREthereumAccount.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -94,7 +93,7 @@ extern "C" {
     cryptoAccountValidateSerialization (BRCryptoAccount account,
                                         const uint8_t *bytes,
                                         size_t bytesCount);
-    
+
     extern uint64_t
     cryptoAccountGetTimestamp (BRCryptoAccount account);
 

--- a/crypto/BRCryptoBase.h
+++ b/crypto/BRCryptoBase.h
@@ -15,7 +15,6 @@
 #include <stdatomic.h>
 #include "support/BRInt.h"
 #include "support/BRSyncMode.h"
-#include "ethereum/base/BREthereumHash.h"
 // temporary
 #include <stdio.h>
 

--- a/crypto/BRCryptoCipher.c
+++ b/crypto/BRCryptoCipher.c
@@ -8,6 +8,9 @@
 //  See the LICENSE file at the project root for license information.
 //  See the CONTRIBUTORS file at the project root for a list of contributors.
 
+#include <assert.h>
+#include <stdlib.h>
+
 #include "BRCryptoCipher.h"
 #include "BRCryptoKey.h"
 #include "support/BRBase.h"

--- a/crypto/BRCryptoCoder.c
+++ b/crypto/BRCryptoCoder.c
@@ -8,6 +8,10 @@
 //  See the LICENSE file at the project root for license information.
 //  See the CONTRIBUTORS file at the project root for a list of contributors.
 
+#include <assert.h>
+#include <stdlib.h>
+#include <string.h>
+
 #include "BRCryptoCoder.h"
 #include "ethereum/util/BRUtilHex.h"
 #include "support/BRBase58.h"

--- a/crypto/BRCryptoCurrency.c
+++ b/crypto/BRCryptoCurrency.c
@@ -10,6 +10,7 @@
 
 #include "BRCryptoCurrency.h"
 
+#include <assert.h>
 #include <stdlib.h>
 #include <string.h>
 

--- a/crypto/BRCryptoHash.c
+++ b/crypto/BRCryptoHash.c
@@ -11,6 +11,7 @@
 
 #include "BRCryptoHash.h"
 #include "support/BRInt.h"
+#include "ethereum/base/BREthereumHash.h"
 #include "ethereum/util/BRUtilHex.h"
 #include "generic/BRGeneric.h"
 

--- a/crypto/BRCryptoHasher.c
+++ b/crypto/BRCryptoHasher.c
@@ -8,6 +8,9 @@
 //  See the LICENSE file at the project root for license information.
 //  See the CONTRIBUTORS file at the project root for a list of contributors.
 
+#include <assert.h>
+#include <stdlib.h>
+
 #include "BRCryptoHasher.h"
 #include "support/BRCrypto.h"
 

--- a/crypto/BRCryptoKey.c
+++ b/crypto/BRCryptoKey.c
@@ -8,6 +8,9 @@
 //  See the LICENSE file at the project root for license information.
 //  See the CONTRIBUTORS file at the project root for a list of contributors.
 
+#include <assert.h>
+#include <stdlib.h>
+
 #include "BRCryptoKey.h"
 #include "BRKey.h"
 #include "BRBIP39Mnemonic.h"

--- a/crypto/BRCryptoPrivate.h
+++ b/crypto/BRCryptoPrivate.h
@@ -36,6 +36,7 @@
 #include "bcash/BRBCashParams.h"
 #include "ethereum/BREthereum.h"
 #include "generic/BRGeneric.h"
+#include "generic/BRGenericWalletManager.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -124,11 +125,11 @@ extern "C" {
 
     private_extern BRCryptoBlockChainType
     cryptoAddressGetType (BRCryptoAddress address);
-    
+
     private_extern BRAddress
     cryptoAddressAsBTC (BRCryptoAddress address,
                         BRCryptoBoolean *isBitcoinAddr);
-    
+
     private_extern BREthereumAddress
     cryptoAddressAsETH (BRCryptoAddress address);
 
@@ -325,6 +326,15 @@ extern "C" {
     private_extern BRArrayOf(BRTxOutput)
     cryptoPaymentProtocolRequestGetOutputsAsBTC (BRCryptoPaymentProtocolRequest request);
 
+    /// MARK: - Status
+
+    private_extern BRCryptoStatus
+    cryptoStatusFromETH (BREthereumStatus status);
+
+    private_extern BREthereumStatus
+    cryptoStatusAsETH (BRCryptoStatus status);
+
+
     /// MARK: - Wallet
 
     private_extern BRCryptoBlockChainType
@@ -380,6 +390,16 @@ extern "C" {
     cryptoWalletRemTransfer (BRCryptoWallet wallet, BRCryptoTransfer transfer);
 
     /// MARK: - WalletManager
+
+    private_extern BRWalletManagerClient
+    cryptoWalletManagerClientCreateBTCClient (OwnershipKept BRCryptoWalletManager cwm);
+
+    private_extern BREthereumClient
+    cryptoWalletManagerClientCreateETHClient (OwnershipKept BRCryptoWalletManager cwm);
+
+    private_extern BRGenericClient
+    cryptoWalletManagerClientCreateGENClient (OwnershipKept BRCryptoWalletManager cwm);
+
 
     private_extern BRCryptoWalletManagerState
     cryptoWalletManagerStateInit(BRCryptoWalletManagerStateType type);

--- a/crypto/BRCryptoSigner.c
+++ b/crypto/BRCryptoSigner.c
@@ -8,6 +8,9 @@
 //  See the LICENSE file at the project root for license information.
 //  See the CONTRIBUTORS file at the project root for a list of contributors.
 
+#include <assert.h>
+#include <stdlib.h>
+
 #include "BRCryptoSigner.h"
 #include "support/BRCrypto.h"
 

--- a/crypto/BRCryptoStatus.c
+++ b/crypto/BRCryptoStatus.c
@@ -9,6 +9,7 @@
 //  See the CONTRIBUTORS file at the project root for a list of contributors.
 
 #include "BRCryptoStatus.h"
+#include "BRCryptoPrivate.h"
 
 extern BRCryptoStatus
     cryptoStatusFromETH (BREthereumStatus status) {

--- a/crypto/BRCryptoStatus.h
+++ b/crypto/BRCryptoStatus.h
@@ -12,7 +12,6 @@
 #define BRCryptoStatus_h
 
 #include "BRCryptoBase.h"
-#include "ethereum/ewm/BREthereumBase.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -48,12 +47,6 @@ extern "C" {
         // Block
         // Listener
     } BRCryptoStatus;
-
-    extern BRCryptoStatus
-        cryptoStatusFromETH (BREthereumStatus status);
-
-    extern BREthereumStatus
-        cryptoStatusAsETH (BRCryptoStatus status);
 
 #ifdef __cplusplus
 }

--- a/crypto/BRCryptoTransfer.h
+++ b/crypto/BRCryptoTransfer.h
@@ -16,8 +16,6 @@
 #include "BRCryptoAmount.h"
 #include "BRCryptoFeeBasis.h"
 
-//#include "ethereum/base/BREthereumBase.h"
-
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/crypto/BRCryptoWalletManager.h
+++ b/crypto/BRCryptoWalletManager.h
@@ -20,9 +20,6 @@
 #include "BRCryptoWallet.h"
 #include "BRCryptoWalletManagerClient.h"
 
-#include "ethereum/BREthereum.h"
-#include "bitcoin/BRWalletManager.h"
-
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/crypto/BRCryptoWalletManagerClient.h
+++ b/crypto/BRCryptoWalletManagerClient.h
@@ -18,10 +18,6 @@
 #include "BRCryptoTransfer.h"
 #include "BRCryptoWallet.h"
 
-#include "ethereum/BREthereum.h"
-#include "bitcoin/BRWalletManager.h"
-#include "generic/BRGenericWalletManager.h"
-
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -95,7 +91,7 @@ extern "C" {
                                             OwnershipGiven BRCryptoCWMClientCallbackState callbackState,
                                             OwnershipKept const char *network,
                                             OwnershipKept const char *address, // disappears immediately
-                                            BREthereumSyncInterestSet interests,
+                                            unsigned int interests,
                                             uint64_t blockNumberStart,
                                             uint64_t blockNumberStop);
 
@@ -194,15 +190,6 @@ extern "C" {
         BRCryptoCWMClientETH eth;
         BRCryptoCWMClientGEN gen;
     } BRCryptoCWMClient;
-
-    extern BRWalletManagerClient
-    cryptoWalletManagerClientCreateBTCClient (OwnershipKept BRCryptoWalletManager cwm);
-
-    extern BREthereumClient
-    cryptoWalletManagerClientCreateETHClient (OwnershipKept BRCryptoWalletManager cwm);
-
-    extern BRGenericClient
-    cryptoWalletManagerClientCreateGENClient (BRCryptoWalletManager cwm);
 
     extern void
     cwmAnnounceGetBlockNumberSuccessAsInteger (OwnershipKept BRCryptoWalletManager cwm,


### PR DESCRIPTION
- Removed include statements for BTC/ETH in public headers (i.e. not BRCryptoXyzPrivate.h headers)
- Moved functions declarations that used BTC/ETH/GEN types to BRCryptoPrivate.h.
- Added include statements for system headers uncovered by cleanup

Potentially controversial change is to the `BRCryptoCWMEthGetBlocksCallback` declaration in `BRCryptoWalletManagerClient.h`. It was of type `BREthereumSyncInterestSet`. To achieve removal of ETH headers there, needed to change to its alias (unsigned int). Alternatively, could add a typedef for it? Or could add the header back?