### PR TITLE
CORE-727: Handle an 'all zeros' string in createUInt256Parse()

### DIFF
--- a/ethereum/util/BRUtilMathParse.c
+++ b/ethereum/util/BRUtilMathParse.c
@@ -22,6 +22,7 @@
 //
 static BRCoreParseStatus
 parseInIntegerInBase (const char *number, int base) {
+    // This isn't the right way to handle an empty `number` string.
     if (NULL == number || '\0' == *number) return CORE_PARSE_STRANGE_DIGITS;
     while (*number) {
         switch (base) {
@@ -228,6 +229,12 @@ createUInt256Parse (const char *string, int base, BRCoreParseStatus *status) {
 
     // Strip leading '0's
     while ('0' == *string) string++;
+
+    // If the string is now empty, we've a value of '0'
+    if ('\0' == *string) {
+        *status = CORE_PARSE_OK;
+        return UINT256_ZERO;
+    }
 
     if ('\0' != *string && ('-' == *string || '+' == *string)) {
         *status = CORE_PARSE_STRANGE_DIGITS;

--- a/ethereum/util/testUtil.c
+++ b/ethereum/util/testUtil.c
@@ -355,6 +355,28 @@ runMathParseTests () {
             && r.u64[2] == 0
             && r.u64[3] == 0);
 
+    r = createUInt256Parse("0000", 10, &status);
+    assert (CORE_PARSE_OK == status && eqUInt256 (r, UINT256_ZERO));
+
+    r = createUInt256Parse("0000", 2, &status);
+    assert (CORE_PARSE_OK == status && eqUInt256 (r, UINT256_ZERO));
+
+    r = createUInt256Parse("0x0000", 16, &status);
+    assert (CORE_PARSE_OK == status && eqUInt256 (r, UINT256_ZERO));
+
+    r = createUInt256Parse("0x", 16, &status);
+    assert (CORE_PARSE_OK == status && eqUInt256 (r, UINT256_ZERO));
+
+    r = createUInt256Parse("", 10, &status);
+    assert (CORE_PARSE_OK == status && eqUInt256 (r, UINT256_ZERO));
+
+    r = createUInt256Parse("", 2, &status);
+    assert (CORE_PARSE_OK == status && eqUInt256 (r, UINT256_ZERO));
+
+    r = createUInt256Parse("", 16, &status);
+    assert (CORE_PARSE_OK == status && eqUInt256 (r, UINT256_ZERO));
+
+
     char *s;
     r = createUInt256Parse("425693205796080237694414176550132631862392541400559", 10, &status);
     s = coerceString(r, 10);


### PR DESCRIPTION
Prior PR (for CORE-501) introduced an overly restrictive constraint in the parse.  The issue shows up when syncing the 'loan (mainnet)' wallet.