### PR TITLE
CORE-732: Add example of NetworkPeer in CryptoDemo

### DIFF
--- a/Java/CryptoDemo/src/main/java/com/breadwallet/cryptodemo/WalletListActivity.java
+++ b/Java/CryptoDemo/src/main/java/com/breadwallet/cryptodemo/WalletListActivity.java
@@ -112,9 +112,6 @@ public class WalletListActivity extends AppCompatActivity implements DefaultSyst
             case R.id.action_sync:
                 sync();
                 return true;
-            case R.id.action_reset:
-                reset();
-                return true;
             case R.id.action_wipe:
                 wipe();
                 return true;
@@ -249,13 +246,6 @@ public class WalletListActivity extends AppCompatActivity implements DefaultSyst
 
     private void updateFees() {
         ApplicationExecutors.runOnBlockingExecutor(() -> CoreCryptoApplication.getSystem().updateNetworkFees(null));
-    }
-
-    private void reset() {
-        ApplicationExecutors.runOnBlockingExecutor(() -> {
-            CoreCryptoApplication.resetSystem();
-            runOnUiThread(this::recreate);
-        });
     }
 
     private void wipe() {

--- a/Java/CryptoDemo/src/main/res/layout/layout_connect_with_peer.xml
+++ b/Java/CryptoDemo/src/main/res/layout/layout_connect_with_peer.xml
@@ -1,0 +1,80 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:orientation="vertical">
+
+    <TextView
+        android:labelFor="@id/address_view"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="10dp"
+        android:layout_marginStart="10dp"
+        android:layout_marginEnd="10dp"
+        android:layout_marginBottom="5dp"
+        android:text="Address"
+        tools:ignore="HardcodedText"/>
+
+    <EditText
+        android:id="@+id/address_view"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="5dp"
+        android:layout_marginStart="10dp"
+        android:layout_marginEnd="10dp"
+        android:layout_marginBottom="5dp"
+        android:inputType="number|numberDecimal"
+        android:digits="0123456789."
+        android:text="127.0.0.1"
+        tools:ignore="Autofill,HardcodedText" />
+
+    <TextView
+        android:labelFor="@id/port_view"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="10dp"
+        android:layout_marginStart="10dp"
+        android:layout_marginEnd="10dp"
+        android:layout_marginBottom="5dp"
+        android:text="Address"
+        tools:ignore="HardcodedText"/>
+
+    <EditText
+        android:id="@+id/port_view"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="5dp"
+        android:layout_marginStart="10dp"
+        android:layout_marginEnd="10dp"
+        android:layout_marginBottom="5dp"
+        android:inputType="number"
+        android:digits="0123456789"
+        android:text="8333"
+        tools:ignore="Autofill,HardcodedText" />
+
+    <TextView
+        android:labelFor="@id/pubkey_view"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="10dp"
+        android:layout_marginStart="10dp"
+        android:layout_marginEnd="10dp"
+        android:layout_marginBottom="5dp"
+        android:text="Public Key (Optional)"
+        tools:ignore="HardcodedText"/>
+
+    <EditText
+        android:id="@+id/pubkey_view"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="5dp"
+        android:layout_marginStart="10dp"
+        android:layout_marginEnd="10dp"
+        android:layout_marginBottom="10dp"
+        android:inputType="text"
+        tools:text="Public key goes here"
+        tools:ignore="Autofill" />
+
+</LinearLayout>

--- a/Java/CryptoDemo/src/main/res/menu/menu_transfer_list.xml
+++ b/Java/CryptoDemo/src/main/res/menu/menu_transfer_list.xml
@@ -8,6 +8,11 @@
         app:showAsAction="never"
         tools:ignore="HardcodedText"/>
 
+    <item android:id="@+id/action_connect_with_peer"
+        android:title="Connect with Peer"
+        app:showAsAction="never"
+        tools:ignore="HardcodedText"/>
+
     <item android:id="@+id/action_disconnect"
         android:title="Disconnect"
         app:showAsAction="never"

--- a/Java/CryptoDemo/src/main/res/menu/menu_wallet_list.xml
+++ b/Java/CryptoDemo/src/main/res/menu/menu_wallet_list.xml
@@ -28,11 +28,6 @@
         app:showAsAction="never"
         tools:ignore="HardcodedText"/>
 
-    <item android:id="@+id/action_reset"
-        android:title="Reset"
-        app:showAsAction="never"
-        tools:ignore="HardcodedText" />
-
     <item android:id="@+id/action_wipe"
         android:title="Wipe"
         app:showAsAction="never"


### PR DESCRIPTION
@pbudelli asked about how to set a custom node for BTC so I added the functionality to the demo app.

Used the opportunity to add back the wipe-from-intent functionality (useful if the app is in a bad state on startup). Also removed the reset command (in CryptoDemo, was same as wipe command since the app doesn't have a list of selectable paper keys).