### PR TITLE
CORE-724: Handle BRWalletNew returning NULL in BRWalletManager

### DIFF
--- a/bitcoin/BRPeerManager.c
+++ b/bitcoin/BRPeerManager.c
@@ -268,8 +268,8 @@ static void _BRPeerManagerLoadBloomFilter(BRPeerManager *manager, BRPeer *peer)
     // every time a new wallet address is added, the bloom filter has to be rebuilt, and each address is only used
     // for one transaction, so here we generate some spare addresses to avoid rebuilding the filter each time a
     // wallet transaction is encountered during the chain sync
-    BRWalletUnusedAddrs(manager->wallet, NULL, SEQUENCE_GAP_LIMIT_EXTERNAL + 100, 0);
-    BRWalletUnusedAddrs(manager->wallet, NULL, SEQUENCE_GAP_LIMIT_INTERNAL + 100, 1);
+    BRWalletUnusedAddrs(manager->wallet, NULL, SEQUENCE_GAP_LIMIT_EXTERNAL_EXTENDED, SEQUENCE_EXTERNAL_CHAIN);
+    BRWalletUnusedAddrs(manager->wallet, NULL, SEQUENCE_GAP_LIMIT_INTERNAL_EXTENDED, SEQUENCE_INTERNAL_CHAIN);
 
     BRSetApply(manager->orphans, NULL, _setApplyFreeBlock);
     BRSetClear(manager->orphans); // clear out orphans that may have been received on an old filter
@@ -968,8 +968,8 @@ static void _peerRelayedTx(void *info, BRTransaction *tx)
 
             // the transaction likely consumed one or more wallet addresses, so check that at least the next <gap limit>
             // unused addresses are still matched by the bloom filter
-            BRWalletUnusedAddrs(manager->wallet, addrs, SEQUENCE_GAP_LIMIT_EXTERNAL, 0);
-            BRWalletUnusedAddrs(manager->wallet, addrs + SEQUENCE_GAP_LIMIT_EXTERNAL, SEQUENCE_GAP_LIMIT_INTERNAL, 1);
+            BRWalletUnusedAddrs(manager->wallet, addrs, SEQUENCE_GAP_LIMIT_EXTERNAL, SEQUENCE_EXTERNAL_CHAIN);
+            BRWalletUnusedAddrs(manager->wallet, addrs + SEQUENCE_GAP_LIMIT_EXTERNAL, SEQUENCE_GAP_LIMIT_INTERNAL, SEQUENCE_INTERNAL_CHAIN);
 
             for (size_t i = 0; i < SEQUENCE_GAP_LIMIT_EXTERNAL + SEQUENCE_GAP_LIMIT_INTERNAL; i++) {
                 if (! BRAddressHash160(&hash, manager->params->addrParams, addrs[i].s) ||

--- a/bitcoin/BRSyncManager.c
+++ b/bitcoin/BRSyncManager.c
@@ -1436,12 +1436,12 @@ BRClientSyncManagerScanStateInit (BRClientSyncManagerScanState scanState,
     assert (scanState->endBlockNumber > scanState->begBlockNumber);
 
     // generate addresses
-    BRWalletUnusedAddrs (wallet, NULL, SEQUENCE_GAP_LIMIT_EXTERNAL, 0);
-    BRWalletUnusedAddrs (wallet, NULL, SEQUENCE_GAP_LIMIT_INTERNAL, 1);
+    BRWalletUnusedAddrs (wallet, NULL, SEQUENCE_GAP_LIMIT_EXTERNAL, SEQUENCE_EXTERNAL_CHAIN);
+    BRWalletUnusedAddrs (wallet, NULL, SEQUENCE_GAP_LIMIT_INTERNAL, SEQUENCE_INTERNAL_CHAIN);
 
     // save the last known external and internal addresses
-    BRWalletUnusedAddrs(wallet, &scanState->lastExternalAddress, 1, 0);
-    BRWalletUnusedAddrs(wallet, &scanState->lastInternalAddress, 1, 1);
+    BRWalletUnusedAddrs(wallet, &scanState->lastExternalAddress, 1, SEQUENCE_EXTERNAL_CHAIN);
+    BRWalletUnusedAddrs(wallet, &scanState->lastInternalAddress, 1, SEQUENCE_INTERNAL_CHAIN);
 
     // save the current requestId
     scanState->requestId = rid;
@@ -1517,14 +1517,14 @@ BRClientSyncManagerScanStateAdvanceAndGetNewAddresses (BRClientSyncManagerScanSt
     BRArrayOf(char *) newAddresses = NULL;
 
     // generate addresses
-    BRWalletUnusedAddrs (wallet, NULL, SEQUENCE_GAP_LIMIT_EXTERNAL, 0);
-    BRWalletUnusedAddrs (wallet, NULL, SEQUENCE_GAP_LIMIT_INTERNAL, 1);
+    BRWalletUnusedAddrs (wallet, NULL, SEQUENCE_GAP_LIMIT_EXTERNAL, SEQUENCE_EXTERNAL_CHAIN);
+    BRWalletUnusedAddrs (wallet, NULL, SEQUENCE_GAP_LIMIT_INTERNAL, SEQUENCE_INTERNAL_CHAIN);
 
     // get the first unused address
     BRAddress externalAddress = BR_ADDRESS_NONE;
     BRAddress internalAddress = BR_ADDRESS_NONE;
-    BRWalletUnusedAddrs (wallet, &externalAddress, 1, 0);
-    BRWalletUnusedAddrs (wallet, &internalAddress, 1, 1);
+    BRWalletUnusedAddrs (wallet, &externalAddress, 1, SEQUENCE_EXTERNAL_CHAIN);
+    BRWalletUnusedAddrs (wallet, &internalAddress, 1, SEQUENCE_INTERNAL_CHAIN);
 
     // check if the first unused addresses have changed since last completion
     if (!BRAddressEq (&externalAddress, &scanState->lastExternalAddress) ||

--- a/bitcoin/BRWallet.c
+++ b/bitcoin/BRWallet.c
@@ -287,8 +287,8 @@ BRWallet *BRWalletNew(BRAddressParams addrParams, BRTransaction *transactions[],
         }
     }
     
-    BRWalletUnusedAddrs(wallet, NULL, SEQUENCE_GAP_LIMIT_EXTERNAL, SEQUENCE_EXTERNAL_CHAIN);
-    BRWalletUnusedAddrs(wallet, NULL, SEQUENCE_GAP_LIMIT_INTERNAL, SEQUENCE_INTERNAL_CHAIN);
+    BRWalletUnusedAddrs(wallet, NULL, SEQUENCE_GAP_LIMIT_EXTERNAL_EXTENDED, SEQUENCE_EXTERNAL_CHAIN);
+    BRWalletUnusedAddrs(wallet, NULL, SEQUENCE_GAP_LIMIT_INTERNAL_EXTENDED, SEQUENCE_INTERNAL_CHAIN);
 
     _BRWalletUpdateBalance(wallet);
 
@@ -808,8 +808,8 @@ int BRWalletRegisterTransaction(BRWallet *wallet, BRTransaction *tx)
 
     if (wasAdded) {
         // when a wallet address is used in a transaction, generate a new address to replace it
-        BRWalletUnusedAddrs(wallet, NULL, SEQUENCE_GAP_LIMIT_EXTERNAL, 0);
-        BRWalletUnusedAddrs(wallet, NULL, SEQUENCE_GAP_LIMIT_INTERNAL, 1);
+        BRWalletUnusedAddrs(wallet, NULL, SEQUENCE_GAP_LIMIT_EXTERNAL, SEQUENCE_EXTERNAL_CHAIN);
+        BRWalletUnusedAddrs(wallet, NULL, SEQUENCE_GAP_LIMIT_INTERNAL, SEQUENCE_INTERNAL_CHAIN);
         if (wallet->balanceChanged) wallet->balanceChanged(wallet->callbackInfo, wallet->balance);
         if (wallet->txAdded) wallet->txAdded(wallet->callbackInfo, tx);
     }

--- a/support/BRBIP32Sequence.h
+++ b/support/BRBIP32Sequence.h
@@ -40,10 +40,31 @@ extern "C" {
 
 #define BIP32_HARD                  0x80000000
 
-#define SEQUENCE_GAP_LIMIT_EXTERNAL 10
-#define SEQUENCE_GAP_LIMIT_INTERNAL 5
-#define SEQUENCE_EXTERNAL_CHAIN     0
-#define SEQUENCE_INTERNAL_CHAIN     1
+// Each chain has a standard gap limit, as well as an extended one. The extended
+// gap limit is used when constructing the P2P bloom filter, rather than the
+// standard one, as this construction is an "expensive" operation (requiring
+// a pause in syncing). Thus, to minimize this cost, a larger than standard
+// chain length is used to construct addresses for the filter's construction.
+//
+// A consequence of this (as found in CORE-724) is that the wallet's chains
+// need to be initialized with the extended length values. This is to avoid
+// the case where a wallet is being restored (i.e. synced from its key date,
+// with no blocks/transactions available initially) and a pending transaction
+// is reported from the mempool (based on the larger bloom filter address
+// chains). If the wallet were to be reconstructed with only that pending
+// transaction loaded from the persistent store, the logic in `BRWalletNew`
+// would not recognize the transaction as belonging to the wallet, assuming
+// that the addresses involved were beyond the standard gap limit, and the
+// function would return NULL.
+
+#define SEQUENCE_EXTERNAL_CHAIN              0
+#define SEQUENCE_INTERNAL_CHAIN              1
+
+#define SEQUENCE_GAP_LIMIT_EXTERNAL          10
+#define SEQUENCE_GAP_LIMIT_EXTERNAL_EXTENDED (SEQUENCE_GAP_LIMIT_EXTERNAL + 100)
+
+#define SEQUENCE_GAP_LIMIT_INTERNAL          5
+#define SEQUENCE_GAP_LIMIT_INTERNAL_EXTENDED (SEQUENCE_GAP_LIMIT_INTERNAL + 100)
 
 typedef struct {
     uint32_t fingerPrint;


### PR DESCRIPTION
Couple commits here that do the following:
- Update the gap length used in BRWalletNew to account for bloom filter construction
- Update BRWalletManagerNew to handle BRWalletNew returning NULL
- Fix some "issues" in BRSyncManager (function call in macro means it was called twice, implicit cast)

For the "Update the gap length used in BRWalletNew to account for bloom filter construction" change, I tested by getting a wallet in the "bad state" outlined in the JIRA and then confirming that, with the fix, startup progressed normally.

For the "Update BRWalletManagerNew to handle BRWalletNew returning NULL" change, I tested by hitting each fail point in `BRWalletManagerNew` (via specific builds).