### PR TITLE
CORE-791: Avoid Duplicate Unit Declarations

### DIFF
--- a/Java/corecrypto/src/commonTest/java/com/breadwallet/corecrypto/AmountAIT.java
+++ b/Java/corecrypto/src/commonTest/java/com/breadwallet/corecrypto/AmountAIT.java
@@ -46,8 +46,8 @@ public class AmountAIT {
         assertEquals(new Double(-1.5), btc4.doubleAmount(btc_btc).get());
         assertEquals(new Double(-150000000), btc4.doubleAmount(satoshi_btc).get());
 
-        assertEquals("(B1.50)", btc4.toStringAsUnit(btc_btc, null).get());
-        assertEquals("(SAT150,000,000)", btc4.toStringAsUnit(satoshi_btc, null).get());
+        assertEquals("-B1.50", btc4.toStringAsUnit(btc_btc, null).get());
+        assertEquals("-SAT150,000,000", btc4.toStringAsUnit(satoshi_btc, null).get());
 
         assertEquals (btc1.doubleAmount(btc_btc).get(),     btc1.convert(satoshi_btc).get().doubleAmount(btc_btc).get());
         assertEquals (btc1.doubleAmount(satoshi_btc).get(), btc1.convert(btc_btc).get().doubleAmount(satoshi_btc).get());
@@ -78,8 +78,8 @@ public class AmountAIT {
         Amount btc4s = Amount.create("0x5f5e100", true, satoshi_btc).get();
         assertEquals(new Double(-100000000), btc4s.doubleAmount(satoshi_btc).get());
         assertEquals(new Double(-1), btc4s.doubleAmount(btc_btc).get());
-        assertEquals("(SAT100,000,000)", btc4s.toStringAsUnit(satoshi_btc, null).get());
-        assertEquals("(B1.00)", btc4s.toStringAsUnit(btc_btc, null).get());
+        assertEquals("-SAT100,000,000", btc4s.toStringAsUnit(satoshi_btc, null).get());
+        assertEquals("-B1.00", btc4s.toStringAsUnit(btc_btc, null).get());
 
         assertFalse(Amount.create("w0x5f5e100", false, satoshi_btc).isPresent());
         assertFalse(Amount.create("0x5f5e100w", false, satoshi_btc).isPresent());

--- a/Java/corecrypto/src/main/java/com/breadwallet/corecrypto/NetworkDiscovery.java
+++ b/Java/corecrypto/src/main/java/com/breadwallet/corecrypto/NetworkDiscovery.java
@@ -246,16 +246,15 @@ final class NetworkDiscovery {
     }
 
     private static Unit currencyToDefaultBaseUnit(Currency currency) {
-        String symb = currency.getCode().toLowerCase(Locale.ROOT) + "i";
-        String name = currency.getCode().toUpperCase(Locale.ROOT) + "_INTEGER";
-        String uids = String.format("%s:%s", currency.getUids(), name);
-        return Unit.create(currency, uids, name, symb);
+        String code = currency.getCode().toLowerCase(Locale.ROOT) + "i";
+        String name = currency.getName() + " INT";
+        String symb = currency.getCode().toUpperCase(Locale.ROOT) + "I";
+        return Unit.create(currency, code, name, symb);
     }
 
     private static Unit currencyDenominationToBaseUnit(Currency currency,
                                                        CurrencyDenomination denomination) {
-        String uids = String.format("%s:%s", currency.getUids(), denomination.getCode());
-        return Unit.create(currency, uids, denomination.getName(), denomination.getSymbol());
+        return Unit.create(currency, denomination.getCode(), denomination.getName(), denomination.getSymbol());
     }
 
     private static List<Unit> currencyDenominationToUnits(Currency currency,
@@ -263,8 +262,7 @@ final class NetworkDiscovery {
                                                           Unit base) {
         List<Unit> units = new ArrayList<>();
         for (CurrencyDenomination denomination : denominations) {
-            String uids = String.format("%s:%s", currency.getUids(), denomination.getCode());
-            units.add(Unit.create(currency, uids, denomination.getName(), denomination.getSymbol(), base,
+            units.add(Unit.create(currency, denomination.getCode(), denomination.getName(), denomination.getSymbol(), base,
                       denomination.getDecimals()));
         }
         return units;

--- a/Java/corecrypto/src/main/java/com/breadwallet/corecrypto/Unit.java
+++ b/Java/corecrypto/src/main/java/com/breadwallet/corecrypto/Unit.java
@@ -19,14 +19,14 @@ import java.util.Objects;
 final class Unit implements com.breadwallet.crypto.Unit {
 
     /* package */
-    static Unit create(Currency currency, String uids, String name, String symbol) {
-        BRCryptoUnit core = BRCryptoUnit.createAsBase(currency.getCoreBRCryptoCurrency(), uids, name, symbol);
+    static Unit create(Currency currency, String code, String name, String symbol) {
+        BRCryptoUnit core = BRCryptoUnit.createAsBase(currency.getCoreBRCryptoCurrency(), code, name, symbol);
         return Unit.create(core);
     }
 
     /* package */
-    static Unit create(Currency currency, String uids, String name, String symbol, Unit base, UnsignedInteger decimals) {
-        BRCryptoUnit core = BRCryptoUnit.create(currency.getCoreBRCryptoCurrency(), uids, name, symbol, base.core, decimals);
+    static Unit create(Currency currency, String code, String name, String symbol, Unit base, UnsignedInteger decimals) {
+        BRCryptoUnit core = BRCryptoUnit.create(currency.getCoreBRCryptoCurrency(), code, name, symbol, base.core, decimals);
         return Unit.create(core);
     }
 

--- a/Java/corenative/src/main/java/com/breadwallet/corenative/CryptoLibraryDirect.java
+++ b/Java/corenative/src/main/java/com/breadwallet/corenative/CryptoLibraryDirect.java
@@ -340,7 +340,7 @@ public final class CryptoLibraryDirect {
     public static native void cwmAnnounceGetBlockNumberSuccessAsString(Pointer cwm, Pointer callbackState, String blockNumber);
     public static native void cwmAnnounceGetBlockNumberFailure(Pointer cwm, Pointer callbackState);
     public static native void cwmAnnounceGetTransactionsItemBTC(Pointer cwm, Pointer callbackState,
-                                           BRCryptoTransferStateType status,
+                                           int status,
                                            byte[] transaction, SizeT transactionLength, long timestamp, long blockHeight);
     public static native void cwmAnnounceGetTransactionsItemETH(Pointer cwm, Pointer callbackState,
                                            String hash, String sourceAddr, String targetAddr, String contractAddr,
@@ -349,7 +349,7 @@ public final class CryptoLibraryDirect {
                                            String blockConfirmations, String blockTransacionIndex, String blockTimestamp,
                                            String isError);
     public static native void cwmAnnounceGetTransactionsItemGEN(Pointer cwm, Pointer callbackState,
-                                           BRCryptoTransferStateType status,
+                                           int status,
                                            byte[] transaction, SizeT transactionLength, long timestamp, long blockHeight);
     public static native void cwmAnnounceGetTransactionsComplete(Pointer cwm, Pointer callbackState, int success);
     public static native void cwmAnnounceGetTransferItemGEN(Pointer cwm, Pointer callbackState,

--- a/Java/corenative/src/main/java/com/breadwallet/corenative/crypto/BRCryptoWalletManager.java
+++ b/Java/corenative/src/main/java/com/breadwallet/corenative/crypto/BRCryptoWalletManager.java
@@ -343,7 +343,7 @@ public class BRCryptoWalletManager extends PointerType {
                                                UnsignedLong blockHeight) {
         Pointer thisPtr = this.getPointer();
 
-        CryptoLibraryDirect.cwmAnnounceGetTransactionsItemBTC(thisPtr, callbackState.getPointer(), status, transaction, new SizeT(transaction.length),
+        CryptoLibraryDirect.cwmAnnounceGetTransactionsItemBTC(thisPtr, callbackState.getPointer(), status.toCore(), transaction, new SizeT(transaction.length),
                 timestamp.longValue(), blockHeight.longValue());
     }
 
@@ -363,7 +363,7 @@ public class BRCryptoWalletManager extends PointerType {
                                                UnsignedLong timestamp, UnsignedLong blockHeight) {
         Pointer thisPtr = this.getPointer();
 
-        CryptoLibraryDirect.cwmAnnounceGetTransactionsItemGEN(thisPtr, callbackState.getPointer(), status, transaction, new SizeT(transaction.length),
+        CryptoLibraryDirect.cwmAnnounceGetTransactionsItemGEN(thisPtr, callbackState.getPointer(), status.toCore(), transaction, new SizeT(transaction.length),
                 timestamp.longValue(), blockHeight.longValue());
     }
 

--- a/Java/crypto/src/main/java/com/breadwallet/crypto/blockchaindb/models/bdb/CurrencyDenomination.java
+++ b/Java/crypto/src/main/java/com/breadwallet/crypto/blockchaindb/models/bdb/CurrencyDenomination.java
@@ -13,6 +13,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.primitives.UnsignedInteger;
 
+import java.util.Locale;
 import java.util.Map;
 
 import static com.google.common.base.Preconditions.checkNotNull;
@@ -93,6 +94,6 @@ public class CurrencyDenomination {
 
     private static String lookupSymbol(String code) {
         String symbol = CURRENCY_SYMBOLS.get(code);
-        return symbol != null ? symbol : code;
+        return symbol != null ? symbol : code.toUpperCase(Locale.ROOT);
     }
 }

--- a/Swift/BRCrypto/BRCryptoSystem.swift
+++ b/Swift/BRCrypto/BRCryptoSystem.swift
@@ -366,20 +366,26 @@ public final class System {
     ///
     public func configure (withCurrencyModels applicationCurrencies: [BlockChainDB.Model.Currency]) {
         func currencyDenominationToBaseUnit (currency: Currency, model: BlockChainDB.Model.CurrencyDenomination) -> Unit {
-            let uids = "\(currency.uids):\(model.code)"
-            return Unit (currency: currency, uids: uids, name: model.name, symbol: model.symbol)
+            return Unit (currency: currency,
+                         code:   model.code,
+                         name:   model.name,
+                         symbol: model.symbol)
         }
 
         func currencyToDefaultBaseUnit (currency: Currency) -> Unit {
-            let symb = "\(currency.code)I".lowercased()
-            let name = "\(currency.code) INT".uppercased()
-            let uids = "\(currency.uids):\(name)"
-            return Unit (currency: currency, uids: uids, name: name, symbol: symb)
+            return Unit (currency: currency,
+                         code:   "\(currency.code.lowercased())i",
+                         name:   "\(currency.name) INT",
+                         symbol: "\(currency.code.uppercased())I")
         }
 
         func currencyDenominationToUnit (currency: Currency, model: BlockChainDB.Model.CurrencyDenomination, base: Unit) -> Unit {
-            let uids = "\(currency.uids):\(model.code)"
-            return Unit (currency: currency, uids: uids, name: model.name, symbol: model.symbol, base: base, decimals: model.decimals)
+            return Unit (currency: currency,
+                         code:   model.code,
+                         name:   model.name,
+                         symbol: model.symbol,
+                         base:   base,
+                         decimals: model.decimals)
         }
 
         // Query for blockchains on the system.queue - thus system.configure() returns instantly

--- a/Swift/BRCrypto/BRCryptoUnit.swift
+++ b/Swift/BRCrypto/BRCryptoUnit.swift
@@ -65,20 +65,20 @@ public final class Unit: Hashable {
     }
 
     internal convenience init (currency: Currency,
-                               uids: String,
+                               code: String,
                                name: String,
                                symbol: String) {
-        self.init (core: cryptoUnitCreateAsBase (currency.core, uids, name, symbol),
+        self.init (core: cryptoUnitCreateAsBase (currency.core, code, name, symbol),
                    take: false)
     }
 
     internal convenience init (currency: Currency,
-                               uids: String,
+                               code: String,
                                name: String,
                                symbol: String,
                                base: Unit,
                                decimals: UInt8) {
-        self.init (core: cryptoUnitCreate (currency.core, uids, name, symbol, base.core, decimals),
+        self.init (core: cryptoUnitCreate (currency.core, code, name, symbol, base.core, decimals),
                    take: false)
     }
 

--- a/Swift/BRCrypto/common/BRBlockChainDB.swift
+++ b/Swift/BRCrypto/common/BRBlockChainDB.swift
@@ -295,7 +295,7 @@ public class BlockChainDB {
 
         static internal let currencySymbols = ["btc":"₿", "eth":"Ξ"]
         static internal func lookupSymbol (_ code: String) -> String {
-            return currencySymbols[code] ?? code
+            return currencySymbols[code] ?? code.uppercased()
         }
 
         static private let currencyInternalAddress = "__native__"

--- a/Swift/BRCryptoTests/BRCryptoAmountTests.swift
+++ b/Swift/BRCryptoTests/BRCryptoAmountTests.swift
@@ -47,8 +47,8 @@ class BRCryptoAmountTests: XCTestCase {
         let btc = Currency (uids: "Bitcoin",  name: "Bitcoin",  code: "BTC", type: "native", issuer: nil)
         let eth = Currency (uids: "Ethereum", name: "Ethereum", code: "ETH", type: "native", issuer: nil)
 
-        let BTC_SATOSHI = BRCrypto.Unit (currency: btc, uids: "BTC-SAT",  name: "Satoshi", symbol: "SAT")
-        let BTC_BTC = BRCrypto.Unit (currency: btc, uids: "BTC-BTC", name: "Bitcoin", symbol: "B", base: BTC_SATOSHI, decimals: 8)
+        let BTC_SATOSHI = BRCrypto.Unit (currency: btc, code: "BTC-SAT",  name: "Satoshi", symbol: "SAT")
+        let BTC_BTC     = BRCrypto.Unit (currency: btc, code: "BTC-BTC", name: "Bitcoin", symbol: "B", base: BTC_SATOSHI, decimals: 8)
 
         XCTAssert (BTC_SATOSHI.currency.code == btc.code)
         XCTAssert (BTC_SATOSHI.name == "Satoshi")
@@ -64,7 +64,7 @@ class BRCryptoAmountTests: XCTestCase {
         XCTAssertTrue  (BTC_BTC.isCompatible (with: BTC_SATOSHI))
         XCTAssertTrue  (BTC_SATOSHI.isCompatible (with: BTC_BTC))
 
-        let ETH_WEI = BRCrypto.Unit (currency: eth, uids: "ETH-WEI", name: "WEI", symbol: "wei")
+        let ETH_WEI = BRCrypto.Unit (currency: eth, code: "ETH-WEI", name: "WEI", symbol: "wei")
         XCTAssertFalse (ETH_WEI.isCompatible (with: BTC_BTC))
         XCTAssertFalse (BTC_BTC.isCompatible (with: ETH_WEI))
 
@@ -83,12 +83,12 @@ class BRCryptoAmountTests: XCTestCase {
         let btc = Currency (uids: "Bitcoin",  name: "Bitcoin",  code: "BTC", type: "native", issuer: nil)
         let eth = Currency (uids: "Ethereum", name: "Ethereum", code: "ETH", type: "native", issuer: nil)
 
-        let BTC_SATOSHI = BRCrypto.Unit (currency: btc, uids: "BTC-SAT",  name: "Satoshi", symbol: "SAT")
-        let BTC_BTC = BRCrypto.Unit (currency: btc, uids: "BTC-BTC",  name: "Bitcoin", symbol: "B", base: BTC_SATOSHI, decimals: 8)
+        let BTC_SATOSHI = BRCrypto.Unit (currency: btc, code: "BTC-SAT",  name: "Satoshi", symbol: "SAT")
+        let BTC_BTC     = BRCrypto.Unit (currency: btc, code: "BTC-BTC",  name: "Bitcoin", symbol: "B", base: BTC_SATOSHI, decimals: 8)
 
-        let ETH_WEI  = BRCrypto.Unit (currency: eth, uids: "ETH-WEI", name: "WEI",   symbol: "wei")
-        let ETH_GWEI = BRCrypto.Unit (currency: eth, uids: "ETH-GWEI", name: "GWEI",  symbol: "gwei", base: ETH_WEI, decimals: 9)
-        let ETH_ETHER = BRCrypto.Unit (currency: eth, uids: "ETH-ETH", name: "ETHER", symbol: "E",    base: ETH_WEI, decimals: 18)
+        let ETH_WEI   = BRCrypto.Unit (currency: eth, code: "ETH-WEI", name: "WEI",   symbol: "wei")
+        let ETH_GWEI  = BRCrypto.Unit (currency: eth, code: "ETH-GWEI", name: "GWEI",  symbol: "gwei", base: ETH_WEI, decimals: 9)
+        let ETH_ETHER = BRCrypto.Unit (currency: eth, code: "ETH-ETH", name: "ETHER", symbol: "E",    base: ETH_WEI, decimals: 18)
 
         let btc1 = Amount.create (integer: 100000000, unit: BTC_SATOSHI)
         XCTAssert (100000000 == btc1.double (as: BTC_SATOSHI))
@@ -228,9 +228,9 @@ class BRCryptoAmountTests: XCTestCase {
         var result: String! = nil
         let eth = Currency (uids: "Ethereum", name: "Ethereum", code: "ETH", type: "native", issuer: nil)
 
-        let ETH_WEI  = BRCrypto.Unit (currency: eth, uids: "ETH-WEI", name: "WEI",   symbol: "wei")
-        let ETH_GWEI = BRCrypto.Unit (currency: eth, uids: "ETH-GWEI", name: "GWEI",  symbol: "gwei", base: ETH_WEI, decimals: 9)
-        let ETH_ETHER = BRCrypto.Unit (currency: eth, uids: "ETH-ETH", name: "ETHER", symbol: "E",    base: ETH_WEI, decimals: 18)
+        let ETH_WEI   = BRCrypto.Unit (currency: eth, code: "ETH-WEI", name: "WEI",   symbol: "wei")
+        let ETH_GWEI  = BRCrypto.Unit (currency: eth, code: "ETH-GWEI", name: "GWEI",  symbol: "gwei", base: ETH_WEI, decimals: 9)
+        let ETH_ETHER = BRCrypto.Unit (currency: eth, code: "ETH-ETH", name: "ETHER", symbol: "E",    base: ETH_WEI, decimals: 18)
 
         let a1 = Amount.create(string:  "12.12345678", negative: false, unit: ETH_ETHER)
         XCTAssertNotNil(a1)
@@ -295,8 +295,8 @@ class BRCryptoAmountTests: XCTestCase {
     func testAmountBTC () {
         let btc = Currency (uids: "Bitcoin",  name: "Bitcoin",  code: "BTC", type: "native", issuer: nil)
 
-        let BTC_SATOSHI = BRCrypto.Unit (currency: btc, uids: "BTC-SAT",  name: "Satoshi", symbol: "SAT")
-        let BTC_BTC = BRCrypto.Unit (currency: btc, uids: "BTC-BTC",  name: "Bitcoin", symbol: "B", base: BTC_SATOSHI, decimals: 8)
+        let BTC_SATOSHI = BRCrypto.Unit (currency: btc, code: "BTC-SAT",  name: "Satoshi", symbol: "SAT")
+        let BTC_BTC     = BRCrypto.Unit (currency: btc, code: "BTC-BTC",  name: "Bitcoin", symbol: "B", base: BTC_SATOSHI, decimals: 8)
 
         XCTAssertEqual (btc, BTC_SATOSHI.currency)
 
@@ -309,8 +309,8 @@ class BRCryptoAmountTests: XCTestCase {
     func testAmountExtended () {
         let btc = Currency (uids: "Bitcoin",  name: "Bitcoin",  code: "BTC", type: "native", issuer: nil)
 
-        let BTC_SATOSHI = BRCrypto.Unit (currency: btc, uids: "BTC-SAT",   name: "Satoshi",  symbol: "SAT")
-        let BTC_MONGO   = BRCrypto.Unit (currency: btc, uids: "BTC-MONGO", name: "BitMongo", symbol: "BM", base: BTC_SATOSHI, decimals: 70)
+        let BTC_SATOSHI = BRCrypto.Unit (currency: btc, code: "BTC-SAT",   name: "Satoshi",  symbol: "SAT")
+        let BTC_MONGO   = BRCrypto.Unit (currency: btc, code: "BTC-MONGO", name: "BitMongo", symbol: "BM", base: BTC_SATOSHI, decimals: 70)
 
         let btc1 = Amount.create (integer: 100000000, unit: BTC_SATOSHI)
         let btc2 = Amount.create (integer: 100000001, unit: BTC_SATOSHI)
@@ -335,13 +335,13 @@ class BRCryptoAmountTests: XCTestCase {
     func testCurrencyPair () {
         let btc = Currency (uids: "Bitcoin",  name: "Bitcoin",  code: "BTC", type: "native", issuer: nil)
 
-        let BTC_SATOSHI = BRCrypto.Unit (currency: btc, uids: "BTC-SAT",  name: "Satoshi", symbol: "SAT")
-        let BTC_BTC = BRCrypto.Unit (currency: btc, uids: "BTC-BTC",  name: "Bitcoin", symbol: "B", base: BTC_SATOSHI, decimals: 8)
+        let BTC_SATOSHI = BRCrypto.Unit (currency: btc, code: "BTC-SAT",  name: "Satoshi", symbol: "SAT")
+        let BTC_BTC     = BRCrypto.Unit (currency: btc, code: "BTC-BTC",  name: "Bitcoin", symbol: "B", base: BTC_SATOSHI, decimals: 8)
 
         let usd = Currency (uids: "USDollar", name: "USDollar", code: "USD", type: "fiat", issuer: nil)
 
-        let usd_cents  = BRCrypto.Unit (currency: usd, uids: "USD-Cents", name: "Cents", symbol: "c")
-        let usd_dollar = BRCrypto.Unit (currency: usd, uids: "USD-Dollar", name: "Dollars", symbol: "$", base: usd_cents, decimals: 2)
+        let usd_cents  = BRCrypto.Unit (currency: usd, code: "USD-Cents", name: "Cents", symbol: "c")
+        let usd_dollar = BRCrypto.Unit (currency: usd, code: "USD-Dollar", name: "Dollars", symbol: "$", base: usd_cents, decimals: 2)
 
         let pair = CurrencyPair (baseUnit: BTC_BTC, quoteUnit: usd_dollar, exchangeRate: 10000)
         XCTAssertEqual("Bitcoin/Dollars=10000.0", pair.description)

--- a/Swift/BRCryptoTests/BRCryptoNetworkTests.swift
+++ b/Swift/BRCryptoTests/BRCryptoNetworkTests.swift
@@ -22,8 +22,8 @@ class BRCryptoNetworkTests: XCTestCase {
     func testNetworkBTC () {
         let btc = Currency (uids: "bitcoin-mainnet:__native__",  name: "Bitcoin",  code: "btc", type: "native", issuer: nil)
 
-        let BTC_SATOSHI = BRCrypto.Unit (currency: btc, uids: "sat",  name: "Satoshi", symbol: "SAT")
-        let BTC_BTC = BRCrypto.Unit (currency: btc, uids: "btc",  name: "Bitcoin", symbol: "B", base: BTC_SATOSHI, decimals: 8)
+        let BTC_SATOSHI = BRCrypto.Unit (currency: btc, code: "sat",  name: "Satoshi", symbol: "SAT")
+        let BTC_BTC     = BRCrypto.Unit (currency: btc, code: "btc",  name: "Bitcoin", symbol: "B", base: BTC_SATOSHI, decimals: 8)
 
         let fee = NetworkFee (timeIntervalInMilliseconds: 30 * 1000,
                               pricePerCostFactor: Amount.create(integer: 1000, unit: BTC_SATOSHI))
@@ -53,7 +53,7 @@ class BRCryptoNetworkTests: XCTestCase {
         XCTAssertTrue (network.hasUnitFor(currency: btc, unit: BTC_SATOSHI) ?? false)
 
         let eth = Currency (uids: "ethereum-mainnet:__native__", name: "Ethereum", code: "ETH", type: "native", issuer: nil)
-        let ETH_WEI  = BRCrypto.Unit (currency: eth, uids: "ETH-WEI", name: "WEI",   symbol: "wei")
+        let ETH_WEI  = BRCrypto.Unit (currency: eth, code: "ETH-WEI", name: "WEI",   symbol: "wei")
 
         XCTAssertFalse (network.hasCurrency(eth))
         XCTAssertNil   (network.baseUnitFor(currency: eth))
@@ -72,9 +72,9 @@ class BRCryptoNetworkTests: XCTestCase {
 
     func testNetworkETH () {
         let eth = Currency (uids: "ethereum-mainnet:__native__", name: "Ethereum", code: "eth", type: "native", issuer: nil)
-        let ETH_WEI  = BRCrypto.Unit (currency: eth, uids: "wei", name: "WEI",   symbol: "wei")
-        let ETH_GWEI = BRCrypto.Unit (currency: eth, uids: "gwei", name: "GWEI",  symbol: "gwei", base: ETH_WEI, decimals: 9)
-        let ETH_ETHER = BRCrypto.Unit (currency: eth, uids: "eth", name: "ETHER", symbol: "E",    base: ETH_WEI, decimals: 18)
+        let ETH_WEI   = BRCrypto.Unit (currency: eth, code: "wei", name: "WEI",   symbol: "wei")
+        let ETH_GWEI  = BRCrypto.Unit (currency: eth, code: "gwei", name: "GWEI",  symbol: "gwei", base: ETH_WEI, decimals: 9)
+        let ETH_ETHER = BRCrypto.Unit (currency: eth, code: "eth", name: "ETHER", symbol: "E",    base: ETH_WEI, decimals: 18)
 
         let brd = Currency (uids: "ethereum-mainnet:0x558ec3152e2eb2174905cd19aea4e34a23de9ad6", name: "BRD Token", code: "brd", type: "erc20", issuer: "0x558ec3152e2eb2174905cd19aea4e34a23de9ad6")
         // let brd_brdi = BRCrypto.Unit (currency: brd, uids: "BRDI", name: "BRD Token INT", symbol: "BRDI")

--- a/crypto/BRCryptoAccount.c
+++ b/crypto/BRCryptoAccount.c
@@ -20,6 +20,11 @@ static void _accounts_init (void) {
     // ...
 }
 
+private_extern void
+cryptoAccountInstall (void) {
+    pthread_once (&_accounts_once, _accounts_init);
+}
+
 static uint16_t
 checksumFletcher16 (const uint8_t *data, size_t count);
 
@@ -91,7 +96,7 @@ static BRCryptoAccount
 cryptoAccountCreateFromSeedInternal (UInt512 seed,
                                      uint64_t timestamp,
                                      const char *uids) {
-    pthread_once (&_accounts_once, _accounts_init);
+    cryptoAccountInstall();
 
     return cryptoAccountCreateInternal (BRBIP32MasterPubKey (seed.u8, sizeof (seed.u8)),
                                         createAccountWithBIP32Seed(seed),
@@ -120,7 +125,7 @@ cryptoAccountCreate (const char *phrase, uint64_t timestamp, const char *uids) {
  */
 extern BRCryptoAccount
 cryptoAccountCreateFromSerialization (const uint8_t *bytes, size_t bytesCount, const char *uids) {
-    pthread_once (&_accounts_once, _accounts_init);
+    cryptoAccountInstall();
 
     uint8_t *bytesPtr = (uint8_t *) bytes;
     uint8_t *bytesEnd = bytesPtr + bytesCount;

--- a/crypto/BRCryptoAccountP.h
+++ b/crypto/BRCryptoAccountP.h
@@ -35,6 +35,16 @@ struct BRCryptoAccountRecord {
 };
 
 /**
+ * Onetime install of BRCryptoAccount static state.  The static state includes the 'GEN Handlers'
+ * which allow BRCryptoAccount to create the required GEN accounts.  In not-DEBUG environments the
+ * static install happens w/i BRCryptoAccount; however, in a DEBUG environment, such as when unit
+ * testing, some BRCryptoNetwork function are invoked prior to BRCryptoAccount install.  So, we
+ * make this function `private_extern` and call it from BRCryptoNetwork.
+ */
+private_extern void
+cryptoAccountInstall (void);
+
+/**
  * Given a phrase (A BIP-39 PaperKey) dervie the corresponding 'seed'.  This is used
  * exclusive to sign transactions (BTC ones for sure).
  *
@@ -42,7 +52,7 @@ struct BRCryptoAccountRecord {
  *
  * @return A UInt512 seed
  */
-extern UInt512
+private_extern UInt512
 cryptoAccountDeriveSeed (const char *phrase);
 
 

--- a/crypto/BRCryptoNetwork.c
+++ b/crypto/BRCryptoNetwork.c
@@ -880,6 +880,23 @@ cryptoNetworkInstallBuiltins (BRCryptoCount *networksCount) {
         
         cryptoNetworkSetHeight (network, networkSpec->height);
         networks[networkIndex] = network;
+
+#define SHOW_BUILTIN_CURRENCIES DEBUG
+#if defined (SHOW_BUILTIN_CURRENCIES)
+        printf ("== Network: %s, '%s'\n", network->uids, network->name);
+        for (size_t ai = 0; ai < array_count(network->associations); ai++) {
+            BRCryptoCurrencyAssociation a = network->associations[ai];
+            printf ("    Currency: %s, '%s'\n", cryptoCurrencyGetUids(a.currency), cryptoCurrencyGetName(a.currency));
+            printf ("    Base Unit: %s\n", cryptoUnitGetUids(a.baseUnit));
+            printf ("    Default Unit: %s\n", cryptoUnitGetUids(a.defaultUnit));
+            printf ("    Units:\n");
+            for (size_t ui = 0; ui < array_count(a.units); ui++) {
+                BRCryptoUnit u = a.units[ui];
+                printf ("      %s, '%s', %5s\n", cryptoUnitGetUids (u), cryptoUnitGetName(u), cryptoUnitGetSymbol(u));
+            }
+            printf ("\n");
+        }
+#endif
     }
 
     return networks;

--- a/crypto/BRCryptoNetwork.c
+++ b/crypto/BRCryptoNetwork.c
@@ -12,6 +12,7 @@
 #include "BRCryptoUnit.h"
 #include "BRCryptoAddressP.h"
 #include "BRCryptoAmountP.h"
+#include "BRCryptoAccountP.h"
 
 #include "bitcoin/BRChainParams.h"
 #include "bcash/BRBCashParams.h"
@@ -121,6 +122,8 @@ static BRCryptoNetwork
 cryptoNetworkCreate (const char *uids,
                      const char *name,
                      BRCryptoNetworkCanonicalType canonicalType) {
+    cryptoAccountInstall();
+
     BRCryptoNetwork network = malloc (sizeof (struct BRCryptoNetworkRecord));
 
     network->canonicalType = canonicalType;
@@ -667,6 +670,8 @@ cryptoNetworkCreateBuiltin (const char *symbol,
 
 extern BRCryptoNetwork *
 cryptoNetworkInstallBuiltins (BRCryptoCount *networksCount) {
+    cryptoAccountInstall();
+
     // Network Specification
     struct NetworkSpecification {
         char *symbol;

--- a/crypto/BRCryptoUnit.c
+++ b/crypto/BRCryptoUnit.c
@@ -12,6 +12,7 @@
 #include "support/BRArray.h"
 
 #include <stdlib.h>
+#include <stdio.h>
 #include <string.h>
 #include <assert.h>
 
@@ -29,25 +30,27 @@ IMPLEMENT_CRYPTO_GIVE_TAKE (BRCryptoUnit, cryptoUnit)
 
 static BRCryptoUnit
 cryptoUnitCreateInternal (BRCryptoCurrency currency,
-                          const char *uids,
+                          const char *code,
                           const char *name,
                           const char *symbol) {
     BRCryptoUnit unit = malloc (sizeof (struct BRCryptoUnitRecord));
 
     unit->currency = cryptoCurrencyTake (currency);
-    unit->uids   = strdup (uids);
     unit->name   = strdup (name);
     unit->symbol = strdup (symbol);
+    unit->uids   = malloc (strlen (cryptoCurrencyGetUids(currency)) + 1 + strlen(code) + 1);
+    sprintf (unit->uids, "%s:%s", cryptoCurrencyGetUids(currency), code);
+
     unit->ref = CRYPTO_REF_ASSIGN (cryptoUnitRelease);
     return unit;
 }
 
 extern BRCryptoUnit
 cryptoUnitCreateAsBase (BRCryptoCurrency currency,
-                        const char *uids,
+                        const char *code,
                         const char *name,
                         const char *symbol) {
-    BRCryptoUnit unit = cryptoUnitCreateInternal (currency, uids, name, symbol);
+    BRCryptoUnit unit = cryptoUnitCreateInternal (currency, code, name, symbol);
 
     unit->base = NULL;
     unit->decimals = 0;
@@ -57,13 +60,13 @@ cryptoUnitCreateAsBase (BRCryptoCurrency currency,
 
 extern BRCryptoUnit
 cryptoUnitCreate (BRCryptoCurrency currency,
-                  const char *uids,
+                  const char *code,
                   const char *name,
                   const char *symbol,
                   BRCryptoUnit baseUnit,
                   uint8_t powerOffset) {
     assert (NULL != baseUnit);
-    BRCryptoUnit unit = cryptoUnitCreateInternal (currency, uids, name, symbol);
+    BRCryptoUnit unit = cryptoUnitCreateInternal (currency, code, name, symbol);
 
     unit->base = cryptoUnitTake (baseUnit);
     unit->decimals = powerOffset;

--- a/include/BRCryptoUnit.h
+++ b/include/BRCryptoUnit.h
@@ -22,13 +22,13 @@ extern "C" {
 
     private_extern BRCryptoUnit
     cryptoUnitCreateAsBase (BRCryptoCurrency currency,
-                            const char *uids,
+                            const char *code,
                             const char *name,
                             const char *symbol);
 
     private_extern BRCryptoUnit
     cryptoUnitCreate (BRCryptoCurrency currency,
-                      const char *uids,
+                      const char *code,
                       const char *name,
                       const char *symbol,
                       BRCryptoUnit baseUnit,


### PR DESCRIPTION
There was a inconsistency between the Unit::uids created by BlockchainDB.configure and by cryptoNetworkInstallBuiltins.  With this change, Unit::uids are created in `cryptoUnitCreate()` and BlockchainDB and BRCRyptoNetwork pass in the Unit::code.

Also, this change fixes some unit test errors and compilation errors.  And some inconsistencies between Java/Swift as regard Unit declaration.