### PR TITLE
CORE-774: Remove `BRCryptoBlockChainType` from the public interface.

### DIFF
--- a/Swift/BRCore.xcodeproj/project.pbxproj
+++ b/Swift/BRCore.xcodeproj/project.pbxproj
@@ -612,6 +612,7 @@
 		3C7BE5AF230F0BFB005FD4CD /* WalletManagerViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WalletManagerViewController.swift; sourceTree = "<group>"; };
 		3C812EBE2266675E0007D335 /* BRRipple.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = BRRipple.h; sourceTree = "<group>"; };
 		3C812EC12266721E0007D335 /* testRipple.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = testRipple.c; sourceTree = "<group>"; };
+		3C8380A523A0381800CC3674 /* BRCryptoBaseP.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = BRCryptoBaseP.h; sourceTree = "<group>"; };
 		3C9025EE21063AD200143B69 /* testUtil.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = testUtil.c; sourceTree = "<group>"; };
 		3C9025F021063BDC00143B69 /* testRlp.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = testRlp.c; sourceTree = "<group>"; };
 		3C9025F221064B6700143B69 /* testEvent.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = testEvent.c; sourceTree = "<group>"; };
@@ -1371,6 +1372,7 @@
 			isa = PBXGroup;
 			children = (
 				3C97E25D22430AA1003FD88F /* BRCryptoPrivate.h */,
+				3C8380A523A0381800CC3674 /* BRCryptoBaseP.h */,
 				3C56C97C22F8F8C20054AD21 /* BRCryptoStatus.c */,
 				3CCC61E7228C6C2000C0A13E /* BRCryptoHash.c */,
 				3C97E2332241658E003FD88F /* BRCryptoCurrency.c */,

--- a/crypto/BRCryptoAddressP.h
+++ b/crypto/BRCryptoAddressP.h
@@ -11,7 +11,7 @@
 #ifndef BRCryptoAddressP_h
 #define BRCryptoAddressP_h
 
-#include "BRCryptoBase.h"
+#include "BRCryptoBaseP.h"
 #include "BRCryptoAddress.h"
 
 #include "bcash/BRBCashAddr.h"

--- a/crypto/BRCryptoBaseP.h
+++ b/crypto/BRCryptoBaseP.h
@@ -1,0 +1,27 @@
+//
+//  BRCryptoBaseP.h
+//  BRCore
+//
+//  Created by Ed Gamble on 12/10/19.
+//  Copyright © 2019 Breadwinner AG. All rights reserved.
+//
+//  See the LICENSE file at the project root for license information.
+//  See the CONTRIBUTORS file at the project root for a list of contributors.
+
+#ifndef BRCryptoBaseP_h
+#define BRCryptoBaseP_h
+
+#include "BRCryptoBase.h"
+
+/// Private-ish
+///
+/// This is an implementation detail
+///
+typedef enum {
+    BLOCK_CHAIN_TYPE_BTC,
+    BLOCK_CHAIN_TYPE_ETH,
+    BLOCK_CHAIN_TYPE_GEN
+} BRCryptoBlockChainType;
+
+
+#endif /* BRCryptoBaseP_h */

--- a/crypto/BRCryptoFeeBasis.c
+++ b/crypto/BRCryptoFeeBasis.c
@@ -78,7 +78,7 @@ cryptoFeeBasisRelease (BRCryptoFeeBasis feeBasis) {
     free (feeBasis);
 }
 
-extern BRCryptoBlockChainType
+private_extern BRCryptoBlockChainType
 cryptoFeeBasisGetType (BRCryptoFeeBasis feeBasis) {
     return feeBasis->type;
 }

--- a/crypto/BRCryptoFeeBasisP.h
+++ b/crypto/BRCryptoFeeBasisP.h
@@ -10,6 +10,7 @@
 #define BRCryptoFeeBasisP_h
 
 #include "BRCryptoFeeBasis.h"
+#include "BRCryptoBaseP.h"
 
 #include "ethereum/BREthereum.h"
 #include "generic/BRGeneric.h"
@@ -34,6 +35,9 @@ struct BRCryptoFeeBasisRecord {
     BRCryptoUnit unit;
     BRCryptoRef ref;
 };
+
+private_extern BRCryptoBlockChainType
+cryptoFeeBasisGetType (BRCryptoFeeBasis feeBasis);
 
  private_extern uint64_t
  cryptoFeeBasisAsBTC (BRCryptoFeeBasis feeBasis);

--- a/crypto/BRCryptoHash.c
+++ b/crypto/BRCryptoHash.c
@@ -10,6 +10,8 @@
 //
 
 #include "BRCryptoHash.h"
+#include "BRCryptoBaseP.h"
+
 #include "support/BRInt.h"
 #include "ethereum/base/BREthereumHash.h"
 #include "ethereum/util/BRUtilHex.h"

--- a/crypto/BRCryptoNetwork.c
+++ b/crypto/BRCryptoNetwork.c
@@ -196,7 +196,7 @@ cryptoNetworkRelease (BRCryptoNetwork network) {
     free (network);
 }
 
-extern BRCryptoBlockChainType
+private_extern BRCryptoBlockChainType
 cryptoNetworkGetType (BRCryptoNetwork network) {
     return network->type;
 }

--- a/crypto/BRCryptoNetworkP.h
+++ b/crypto/BRCryptoNetworkP.h
@@ -13,7 +13,7 @@
 
 #include <pthread.h>
 
-#include "BRCryptoBase.h"
+#include "BRCryptoBaseP.h"
 #include "BRCryptoNetwork.h"
 
 #include "bitcoin/BRChainParams.h"
@@ -90,6 +90,8 @@ struct BRCryptoNetworkRecord {
     BRCryptoRef ref;
 };
 
+private_extern BRCryptoBlockChainType
+cryptoNetworkGetType (BRCryptoNetwork network);
 
  private_extern void
  cryptoNetworkAnnounce (BRCryptoNetwork network);

--- a/crypto/BRCryptoTransfer.c
+++ b/crypto/BRCryptoTransfer.c
@@ -229,7 +229,7 @@ cryptoTransferRelease (BRCryptoTransfer transfer) {
     free (transfer);
 }
 
-extern BRCryptoBlockChainType
+private_extern BRCryptoBlockChainType
 cryptoTransferGetType (BRCryptoTransfer transfer) {
     return transfer->type;
 }

--- a/crypto/BRCryptoTransferP.h
+++ b/crypto/BRCryptoTransferP.h
@@ -14,6 +14,7 @@
 #include <pthread.h>
 
 #include "BRCryptoTransfer.h"
+#include "BRCryptoBaseP.h"
 
 #include "bitcoin/BRWallet.h"
 #include "bitcoin/BRTransaction.h"
@@ -76,7 +77,8 @@ struct BRCryptoTransferRecord {
     BRCryptoRef ref;
 };
 
-/// MARK: Transfer
+private_extern BRCryptoBlockChainType
+cryptoTransferGetType (BRCryptoTransfer transfer);
 
 private_extern void
 cryptoTransferSetState (BRCryptoTransfer transfer,

--- a/crypto/BRCryptoWalletP.h
+++ b/crypto/BRCryptoWalletP.h
@@ -13,8 +13,8 @@
 
 #include <pthread.h>
 
-#include "BRCryptoBase.h"
 #include "BRCryptoWallet.h"
+#include "BRCryptoBaseP.h"
 
 #include "bitcoin/BRWallet.h"
 #include "bitcoin/BRWalletManager.h"

--- a/include/BRCryptoBase.h
+++ b/include/BRCryptoBase.h
@@ -44,14 +44,6 @@ extern "C" {
 
 #define AS_CRYPTO_BOOLEAN(zeroIfFalse)   ((zeroIfFalse) ? CRYPTO_TRUE : CRYPTO_FALSE)
 
-
-    // Private-ish
-    typedef enum {
-        BLOCK_CHAIN_TYPE_BTC,
-        BLOCK_CHAIN_TYPE_ETH,
-        BLOCK_CHAIN_TYPE_GEN
-    } BRCryptoBlockChainType;
-
     // Only for use in Swift/Java
     typedef size_t BRCryptoCount;
 

--- a/include/BRCryptoFeeBasis.h
+++ b/include/BRCryptoFeeBasis.h
@@ -21,9 +21,6 @@ extern "C" {
 
     typedef struct BRCryptoFeeBasisRecord *BRCryptoFeeBasis;
 
-    extern BRCryptoBlockChainType
-    cryptoFeeBasisGetType (BRCryptoFeeBasis feeBasis);
-
     extern BRCryptoAmount
     cryptoFeeBasisGetPricePerCostFactor (BRCryptoFeeBasis feeBasis);
 

--- a/include/BRCryptoNetwork.h
+++ b/include/BRCryptoNetwork.h
@@ -69,9 +69,6 @@ extern "C" {
 
     typedef void *BRCryptoNetworkListener;
 
-    extern BRCryptoBlockChainType
-    cryptoNetworkGetType (BRCryptoNetwork network);
-
     extern const char *
     cryptoNetworkGetUids (BRCryptoNetwork network);
 

--- a/include/BRCryptoTransfer.h
+++ b/include/BRCryptoTransfer.h
@@ -124,10 +124,6 @@ extern "C" {
         CRYPTO_TRANSFER_RECOVERED
     } BRCryptoTransferDirection;
 
-
-    extern BRCryptoBlockChainType
-    cryptoTransferGetType (BRCryptoTransfer transfer);
-
     /**
      * Returns the transfer's source address
      *


### PR DESCRIPTION
Requires no Swift change; seems no Java change either.