### PR TITLE
CORE-738: Update testSystemAppCurrencies for API behaviour

### DIFF
--- a/Java/CoreCrypto/src/androidTest/java/com/breadwallet/corecrypto/SystemAIT.java
+++ b/Java/CoreCrypto/src/androidTest/java/com/breadwallet/corecrypto/SystemAIT.java
@@ -93,17 +93,18 @@ public class SystemAIT {
         assertNotNull(network);
 
         assertTrue(network.getCurrencyByCode("eth").isPresent());
-        Optional<? extends Currency> fooCurrency = network.getCurrencyByCode("FOO");
-        assertTrue(fooCurrency.isPresent());
+        assertTrue(network.getCurrencyByCode("foo").isPresent());
+        assertFalse(network.getCurrencyByCode("FOO").isPresent());
 
-        assertEquals("erc20", fooCurrency.get().getType());
+        Currency fooCurrency = network.getCurrencyByCode("foo").get();
+        assertEquals("erc20", fooCurrency.getType());
 
-        Optional<? extends Unit> fooDefault = network.defaultUnitFor(fooCurrency.get());
+        Optional<? extends Unit> fooDefault = network.defaultUnitFor(fooCurrency);
         assertTrue(fooDefault.isPresent());
         assertEquals(UnsignedInteger.valueOf(10), fooDefault.get().getDecimals());
         assertEquals("foo", fooDefault.get().getSymbol());
 
-        Optional<? extends Unit> fooBase = network.baseUnitFor(fooCurrency.get());
+        Optional<? extends Unit> fooBase = network.baseUnitFor(fooCurrency);
         assertTrue(fooBase.isPresent());
         assertEquals(UnsignedInteger.ZERO, fooBase.get().getDecimals());
         assertEquals("fooi", fooBase.get().getSymbol());

--- a/Swift/BRCryptoTests/BRCryptoSystemTests.swift
+++ b/Swift/BRCryptoTests/BRCryptoSystemTests.swift
@@ -87,20 +87,21 @@ class BRCryptoSystemTests: BRCryptoSystemBaseTests {
         XCTAssertNotNil (network)
 
         XCTAssertNotNil (network.currencyBy(code: "eth"))
-        XCTAssertNotNil (network.currencyBy(code: "FOO"))
+        XCTAssertNotNil (network.currencyBy(code: "foo"))
+        XCTAssertNil    (network.currencyBy(code: "FOO"))
 
-        let fooCurrency = network.currencyBy(code: "FOO")!
+        let fooCurrency = network.currencyBy(code: "foo")!
         XCTAssertEqual("erc20",  fooCurrency.type)
 
         guard let fooDef = network.defaultUnitFor(currency: fooCurrency)
             else { XCTAssertTrue (false); return }
         XCTAssertEqual(10, fooDef.decimals)
-        XCTAssertEqual("FOO", fooDef.symbol)
+        XCTAssertEqual("foo", fooDef.symbol)
 
         guard let fooBase = network.baseUnitFor(currency: fooCurrency)
             else { XCTAssertTrue (false); return }
         XCTAssertEqual (0, fooBase.decimals)
-        XCTAssertEqual ("FOOI", fooBase.symbol)
+        XCTAssertEqual ("fooi", fooBase.symbol)
     }
 
     func testSystemModes () {


### PR DESCRIPTION
Tests were failing here; updated Swift/Java to match up with the implementation.