### PR TITLE
CORE-778: Define cryptoWalletHasAddress

### DIFF
--- a/Java/corecrypto/src/main/java/com/breadwallet/corecrypto/Wallet.java
+++ b/Java/corecrypto/src/main/java/com/breadwallet/corecrypto/Wallet.java
@@ -20,7 +20,6 @@ import com.breadwallet.corenative.crypto.BRCryptoWalletSweeper;
 import com.breadwallet.crypto.AddressScheme;
 import com.breadwallet.crypto.WalletState;
 import com.breadwallet.crypto.errors.FeeEstimationError;
-import com.breadwallet.crypto.errors.FeeEstimationInsufficientFundsError;
 import com.breadwallet.crypto.errors.LimitEstimationError;
 import com.breadwallet.crypto.errors.LimitEstimationInsufficientFundsError;
 import com.breadwallet.crypto.errors.LimitEstimationServiceFailureError;
@@ -378,8 +377,8 @@ final class Wallet implements com.breadwallet.crypto.Wallet {
     }
 
     @Override
-    public Address getSource() {
-        return Address.create(core.getSourceAddress(Utilities.addressSchemeToCrypto(walletManager.getAddressScheme())));
+    public boolean containsAddress(com.breadwallet.crypto.Address address) {
+        return core.containsAddress(Address.from(address).getCoreBRCryptoAddress());
     }
 
     @Override

--- a/Java/corenative/src/main/java/com/breadwallet/corenative/CryptoLibraryDirect.java
+++ b/Java/corenative/src/main/java/com/breadwallet/corenative/CryptoLibraryDirect.java
@@ -263,6 +263,7 @@ public final class CryptoLibraryDirect {
     public static native Pointer cryptoWalletGetTransfers(Pointer wallet, SizeTByReference count);
     public static native int cryptoWalletHasTransfer(Pointer wallet, Pointer transfer);
     public static native Pointer cryptoWalletGetAddress(Pointer wallet, int addressScheme);
+    public static native int cryptoWalletHasAddress(Pointer wallet, Pointer address);
     public static native Pointer cryptoWalletGetUnit(Pointer wallet);
     public static native Pointer cryptoWalletGetUnitForFee(Pointer wallet);
     public static native Pointer cryptoWalletGetCurrency(Pointer wallet);

--- a/Java/corenative/src/main/java/com/breadwallet/corenative/crypto/BRCryptoWallet.java
+++ b/Java/corenative/src/main/java/com/breadwallet/corenative/crypto/BRCryptoWallet.java
@@ -89,16 +89,17 @@ public class BRCryptoWallet extends PointerType {
         return BRCryptoWalletState.fromCore(CryptoLibraryDirect.cryptoWalletGetState(thisPtr));
     }
 
-    public BRCryptoAddress getSourceAddress(BRCryptoAddressScheme addressScheme) {
+    public BRCryptoAddress getTargetAddress(BRCryptoAddressScheme addressScheme) {
         Pointer thisPtr = this.getPointer();
 
         return new BRCryptoAddress(CryptoLibraryDirect.cryptoWalletGetAddress(thisPtr, addressScheme.toCore()));
     }
 
-    public BRCryptoAddress getTargetAddress(BRCryptoAddressScheme addressScheme) {
-        Pointer thisPtr = this.getPointer();
-
-        return new BRCryptoAddress(CryptoLibraryDirect.cryptoWalletGetAddress(thisPtr, addressScheme.toCore()));
+    public boolean containsAddress(BRCryptoAddress address) {
+        return BRCryptoBoolean.CRYPTO_TRUE == CryptoLibraryDirect.cryptoWalletHasAddress(
+                this.getPointer(),
+                address.getPointer()
+        );
     }
 
     public Optional<BRCryptoFeeBasis> createTransferFeeBasis(BRCryptoAmount pricePerCostFactor, double costFactor) {

--- a/Java/crypto/src/main/java/com/breadwallet/crypto/Wallet.java
+++ b/Java/crypto/src/main/java/com/breadwallet/crypto/Wallet.java
@@ -101,7 +101,7 @@ public interface Wallet {
 
     Address getTargetForScheme(AddressScheme scheme);
 
-    Address getSource();
+    boolean containsAddress(Address address);
 
     Currency getCurrency();
 

--- a/Java/cryptodemo-android/src/main/java/com/breadwallet/cryptodemo/CoreSystemListener.java
+++ b/Java/cryptodemo-android/src/main/java/com/breadwallet/cryptodemo/CoreSystemListener.java
@@ -154,7 +154,7 @@ public class CoreSystemListener implements SystemListener {
     }
 
     private void logWalletAddresses(Wallet wallet) {
-        Log.log(Level.FINE, String.format("Wallet addresses: %s <--> %s", wallet.getSource(), wallet.getTarget()));
+        Log.log(Level.FINE, String.format("Wallet (target) addresses: %s", wallet.getTarget()));
     }
 
     private void logDiscoveredCurrencies(List<Network> networks) {

--- a/Swift/BRCrypto/BRCryptoWallet.swift
+++ b/Swift/BRCrypto/BRCryptoWallet.swift
@@ -54,18 +54,8 @@ public final class Wallet: Equatable {
         return WalletState (core: cryptoWalletGetState(core))
     }
 
-    /// The default TransferFeeBasis for created transfers.
-//    public var defaultFeeBasis: TransferFeeBasis {
-//        get {
-//            return TransferFeeBasis (core: cryptoWalletGetDefaultFeeBasis (core), take: false) }
-//        set {
-//            let defaultFeeBasis = newValue // rename, for clarity
-//            cryptoWalletSetDefaultFeeBasis (core, defaultFeeBasis.core);
-//        }
-//    }
-
     /// The default TransferFactory for creating transfers.
-    //    var transferFactory: TransferFactory { get set }
+    ///    var transferFactory: TransferFactory { get set }
 
     /// An address suitable for a transfer target (receiving).  Uses the default Address Scheme
     public var target: Address {
@@ -76,15 +66,17 @@ public final class Wallet: Equatable {
         return Address (core: cryptoWalletGetAddress (core, scheme.core), take: false)
     }
 
-    /// TODO: `var targets: [Address]`
+    /// TODO: `var {targets,sources}: [Address]` - for query needs?
 
-    /// TODO: Remove `source
-    /// An address suitable for a transfer source (sending).  Uses the default AddressScheme
-    public var source: Address {
-        return Address (core: cryptoWalletGetAddress (core, manager.addressScheme.core), take: false)
+    ///
+    /// Check if `address` is in `wallet`.  The address is considered in wallet if: a) it
+    /// has been used in a transaction or b) is the target address
+    ///
+    /// - Parameter address: the address to check
+    ///
+    public func hasAddress (_ address: Address) -> Bool {
+        return CRYPTO_TRUE == cryptoWalletHasAddress (core, address.core);
     }
-
-    /// TODO: `var sources: [Address]`
 
     /// The transfers of currency yielding `balance`
     public var transfers: [Transfer] {

--- a/Swift/BRCryptoTests/BRCryptoBaseTests.swift
+++ b/Swift/BRCryptoTests/BRCryptoBaseTests.swift
@@ -249,7 +249,7 @@ class CryptoTestSystemListener: SystemListener {
     var walletExpectation  = XCTestExpectation (description: "ManagerExpectation")
 
     func handleWalletEvent(system: System, manager: WalletManager, wallet: Wallet, event: WalletEvent) {
-        print ("TST: Wallet Event: \(event)")
+        print ("TST: Wallet (\(wallet.name)) Event: \(event)")
         walletEvents.append(event)
         walletHandlers.forEach { $0 (system, manager, wallet, event) }
     }

--- a/Swift/BRCryptoTests/BRCryptoTransferTests.swift
+++ b/Swift/BRCryptoTests/BRCryptoTransferTests.swift
@@ -83,7 +83,7 @@ class BRCryptoTransferTests: BRCryptoSystemBaseTests {
                                                                     ? 1565974068
                                                                     : 1565974410),
                                                                 fee: nil),
-                            hash: "f6d9bca3d4346ce75c151d1d8f061d56ff25e41a89553544b80d316f7d9ccedc",
+                            hash: "0xf6d9bca3d4346ce75c151d1d8f061d56ff25e41a89553544b80d316f7d9ccedc",
                             amount: UInt64(1000000))
         ]
     }
@@ -159,6 +159,14 @@ class BRCryptoTransferTests: BRCryptoSystemBaseTests {
         XCTAssertNotNil (wallet.transferBy(hash: transfer.hash!))
         XCTAssertNotNil (wallet.transferBy(core: transfer.core))
 
+        transfers.forEach {
+            if let address = (transfer.direction == TransferDirection.received
+                ? $0.target
+                : $0.source) {
+                XCTAssertTrue (wallet.hasAddress (address))
+            }
+            else { XCTAssertTrue(false) }
+        }
         // Events
 
         XCTAssertTrue (listener.checkSystemEventsCommonlyWith (network: network,

--- a/Swift/BRCryptoTests/BRCryptoWalletTests.swift
+++ b/Swift/BRCryptoTests/BRCryptoWalletTests.swift
@@ -187,7 +187,7 @@ class BRCryptoWalletTests: BRCryptoSystemBaseTests {
                 }
             }]
 
-        let network: Network! = system.networks.first { .btc == $0.type && isMainnet == $0.isMainnet }
+        let network: Network! = system.networks.first { .bch == $0.type && isMainnet == $0.isMainnet }
         XCTAssertNotNil (network)
 
         let manager: WalletManager! = system.managers.first { $0.network == network }
@@ -197,8 +197,9 @@ class BRCryptoWalletTests: BRCryptoSystemBaseTests {
         XCTAssertNotNil(wallet)
 
         // Checking the wallet address as BCHH
-        let walletAddress = wallet.source
+        let walletAddress = wallet.target
         XCTAssertTrue (walletAddress.description.starts (with: (isMainnet ? "bitcoincash" : "bchtest")))
+        XCTAssertTrue (wallet.hasAddress(walletAddress))
     }
 
     func testWalletETH() {
@@ -232,7 +233,7 @@ class BRCryptoWalletTests: BRCryptoSystemBaseTests {
 
         prepareSystem(listener: listener)
 
-        let network: Network! = system.networks.first { "eth" == $0.currency.code && isMainnet == $0.isMainnet }
+        let network: Network! = system.networks.first { .eth == $0.type && isMainnet == $0.isMainnet }
         XCTAssertNotNil (network)
 
         let manager: WalletManager! = system.managers.first { $0.network == network }
@@ -284,6 +285,7 @@ class BRCryptoWalletTests: BRCryptoSystemBaseTests {
         XCTAssertEqual (walletETH.state, WalletState.created)
         XCTAssertEqual (walletETH.target, walletETH.targetForScheme(manager.addressScheme))
         XCTAssertEqual (walletETH, walletETH)
+        XCTAssertTrue  (walletETH.hasAddress(walletETH.target));
 
 
         XCTAssertTrue  (system === walletBRD.system)
@@ -295,6 +297,6 @@ class BRCryptoWalletTests: BRCryptoSystemBaseTests {
         XCTAssertEqual (walletBRD.balance, Amount.create(integer: 0, unit: walletBRD.unit))
         XCTAssertEqual (walletBRD.state, WalletState.created)
         XCTAssertEqual (walletBRD.target, walletBRD.targetForScheme(manager.addressScheme))
-
+        XCTAssertTrue  (walletBRD.hasAddress(walletBRD.target))
     }
 }

--- a/ethereum/ewm/BREthereumEWM.c
+++ b/ethereum/ewm/BREthereumEWM.c
@@ -1494,6 +1494,19 @@ ewmWalletGetTransferCount(BREthereumEWM ewm,
     return count;
 }
 
+extern BREthereumAddress
+ewmWalletGetAddress (BREthereumEWM ewm,
+                     BREthereumWallet wallet) {
+    return walletGetAddress(wallet);
+}
+
+extern BREthereumBoolean
+ewmWalletHasAddress (BREthereumEWM ewm,
+                     BREthereumWallet wallet,
+                     BREthereumAddress address) {
+    return addressEqual(address, walletGetAddress(wallet));
+}
+
 extern BREthereumToken
 ewmWalletGetToken (BREthereumEWM ewm,
                    BREthereumWallet wallet) {

--- a/ethereum/ewm/BREthereumEWM.h
+++ b/ethereum/ewm/BREthereumEWM.h
@@ -152,6 +152,15 @@ ewmGetWalletHoldingToken(BREthereumEWM ewm,
 
 /// MARK: - Wallet
 
+extern BREthereumAddress
+ewmWalletGetAddress (BREthereumEWM ewm,
+                     BREthereumWallet wallet);
+
+extern BREthereumBoolean
+ewmWalletHasAddress (BREthereumEWM ewm,
+                     BREthereumWallet wallet,
+                     BREthereumAddress address);
+
 extern BREthereumToken
 ewmWalletGetToken (BREthereumEWM ewm,
                    BREthereumWallet wallet);

--- a/include/BRCryptoWallet.h
+++ b/include/BRCryptoWallet.h
@@ -159,6 +159,14 @@ extern "C" {
     cryptoWalletGetAddress (BRCryptoWallet wallet,
                             BRCryptoAddressScheme addressScheme);
 
+    /**
+     * Check if `wallet` has `address`.  Checks that `address` has been used already by `wallet`
+     * or if `address` is the *next* address from `wallet`
+     */
+    extern BRCryptoBoolean
+    cryptoWalletHasAddress (BRCryptoWallet wallet,
+                            BRCryptoAddress address);
+
     extern BRCryptoFeeBasis
     cryptoWalletGetDefaultFeeBasis (BRCryptoWallet wallet);
 


### PR DESCRIPTION
Add cryptoWalletHasAddress() with corresponding Swift and Java interfaces.

Also removes the 'getSourceAddress' functionality - it never really did anything except return the 'target' address.