### PR TITLE
CORE-761: For Swift enums w/ CustomStringConvertible use C Functions

### DIFF
--- a/Swift/BRCrypto/BRCryptoNetwork.swift
+++ b/Swift/BRCrypto/BRCryptoNetwork.swift
@@ -322,14 +322,7 @@ public enum NetworkType: CustomStringConvertible {
     }
 
     public var description: String {
-        switch self {
-            case .btc: return "Bitcoin"
-            case .bch: return "Bitcoin Cash"
-            case .eth: return "Ethereum"
-//        case .xrp: return "Ripple"
-//        case .hbar: return "Hedera"
-
-        }
+        return asUTF8String (cryptoNetworkCanonicalTypeString (core))
     }
 }
 

--- a/Swift/BRCrypto/BRCryptoSystem.swift
+++ b/Swift/BRCrypto/BRCryptoSystem.swift
@@ -1920,54 +1920,18 @@ extension System {
 
 extension BRCryptoTransferEventType: CustomStringConvertible {
     public var description: String {
-        switch self {
-        case CRYPTO_TRANSFER_EVENT_CREATED: return "Created"
-        case CRYPTO_TRANSFER_EVENT_CHANGED: return "Changed"
-        case CRYPTO_TRANSFER_EVENT_DELETED: return "Deleted"
-        default: return "<<unknown>>"
-        }
+        return asUTF8String (cryptoTransferEventTypeString(self))
     }
 }
 
 extension BRCryptoWalletEventType: CustomStringConvertible {
     public var description: String {
-        switch self {
-        case CRYPTO_WALLET_EVENT_CREATED: return "Created"
-        case CRYPTO_WALLET_EVENT_CHANGED: return "Changed"
-        case CRYPTO_WALLET_EVENT_DELETED: return "Deleted"
-
-        case CRYPTO_WALLET_EVENT_TRANSFER_ADDED:     return "Transfer Added"
-        case CRYPTO_WALLET_EVENT_TRANSFER_CHANGED:   return "Transfer Changed"
-        case CRYPTO_WALLET_EVENT_TRANSFER_SUBMITTED: return "Transfer Submitted"
-        case CRYPTO_WALLET_EVENT_TRANSFER_DELETED:   return "Transfer Deleted"
-
-        case CRYPTO_WALLET_EVENT_BALANCE_UPDATED:   return "Balance Updated"
-        case CRYPTO_WALLET_EVENT_FEE_BASIS_UPDATED: return "FeeBasis Updated"
-        case CRYPTO_WALLET_EVENT_FEE_BASIS_ESTIMATED: return "FeeBasis Estimated"
-
-        default: return "<<unknown>>"
-        }
+        return asUTF8String (cryptoWalletEventTypeString (self))
     }
 }
 
 extension BRCryptoWalletManagerEventType: CustomStringConvertible {
     public var description: String {
-        switch self {
-        case CRYPTO_WALLET_MANAGER_EVENT_CREATED: return "Created"
-        case CRYPTO_WALLET_MANAGER_EVENT_CHANGED: return "Changed"
-        case CRYPTO_WALLET_MANAGER_EVENT_DELETED: return "Deleted"
-
-        case CRYPTO_WALLET_MANAGER_EVENT_WALLET_ADDED:   return "Wallet Added"
-        case CRYPTO_WALLET_MANAGER_EVENT_WALLET_CHANGED: return "Wallet Changed"
-        case CRYPTO_WALLET_MANAGER_EVENT_WALLET_DELETED: return "Wallet Deleted"
-
-        // wallet: added, ...
-        case CRYPTO_WALLET_MANAGER_EVENT_SYNC_STARTED:   return "Sync Started"
-        case CRYPTO_WALLET_MANAGER_EVENT_SYNC_CONTINUES: return "Sync Continues"
-        case CRYPTO_WALLET_MANAGER_EVENT_SYNC_STOPPED:   return "Sync Stopped"
-
-        case CRYPTO_WALLET_MANAGER_EVENT_BLOCK_HEIGHT_UPDATED: return "Block Height Updated"
-        default: return "<<unknown>>"
-        }
+        return asUTF8String (cryptoWalletManagerEventTypeString (self))
     }
 }

--- a/crypto/BRCryptoNetwork.c
+++ b/crypto/BRCryptoNetwork.c
@@ -20,6 +20,21 @@
 
 #include <stdbool.h>
 
+/// MARK: - Network Canonical Type
+
+extern const char *
+cryptoNetworkCanonicalTypeString (BRCryptoNetworkCanonicalType type) {
+    static const char *strings[NUMBER_OF_NETWORK_TYPES] = {
+        "CRYPTO_NETWORK_TYPE_BTC",
+        "CRYPTO_NETWORK_TYPE_BCH",
+        "CRYPTO_NETWORK_TYPE_ETH",
+        // "Ripple",
+        // "Hedera"
+    };
+    assert (type < NUMBER_OF_NETWORK_TYPES);
+    return strings[type];
+}
+
 /// MARK: - Network Fee
 
 IMPLEMENT_CRYPTO_GIVE_TAKE (BRCryptoNetworkFee, cryptoNetworkFee)

--- a/crypto/BRCryptoTransfer.c
+++ b/crypto/BRCryptoTransfer.c
@@ -20,6 +20,24 @@
 #include "bitcoin/BRTransaction.h"
 #include "ethereum/BREthereum.h"
 
+/// MARK: - Transfer State Type
+
+extern const char *
+cryptoTransferStateTypeString (BRCryptoTransferStateType type) {
+    static const char *strings[] = {
+        "CRYPTO_TRANSFER_STATE_CREATED",
+        "CRYPTO_TRANSFER_STATE_SIGNED",
+        "CRYPTO_TRANSFER_STATE_SUBMITTED",
+        "CRYPTO_TRANSFER_STATE_INCLUDED",
+        "CRYPTO_TRANSFER_STATE_ERRORED",
+        "CRYPTO_TRANSFER_STATE_DELETED",
+    };
+    assert (CRYPTO_TRANSFER_EVENT_CREATED <= type && type <= CRYPTO_TRANSFER_STATE_DELETED);
+    return strings[type];
+}
+
+/// MARK: Transfer
+
 static BRCryptoTransferDirection
 cryptoTransferDirectionFromBTC (uint64_t send, uint64_t recv, uint64_t fee);
 

--- a/include/BRCryptoNetwork.h
+++ b/include/BRCryptoNetwork.h
@@ -33,16 +33,15 @@ extern "C" {
         CRYPTO_NETWORK_TYPE_BTC,
         CRYPTO_NETWORK_TYPE_BCH,
         CRYPTO_NETWORK_TYPE_ETH,
-#if defined (NEED_XRP)
-        CRYPTO_NETWORK_TYPE_XRP,
-#endif
+        // CRYPTO_NETWORK_TYPE_XRP,
+        // CRYPTO_NETWORK_TYPE_HBAR,
+        // CRYPTO_NETWORK_TYPE_XLM,
     } BRCryptoNetworkCanonicalType;
 
-#if defined (NEED_XRP)
-#  define NUMBER_OF_NETWORK_TYPES    (1 + CRYPTO_NETWORK_TYPE_XRP)
-#else
 #  define NUMBER_OF_NETWORK_TYPES    (1 + CRYPTO_NETWORK_TYPE_ETH)
-#endif
+
+    extern const char *
+    cryptoNetworkCanonicalTypeString (BRCryptoNetworkCanonicalType type);
 
     /// MARK: - (Network) Address Scheme
 

--- a/include/BRCryptoTransfer.h
+++ b/include/BRCryptoTransfer.h
@@ -63,6 +63,9 @@ extern "C" {
         CRYPTO_TRANSFER_STATE_DELETED,
     } BRCryptoTransferStateType;
 
+    extern const char *
+    cryptoTransferStateTypeString (BRCryptoTransferStateType type);
+
     typedef struct {
         BRCryptoTransferStateType type;
         union {


### PR DESCRIPTION
A small Swift cleanup.