### PR TITLE
CORE-458: In `coerceStringPrefaced()` return "0x0", not "0x".

### DIFF
--- a/ethereum/util/BRUtilMathParse.c
+++ b/ethereum/util/BRUtilMathParse.c
@@ -296,6 +296,8 @@ coerceString (UInt256 x, int base) {
             // Reverse and 'strip zeros'
             UInt256 xr = UInt256Reverse(x);  // TODO: LITTLE ENDIAN only
             int xrIndex = 0;
+            // We explicitly handled the '0 == x' case up-front.  Thus xr.u8 *always*
+            // eventually has a non-zero value.
             while (0 == xr.u8[xrIndex]) xrIndex++;
             // Encode
             return encodeHexCreate (NULL, &xr.u8[xrIndex], sizeof (xr.u8) - xrIndex);
@@ -343,8 +345,8 @@ coerceStringPrefaced (UInt256 x, int base, const char *preface) {
     if (NULL == preface || 0 == strcmp ("", preface)) return string;
     char *stringToFree = string; // save the pointer to string
 
-    // Strip off leading zeros in `string`
-    while ('\0' != string[0] && '0' == string[0]) string++;
+    // Strip off leading zeros in `string` but be sure to leave at least one digit
+    while ('\0' != string[0] && '0' == string[0] && '\0' != string[1]) string++;
 
     char *result = malloc (strlen(preface) + strlen (string) + 1);
     strcpy (result, preface);

--- a/ethereum/util/testUtil.c
+++ b/ethereum/util/testUtil.c
@@ -260,6 +260,40 @@ runMathCoerceTests () {
     assert (0 == strcmp (es, "0f"));  // unexpected
     free ((char *) es);
 
+    // Value: 0, w/ and w/o a prefix
+    UInt256 f = { .u64 = { 0, 0, 0, 0}};
+    const char *fs = coerceString (f, 10);
+    assert (0 == strcmp (fs, "0"));
+    free ((char *) fs);
+
+    fs = coerceStringPrefaced (f, 10, NULL);
+    assert (0 == strcmp (fs, "0"));
+    free ((char *) fs);
+
+    fs = coerceStringPrefaced (f, 10, "");
+    assert (0 == strcmp (fs, "0"));
+    free ((char *) fs);
+
+    fs = coerceStringPrefaced (f, 10, "hex");
+    assert (0 == strcmp (fs, "hex0"));
+    free ((char *) fs);
+
+    fs = coerceStringPrefaced (f, 16, "0x");
+    assert (0 == strcmp (fs, "0x0"));
+    free ((char *) fs);
+
+    UInt256 g = createUInt256(0x0a);
+    const char *gs = coerceString (g, 10);
+    assert (0 == strcmp (gs, "10"));
+    free ((char *) gs);
+
+    gs = coerceStringPrefaced (g, 10, NULL);
+    assert (0 == strcmp (gs, "10"));
+    free ((char *) gs);
+
+    gs = coerceStringPrefaced (g, 16, "0x");
+    assert (0 == strcmp (gs, "0xa"));
+    free ((char *) gs);
 }
 
 static void
@@ -382,6 +416,41 @@ runMathParseTests () {
 
     r = createUInt256ParseDecimal("2.5", 0, &status);
     assert (CORE_PARSE_UNDERFLOW == status);
+
+
+    // Strings for: 0xa
+
+    r = createUInt256Parse("0xa", 16, &status);
+    s = coerceStringPrefaced(r, 16, "0x");
+    assert (0 == strcmp ("0xa", s));
+    free (s);
+
+    r = createUInt256Parse("0x0a", 16, &status);
+    s = coerceStringPrefaced(r, 16, "0x");
+    assert (0 == strcmp ("0xa", s));
+    free (s);
+
+    r = createUInt256Parse("0x00a", 16, &status);
+    s = coerceStringPrefaced(r, 16, "0x");
+    assert (0 == strcmp ("0xa", s));
+    free (s);
+
+    // Strings for 0x0
+
+    r = createUInt256Parse("0x", 16, &status);
+    s = coerceStringPrefaced(r, 16, "0x");
+    assert (0 == strcmp ("0x0", s));
+    free (s);
+
+    r = createUInt256Parse("0x0", 16, &status);
+    s = coerceStringPrefaced(r, 16, "0x");
+    assert (0 == strcmp ("0x0", s));
+    free (s);
+
+    r = createUInt256Parse("0x00", 16, &status);
+    s = coerceStringPrefaced(r, 16, "0x");
+    assert (0 == strcmp ("0x0", s));
+    free (s);
 }
 
 extern void


### PR DESCRIPTION
Parsing of a string with a prefix of "0x" requires at least one digit after the "0x" prefix; ensure one exists.  Doing so ensures that 'parse (from string) <==> coerce (to string)' are reversible.