### PR TITLE
CORE-639: Define fileServiceReplace()

### DIFF
--- a/bitcoin/BRWalletManager.c
+++ b/bitcoin/BRWalletManager.c
@@ -1747,11 +1747,10 @@ _BRWalletManagerSyncEvent(void * context,
     switch (event.type) {
         case SYNC_MANAGER_SET_BLOCKS: {
             // filesystem changes are NOT queued; they are acted upon immediately
-            fileServiceClear(bwm->fileService, fileServiceTypeBlocks);
-
-            // !!!!!!!!!
-            // no break;
-            // !!!!!!!!!
+            fileServiceReplace (bwm->fileService, fileServiceTypeBlocks,
+                                (const void **) event.u.blocks.blocks,
+                                event.u.blocks.count);
+            break;
         }
         case SYNC_MANAGER_ADD_BLOCKS: {
             // filesystem changes are NOT queued; they are acted upon immediately
@@ -1759,14 +1758,12 @@ _BRWalletManagerSyncEvent(void * context,
                 fileServiceSave (bwm->fileService, fileServiceTypeBlocks, event.u.blocks.blocks[index]);
             break;
         }
-
         case SYNC_MANAGER_SET_PEERS: {
             // filesystem changes are NOT queued; they are acted upon immediately
-            fileServiceClear(bwm->fileService, fileServiceTypePeers);
-
-            // !!!!!!!!!
-            // no break;
-            // !!!!!!!!!
+            fileServiceReplace (bwm->fileService, fileServiceTypePeers,
+                                (const void **) event.u.peers.peers,
+                                event.u.peers.count);
+            break;
         }
         case SYNC_MANAGER_ADD_PEERS: {
             // filesystem changes are NOT queued; they are acted upon immediately
@@ -1774,7 +1771,6 @@ _BRWalletManagerSyncEvent(void * context,
                 fileServiceSave (bwm->fileService, fileServiceTypePeers, &event.u.peers.peers[index]);
             break;
         }
-
         case SYNC_MANAGER_CONNECTED: {
             bwmSignalWalletManagerEvent(bwm,
                                         (BRWalletManagerEvent) {

--- a/ethereum/ewm/BREthereumEWM.c
+++ b/ethereum/ewm/BREthereumEWM.c
@@ -1988,10 +1988,10 @@ ewmHandleSaveBlocks (BREthereumEWM ewm,
     size_t count = array_count(blocks);
 
     eth_log("EWM", "Save Blocks (Storage): %zu", count);
-    fileServiceClear(ewm->fs, ewmFileServiceTypeBlocks);
+    fileServiceReplace (ewm->fs, ewmFileServiceTypeBlocks,
+                        (const void **) blocks,
+                        count);
 
-    for (size_t index = 0; index < count; index++)
-        fileServiceSave (ewm->fs, ewmFileServiceTypeBlocks, blocks[index]);
     array_free (blocks);
 }
 
@@ -2001,10 +2001,9 @@ ewmHandleSaveNodes (BREthereumEWM ewm,
     size_t count = array_count(nodes);
 
     eth_log("EWM", "Save Nodes (Storage): %zu", count);
-    fileServiceClear(ewm->fs, ewmFileServiceTypeNodes);
-
-    for (size_t index = 0; index < count; index++)
-        fileServiceSave(ewm->fs, ewmFileServiceTypeNodes, nodes[index]);
+    fileServiceReplace (ewm->fs, ewmFileServiceTypeNodes,
+                        (const void **) nodes,
+                        count);
 
     array_free (nodes);
 }

--- a/support/BRFileService.c
+++ b/support/BRFileService.c
@@ -616,6 +616,8 @@ _fileServiceSave (BRFileService fs,
         return fileServiceFailedSDB (fs, needLock, status);
     }
 
+    sqlite3_reset (fs->sdbInsertStmt);
+
     if (needLock)
         pthread_mutex_unlock (&fs->lock);
 
@@ -739,6 +741,9 @@ fileServiceLoad (BRFileService fs,
             // but we'll continue and will try next time we load it.
             _fileServiceSave (fs, type, entity, 0);
     }
+
+    sqlite3_reset (fs->sdbSelectAllStmt);
+
     pthread_mutex_unlock (&fs->lock);
 
     if (dataBytes != dataBytesBuffer) free (dataBytes);
@@ -779,6 +784,8 @@ fileServiceRemove (BRFileService fs,
     if (SQLITE_DONE != status)
         return fileServiceFailedSDB (fs, 1, status);
 
+    sqlite3_reset (fs->sdbDeleteStmt);
+
     pthread_mutex_unlock (&fs->lock);
 
     return 1;
@@ -786,12 +793,13 @@ fileServiceRemove (BRFileService fs,
 
 static int
 fileServiceClearForType (BRFileService fs,
-                         BRFileServiceEntityType *entityType) {
+                         BRFileServiceEntityType *entityType,
+                         int needLock) {
     const char *type = entityType->type;
 
     sqlite3_status_code status;
 
-    pthread_mutex_lock (&fs->lock);
+    if (needLock) pthread_mutex_lock (&fs->lock);
     if (fs->sdbClosed)
         return fileServiceFailedImpl (fs, 1, NULL, NULL, "closed");
 
@@ -805,7 +813,9 @@ fileServiceClearForType (BRFileService fs,
     if (SQLITE_DONE != status)
         return fileServiceFailedSDB (fs, 1, status);
 
-    pthread_mutex_unlock (&fs->lock);
+    sqlite3_reset (fs->sdbDeleteAllTypeStmt);
+
+    if (needLock) pthread_mutex_unlock (&fs->lock);
 
     return 1;
 }
@@ -817,7 +827,7 @@ fileServiceClear (BRFileService fs,
     if (NULL == entityType)
         return fileServiceFailedImpl (fs, 0, NULL, NULL, "missed type");
 
-    return fileServiceClearForType(fs, entityType);
+    return fileServiceClearForType(fs, entityType, 1);
 }
 
 extern int
@@ -825,8 +835,49 @@ fileServiceClearAll (BRFileService fs) {
     int success = 1;
     size_t typeCount = array_count(fs->entityTypes);
     for (size_t index = 0; index < typeCount; index++)
-        success &= fileServiceClearForType (fs, &fs->entityTypes[index]);
+        success &= fileServiceClearForType (fs, &fs->entityTypes[index], 1);
     return success;
+}
+
+static int
+fileServiceReplaceFailed (BRFileService fs, int needUnlock) {
+    if (needUnlock) pthread_mutex_unlock (&fs->lock);
+    return 0;
+}
+
+extern int
+fileServiceReplace (BRFileService fs,
+                    const char *type,
+                    const void **entities,
+                    size_t entitiesCount) {
+    BRFileServiceEntityType *entityType = fileServiceLookupType (fs, type);
+    if (NULL == entityType)
+        return fileServiceFailedImpl (fs, 0, NULL, NULL, "missed type");
+
+    sqlite3_status_code status;
+
+    pthread_mutex_lock (&fs->lock);
+    if (fs->sdbClosed)
+        return fileServiceFailedImpl (fs, 1, NULL, NULL, "closed");
+
+    status = sqlite3_exec (fs->sdb, "BEGIN", NULL, NULL, NULL);
+    if (SQLITE_OK != status)
+        return fileServiceFailedSDB (fs, 1, status);
+
+    if (0 == fileServiceClearForType (fs, entityType, 0))
+        return fileServiceReplaceFailed (fs, 1);
+
+    for (size_t index = 0; index < entitiesCount; index++)
+        if (0 == _fileServiceSave (fs, type, entities[index], 0))
+            return fileServiceReplaceFailed (fs, 1);
+
+    status = sqlite3_exec (fs->sdb, "COMMIT", NULL, NULL, NULL);
+    if (SQLITE_OK != status)
+        return fileServiceFailedSDB (fs, 1, status);
+
+    pthread_mutex_unlock (&fs->lock);
+
+    return 1;
 }
 
 extern int

--- a/support/BRFileService.c
+++ b/support/BRFileService.c
@@ -616,6 +616,7 @@ _fileServiceSave (BRFileService fs,
         return fileServiceFailedSDB (fs, needLock, status);
     }
 
+    // Ensure the 'implicit DB transaction' is committed.
     sqlite3_reset (fs->sdbInsertStmt);
 
     if (needLock)
@@ -652,6 +653,7 @@ fileServiceLoad (BRFileService fs,
         return fileServiceFailedImpl (fs, 1, NULL, NULL, "closed");
 
     sqlite3_reset (fs->sdbSelectAllStmt);
+    sqlite3_clear_bindings (fs->sdbSelectAllStmt);
 
     status = sqlite3_bind_text (fs->sdbSelectAllStmt, 1, type, -1, SQLITE_STATIC);
     if (SQLITE_OK != status)
@@ -742,6 +744,7 @@ fileServiceLoad (BRFileService fs,
             _fileServiceSave (fs, type, entity, 0);
     }
 
+    // Ensure the 'implicit DB transaction' is committed.
     sqlite3_reset (fs->sdbSelectAllStmt);
 
     pthread_mutex_unlock (&fs->lock);
@@ -771,6 +774,7 @@ fileServiceRemove (BRFileService fs,
         return fileServiceFailedImpl (fs, 1, NULL, NULL, "closed");
 
     sqlite3_reset (fs->sdbDeleteStmt);
+    sqlite3_clear_bindings (fs->sdbDeleteStmt);
 
     status = sqlite3_bind_text (fs->sdbDeleteStmt, 1, type, -1, SQLITE_STATIC);
     if (SQLITE_OK != status)
@@ -784,6 +788,7 @@ fileServiceRemove (BRFileService fs,
     if (SQLITE_DONE != status)
         return fileServiceFailedSDB (fs, 1, status);
 
+    // Ensure the 'implicit DB transaction' is committed.
     sqlite3_reset (fs->sdbDeleteStmt);
 
     pthread_mutex_unlock (&fs->lock);
@@ -804,6 +809,7 @@ fileServiceClearForType (BRFileService fs,
         return fileServiceFailedImpl (fs, 1, NULL, NULL, "closed");
 
     sqlite3_reset (fs->sdbDeleteAllTypeStmt);
+    sqlite3_clear_bindings (fs->sdbDeleteAllTypeStmt);
 
     status = sqlite3_bind_text (fs->sdbDeleteAllTypeStmt, 1, type, -1, SQLITE_STATIC);
     if (SQLITE_OK != status)
@@ -813,6 +819,7 @@ fileServiceClearForType (BRFileService fs,
     if (SQLITE_DONE != status)
         return fileServiceFailedSDB (fs, 1, status);
 
+    // Ensure the 'implicit DB transaction' is committed.
     sqlite3_reset (fs->sdbDeleteAllTypeStmt);
 
     if (needLock) pthread_mutex_unlock (&fs->lock);

--- a/support/BRFileService.h
+++ b/support/BRFileService.h
@@ -139,6 +139,12 @@ fileServiceRemove (BRFileService fs,
                    UInt256 identifier);
 
 extern int
+fileServiceReplace (BRFileService fs,
+                    const char *type,
+                    const void **entities,
+                    size_t entitiesCount);
+
+extern int
 fileServiceClear (BRFileService fs,
                   const char *type);
 


### PR DESCRIPTION
I've tested this by aborting the Demo App after the 'clear' and before any 'save' within the BEGIN/COMMIT block.  The old DB content remained, with all blocks in existence before the 'clear'.

But, looking for a careful eye!