### PR TITLE
CORE-722: Add `system.wipe()`

### DIFF
--- a/Java/CoreCrypto/src/main/java/com/breadwallet/corecrypto/System.java
+++ b/Java/CoreCrypto/src/main/java/com/breadwallet/corecrypto/System.java
@@ -435,6 +435,22 @@ final class System implements com.breadwallet.crypto.System {
     }
 
     @Override
+    public void wipe(com.breadwallet.crypto.Network network) {
+        boolean found = false;
+        for (WalletManager walletManager: walletManagers) {
+            if (walletManager.getNetwork().equals(network)) {
+                found = true;
+                break;
+            }
+        }
+
+        // Racy - but if there is no wallet manager for `network`... then
+        if (!found) {
+            WalletManager.wipe(Network.from(network), storagePath);
+        }
+    }
+
+    @Override
     public void connectAll() {
         for (WalletManager manager: getWalletManagers()) {
             manager.connect(null);

--- a/Java/CoreCrypto/src/main/java/com/breadwallet/corecrypto/WalletManager.java
+++ b/Java/CoreCrypto/src/main/java/com/breadwallet/corecrypto/WalletManager.java
@@ -38,15 +38,20 @@ final class WalletManager implements com.breadwallet.crypto.WalletManager {
     private static final String TAG = WalletManager.class.getName();
 
     /* package */
+    static void wipe(Network network, String storagePath) {
+        BRCryptoWalletManager.wipe(network.getCoreBRCryptoNetwork(), storagePath);
+    }
+
+    /* package */
     static Optional<WalletManager> create(BRCryptoCWMListener listener,
-                                BRCryptoCWMClient client,
-                                Account account,
-                                Network network,
-                                WalletManagerMode mode,
-                                AddressScheme addressScheme,
-                                String storagePath,
-                                System system,
-                                SystemCallbackCoordinator callbackCoordinator) {
+                                          BRCryptoCWMClient client,
+                                          Account account,
+                                          Network network,
+                                          WalletManagerMode mode,
+                                          AddressScheme addressScheme,
+                                          String storagePath,
+                                          System system,
+                                          SystemCallbackCoordinator callbackCoordinator) {
         return BRCryptoWalletManager.create(
                 listener,
                 client,

--- a/Java/CoreNative/src/main/java/com/breadwallet/corenative/CryptoLibraryDirect.java
+++ b/Java/CoreNative/src/main/java/com/breadwallet/corenative/CryptoLibraryDirect.java
@@ -264,6 +264,7 @@ public final class CryptoLibraryDirect {
     public static native void cryptoWalletGive(Pointer obj);
 
     // crypto/BRCryptoWalletManager.h
+    public static native Pointer cryptoWalletManagerWipe(Pointer network, String path);
     public static native Pointer cryptoWalletManagerCreate(BRCryptoCWMListener.ByValue listener,
                                                            BRCryptoCWMClient.ByValue client,
                                                            Pointer account,

--- a/Java/CoreNative/src/main/java/com/breadwallet/corenative/crypto/BRCryptoWalletManager.java
+++ b/Java/CoreNative/src/main/java/com/breadwallet/corenative/crypto/BRCryptoWalletManager.java
@@ -31,6 +31,10 @@ import javax.annotation.Nullable;
 
 public class BRCryptoWalletManager extends PointerType {
 
+    public static void wipe(BRCryptoNetwork network, String path) {
+        CryptoLibraryDirect.cryptoWalletManagerWipe(network.getPointer(), path);
+    }
+
     public static Optional<BRCryptoWalletManager> create(BRCryptoCWMListener listener,
                                                          BRCryptoCWMClient client,
                                                          BRCryptoAccount account,

--- a/Java/Crypto/src/main/java/com/breadwallet/crypto/System.java
+++ b/Java/Crypto/src/main/java/com/breadwallet/crypto/System.java
@@ -144,6 +144,17 @@ public interface System {
                                 Set<Currency> currencies);
 
     /**
+     * Remove (aka 'wipe') the persistent storage associated with `network` at `path`.
+     *
+     * This should be used solely to recover from a failure of `createWalletManager`.  A failure
+     * to create a wallet manager is most likely due to corruption of the persistently stored data
+     * and the only way to recover is to wipe that data.
+     *
+     * @param network the network to wipe data for
+     */
+    void wipe(Network network);
+
+    /**
      * Connect all wallet managers.
      *
      * They will be connected w/o an explict NetworkPeer.

--- a/Java/CryptoDemo/src/main/java/com/breadwallet/cryptodemo/CoreSystemListener.java
+++ b/Java/CryptoDemo/src/main/java/com/breadwallet/cryptodemo/CoreSystemListener.java
@@ -53,54 +53,32 @@ public class CoreSystemListener implements SystemListener {
         this.currencyCodesNeeded = new ArrayList<>(currencyCodesNeeded);
     }
 
+    // SystemListener Handlers
+
     @Override
     public void handleSystemEvent(System system, SystemEvent event) {
-        Log.d(TAG, String.format("System: %s", event));
-
         ApplicationExecutors.runOnBlockingExecutor(() -> {
+            Log.d(TAG, String.format("System: %s", event));
+
             event.accept(new DefaultSystemEventVisitor<Void>() {
                 @Nullable
                 @Override
-                public Void visit(SystemManagerAddedEvent event) {
-                    WalletManager manager = event.getWalletManager();
-                    manager.connect(null);
+                public Void visit(SystemNetworkAddedEvent event) {
+                    createWalletManager(system, event.getNetwork());
                     return null;
                 }
 
                 @Nullable
                 @Override
-                public Void visit(SystemNetworkAddedEvent event) {
-                    Network network = event.getNetwork();
-
-                    boolean isNetworkNeeded = false;
-                    for (String currencyCode: currencyCodesNeeded) {
-                        Optional<? extends Currency> currency = network.getCurrencyByCode(currencyCode);
-                        if (currency.isPresent()) {
-                            isNetworkNeeded = true;
-                            break;
-                        }
-                    }
-
-                    if (isMainnet == network.isMainnet() && isNetworkNeeded) {
-                        WalletManagerMode mode = system.supportsWalletManagerMode(network, preferredMode) ?
-                                preferredMode : system.getDefaultWalletManagerMode(network);
-
-                        AddressScheme addressScheme = system.getDefaultAddressScheme(network);
-                        Log.d(TAG, String.format("Creating %s WalletManager with %s and %s", network, mode, addressScheme));
-                        checkState(system.createWalletManager(network, mode, addressScheme, Collections.emptySet()));
-                    }
+                public Void visit(SystemManagerAddedEvent event) {
+                    connectWalletManager(event.getWalletManager());
                     return null;
                 }
 
                 @Nullable
                 @Override
                 public Void visit(SystemDiscoveredNetworksEvent event) {
-                    Log.d(TAG, String.format("Currencies (Discovered): %s", event));
-                    for (Network network: event.getNetworks()) {
-                        for (Currency currency: network.getCurrencies()) {
-                            Log.d(TAG, String.format("    Currency: %s for %s", currency.getCode(), network.getName()));
-                        }
-                    }
+                    logDiscoveredCurrencies(event.getNetworks());
                     return null;
                 }
             });
@@ -109,24 +87,28 @@ public class CoreSystemListener implements SystemListener {
 
     @Override
     public void handleNetworkEvent(System system, Network network, NetworkEvent event) {
-        Log.d(TAG, String.format("Network: %s", event));
+        ApplicationExecutors.runOnBlockingExecutor(() -> {
+            Log.d(TAG, String.format("Network: %s", event));
+        });
     }
 
     @Override
     public void handleManagerEvent(System system, WalletManager manager, WalletManagerEvent event) {
-        Log.d(TAG, String.format("Manager (%s): %s", manager.getName(), event));
+        ApplicationExecutors.runOnBlockingExecutor(() -> {
+                Log.d(TAG, String.format("Manager (%s): %s", manager.getName(), event));
+        });
     }
 
     @Override
     public void handleWalletEvent(System system, WalletManager manager, Wallet wallet, WalletEvent event) {
-        Log.d(TAG, String.format("Wallet (%s:%s): %s", manager.getName(), wallet.getName(), event));
-
         ApplicationExecutors.runOnBlockingExecutor(() -> {
+            Log.d(TAG, String.format("Wallet (%s:%s): %s", manager.getName(), wallet.getName(), event));
+
             event.accept(new DefaultWalletEventVisitor<Void>() {
                 @Nullable
                 @Override
                 public Void visit(WalletCreatedEvent event) {
-                    Log.d(TAG, String.format("Wallet addresses: %s <--> %s", wallet.getSource(), wallet.getTarget()));
+                    logWalletAddresses(wallet);
                     return null;
                 }
             });
@@ -135,6 +117,50 @@ public class CoreSystemListener implements SystemListener {
 
     @Override
     public void handleTransferEvent(System system, WalletManager manager, Wallet wallet, Transfer transfer, TranferEvent event) {
-        Log.d(TAG, String.format("Transfer (%s:%s): %s", manager.getName(), wallet.getName(), event));
+        ApplicationExecutors.runOnBlockingExecutor(() -> {
+            Log.d(TAG, String.format("Transfer (%s:%s): %s", manager.getName(), wallet.getName(), event));
+        });
+    }
+
+    // Misc.
+
+    private void createWalletManager(System system, Network network) {
+        boolean isNetworkNeeded = false;
+        for (String currencyCode : currencyCodesNeeded) {
+            Optional<? extends Currency> currency = network.getCurrencyByCode(currencyCode);
+            if (currency.isPresent()) {
+                isNetworkNeeded = true;
+                break;
+            }
+        }
+
+        if (isMainnet == network.isMainnet() && isNetworkNeeded) {
+            WalletManagerMode mode = system.supportsWalletManagerMode(network, preferredMode) ?
+                    preferredMode : system.getDefaultWalletManagerMode(network);
+
+            AddressScheme addressScheme = system.getDefaultAddressScheme(network);
+            Log.d(TAG, String.format("Creating %s WalletManager with %s and %s", network, mode, addressScheme));
+            boolean success = system.createWalletManager(network, mode, addressScheme, Collections.emptySet());
+            if (!success) {
+                system.wipe(network);
+                checkState(system.createWalletManager(network, mode, addressScheme, Collections.emptySet()));
+            }
+        }
+    }
+
+    private void connectWalletManager(WalletManager walletManager) {
+        walletManager.connect(null);
+    }
+
+    private void logWalletAddresses(Wallet wallet) {
+        Log.d(TAG, String.format("Wallet addresses: %s <--> %s", wallet.getSource(), wallet.getTarget()));
+    }
+
+    private void logDiscoveredCurrencies(List<Network> networks) {
+        for (Network network: networks) {
+            for (Currency currency: network.getCurrencies()) {
+                Log.d(TAG, String.format("Discovered: %s for %s", currency.getCode(), network.getName()));
+            }
+        };
     }
 }

--- a/Swift/BRCrypto/BRCryptoSystem.swift
+++ b/Swift/BRCrypto/BRCryptoSystem.swift
@@ -373,6 +373,22 @@ public final class System {
         return true
     }
 
+    ///
+    /// Remove (aka 'wipe') the persistent storage associated with `network` at `path`.  This should
+    /// be used solely to recover from a failure of `createWalletManager`.  A failure to create
+    /// a wallet manager is most likely due to corruption of the persistently stored data and the
+    /// only way to recover is to wipe that data.
+    ///
+    /// - Parameters:
+    ///   - network: network to wipe data for
+    ///
+    public func wipe (network: Network) {
+        // Racy - but if there is no wallet manager for `network`... then
+        if !managers.contains { network == $0.network } {
+            cryptoWalletManagerWipe (network.core, path);
+        }
+    }
+
     // Wallets - derived as a 'flatMap' of the managers' wallets.
     public var wallets: [Wallet] {
         return managers.flatMap { $0.wallets }

--- a/Swift/BRCryptoDemo/CoreDemoListener.swift
+++ b/Swift/BRCryptoDemo/CoreDemoListener.swift
@@ -112,7 +112,14 @@ class CoreDemoListener: SystemListener {
                                                           mode: mode,
                                                           addressScheme: scheme,
                                                           currencies: currencies)
-                if !success { UIApplication.doError(network: network) }
+                if !success {
+                    system.wipe (network: network)
+                    let successRetry = system.createWalletManager (network: network,
+                                                                   mode: mode,
+                                                                   addressScheme: scheme,
+                                                                   currencies: currencies)
+                    if !successRetry { UIApplication.doError(network: network) }
+                }
             }
 
         case .managerAdded (let manager):

--- a/bitcoin/BRWalletManager.c
+++ b/bitcoin/BRWalletManager.c
@@ -1155,6 +1155,14 @@ BRWalletManagerSetFixedPeer (BRWalletManager manager,
 }
 
 extern void
+BRWalletManagerWipe (const BRChainParams *params,
+                      const char *baseStoragePath) {
+    const char *networkName  = getNetworkName  (params);
+    const char *currencyName = getCurrencyName (params);
+    fileServiceWipe (baseStoragePath, currencyName, networkName);
+}
+
+extern void
 BRWalletManagerScan (BRWalletManager manager) {
     BRWalletManagerScanToDepth (manager, SYNC_DEPTH_FROM_CREATION);
 }

--- a/bitcoin/BRWalletManager.h
+++ b/bitcoin/BRWalletManager.h
@@ -416,6 +416,10 @@ BRWalletManagerExtractFileServiceTypes (BRFileService fileService,
                                         const char **blocks,
                                         const char **peers);
 
+extern void
+BRWalletManagerWipe (const BRChainParams *params,
+                     const char *baseStoragePath);
+
 //
 // Mark: Wallet Sweeper
 //

--- a/crypto/BRCryptoWalletManager.c
+++ b/crypto/BRCryptoWalletManager.c
@@ -21,6 +21,7 @@
 
 #include "bitcoin/BRWalletManager.h"
 #include "ethereum/BREthereum.h"
+#include "support/BRFileService.h"
 
 static void
 cryptoWalletManagerRelease (BRCryptoWalletManager cwm);
@@ -117,6 +118,24 @@ cryptoWalletManagerCreateInternal (BRCryptoCWMListener listener,
     }
 
     return cwm;
+}
+
+extern void
+cryptoWalletManagerWipe (BRCryptoNetwork network,
+                         const char *path) {
+    switch (cryptoNetworkGetType(network)) {
+        case BLOCK_CHAIN_TYPE_BTC:
+            BRWalletManagerWipe (cryptoNetworkAsBTC(network), path);
+            break;
+
+        case BLOCK_CHAIN_TYPE_ETH:
+            ewmWipe (cryptoNetworkAsETH(network), path);
+            break;
+
+        case BLOCK_CHAIN_TYPE_GEN:
+            gwmWipe (cryptoNetworkGetCurrencyCode (network), path);
+            break;
+    }
 }
 
 extern BRCryptoWalletManager

--- a/crypto/BRCryptoWalletManager.h
+++ b/crypto/BRCryptoWalletManager.h
@@ -238,6 +238,10 @@ extern "C" {
                                      BRCryptoWallet wallet,
                                      BRCryptoTransfer transfer);
 
+    extern void
+    cryptoWalletManagerWipe (BRCryptoNetwork network,
+                             const char *path);
+
     DECLARE_CRYPTO_GIVE_TAKE (BRCryptoWalletManager, cryptoWalletManager);
 
     /// MARK: Wallet Migrator

--- a/ethereum/ewm/BREthereumEWM.c
+++ b/ethereum/ewm/BREthereumEWM.c
@@ -1094,6 +1094,12 @@ ewmUpdateMode (BREthereumEWM ewm,
     pthread_mutex_unlock (&ewm->lock);
 }
 
+extern void
+ewmWipe (BREthereumNetwork network,
+         const char *storagePath) {
+    fileServiceWipe (storagePath, "eth", networkGetName(network));
+}
+
 /// MARK: - Blocks
 
 extern uint64_t

--- a/ethereum/ewm/BREthereumEWM.h
+++ b/ethereum/ewm/BREthereumEWM.h
@@ -131,6 +131,10 @@ ewmUpdateMode (BREthereumEWM ewm,
 extern uint64_t
 ewmGetBlockHeight (BREthereumEWM ewm);
 
+extern void
+ewmWipe (BREthereumNetwork network,
+         const char *storagePath);
+
 /// MARK: - Wallets
 
 extern BREthereumWallet *

--- a/generic/BRGenericWalletManager.c
+++ b/generic/BRGenericWalletManager.c
@@ -268,6 +268,12 @@ gwmPeriodicDispatcher (BREventHandler handler,
     // End handling a BRD Sync
 }
 
+extern void
+gwmWipe (const char *type,
+         const char *storagePath) {
+    fileServiceWipe (storagePath, type, "mainnet");
+}
+
 /// MARK: - Announce
 
 // handle transfer

--- a/generic/BRGenericWalletManager.h
+++ b/generic/BRGenericWalletManager.h
@@ -124,6 +124,10 @@ extern "C" {
                         uint8_t *bytes,
                         size_t   bytesCount);
 
+    extern void
+    gwmWipe (const char *type,
+             const char *storagePath);
+
 #ifdef __cplusplus
 }
 #endif

--- a/support/BRFileService.c
+++ b/support/BRFileService.c
@@ -208,6 +208,17 @@ fileServiceCreateReturnError (BRFileService fs,
     return NULL;
 }
 
+static char *
+fileServiceCreateFilePath (const char *basePath,
+                           const char *currency,
+                           const char *network,
+                           const char *filename) {
+    size_t sdbPathLength = strlen (basePath) + 1 + strlen(currency) + 1 + strlen(network) + 1 + strlen (filename) + 1;
+    char   *sdbPath      = malloc (sdbPathLength);
+    sprintf (sdbPath, "%s/%s-%s-%s", basePath, currency, network, filename);
+    return sdbPath;
+}
+
 extern BRFileService
 fileServiceCreate (const char *basePath,
                    const char *currency,
@@ -258,9 +269,7 @@ fileServiceCreate (const char *basePath,
     fs->network  = strdup (network);
 
     // Locate the SQLITE Database
-    size_t sdbPathLength = strlen (basePath) + 1 + strlen(currency) + 1 + strlen(network) + 1 + strlen (FILE_SERVICE_SDB_FILENAME) + 1;
-    fs->sdbPath = malloc (sdbPathLength);
-    sprintf (fs->sdbPath, "%s/%s-%s-%s", basePath, currency, network, FILE_SERVICE_SDB_FILENAME);
+    fs->sdbPath = fileServiceCreateFilePath (basePath, currency, network, FILE_SERVICE_SDB_FILENAME);
 
     // Create/Open the SQLITE Database
     sqlite3_status_code status = sqlite3_open(fs->sdbPath, &fs->sdb);
@@ -826,11 +835,12 @@ fileServiceWipe (const char *basePath,
                  const char *network) {
 
     // Locate the SQLITE Database
-     size_t sdbPathLength = strlen (basePath) + 1 + strlen(currency) + 1 + strlen(network) + 1 + strlen (FILE_SERVICE_SDB_FILENAME) + 1;
-     char   *sdbPath      = malloc (sdbPathLength);
-     sprintf (sdbPath, "%s/%s-%s-%s", basePath, currency, network, FILE_SERVICE_SDB_FILENAME);
+    char *sdbPath = fileServiceCreateFilePath (basePath, currency, network, FILE_SERVICE_SDB_FILENAME);
 
-    return 0 == remove (sdbPath) ? 0 : errno;
+    // Remove it.
+    int   result  = 0 == remove (sdbPath) ? 0 : errno;
+    free (sdbPath);
+    return result;
 }
 
 extern UInt256

--- a/support/BRFileService.c
+++ b/support/BRFileService.c
@@ -820,6 +820,19 @@ fileServiceClearAll (BRFileService fs) {
     return success;
 }
 
+extern int
+fileServiceWipe (const char *basePath,
+                 const char *currency,
+                 const char *network) {
+
+    // Locate the SQLITE Database
+     size_t sdbPathLength = strlen (basePath) + 1 + strlen(currency) + 1 + strlen(network) + 1 + strlen (FILE_SERVICE_SDB_FILENAME) + 1;
+     char   *sdbPath      = malloc (sdbPathLength);
+     sprintf (sdbPath, "%s/%s-%s-%s", basePath, currency, network, FILE_SERVICE_SDB_FILENAME);
+
+    return 0 == remove (sdbPath) ? 0 : errno;
+}
+
 extern UInt256
 fileServiceGetIdentifier (BRFileService fs,
                           const char *type,

--- a/support/BRFileService.h
+++ b/support/BRFileService.h
@@ -232,4 +232,18 @@ fileServiceCreateFromTypeSpecfications (const char *basePath,
                                         size_t specificationsCount,
                                         BRFileServiceTypeSpecification *specfications);
 
+///
+/// Deletes file system data
+///
+/// @param basePath
+/// @param currency
+/// @param network
+///
+/// @return 0 on success, errno on failure
+///
+extern int
+fileServiceWipe (const char *basePath,
+                 const char *currency,
+                 const char *network);
+
 #endif /* BRFileService_h */


### PR DESCRIPTION
Rather than adding an argument to `cryptoWalletManagerCreate()` of `wipe` which a) changes the interface, b) is only used once in a million, c) needs to be propagated down to the BWM, EWM and GWM so that the proper file can be wiped, I added a new function `cryptoWalletManagerWipe()` which propagates down to BWM, EWM and GWM and is called one time in a million via a function on `System`.

Reasonable?  Would need a Java analogue. 

Example in CoreDemoListener.swift:
```
                if !success {
                    system.wipe (network: network)
                    let successRetry = system.createWalletManager (network: network,
                                                                   mode: mode,
                                                                   addressScheme: scheme,
                                                                   currencies: currencies)
                    if !successRetry { UIApplication.doError(network: network) }
                }
            }		
```