### PR TITLE
CORE-804: Provide BlockSet metaData as 'TransferAttribute' data.

### DIFF
--- a/Java/CoreNative/src/main/java/com/breadwallet/corenative/crypto/BRCryptoTransferAttribute.java
+++ b/Java/CoreNative/src/main/java/com/breadwallet/corenative/crypto/BRCryptoTransferAttribute.java
@@ -25,7 +25,7 @@ public class BRCryptoTransferAttribute extends PointerType {
     public Optional<String> getValue() {
         Pointer thisPtr = this.getPointer();
 
-        return Optional.of (CryptoLibraryDirect.cryptoTransferAttributeGetValue(thisPtr))
+        return Optional.fromNullable (CryptoLibraryDirect.cryptoTransferAttributeGetValue(thisPtr))
                 .transform(v -> v.getString(0, "UTF-8"));
     }
 

--- a/Java/corecrypto/src/main/java/com/breadwallet/corecrypto/System.java
+++ b/Java/corecrypto/src/main/java/com/breadwallet/corecrypto/System.java
@@ -2473,7 +2473,8 @@ final class System implements com.breadwallet.crypto.System {
                                                         o.o1.getAmount().getCurrencyId(),
                                                         o.o2,
                                                         timestamp,
-                                                        blockHeight);
+                                                        blockHeight,
+                                                        o.o1.getMeta());
                                             }
                                         }
 

--- a/Java/corenative/src/main/java/com/breadwallet/corenative/CryptoLibraryDirect.java
+++ b/Java/corenative/src/main/java/com/breadwallet/corenative/CryptoLibraryDirect.java
@@ -373,10 +373,11 @@ public final class CryptoLibraryDirect {
                                            int status,
                                            byte[] transaction, SizeT transactionLength, long timestamp, long blockHeight);
     public static native void cwmAnnounceGetTransactionsComplete(Pointer cwm, Pointer callbackState, int success);
-    public static native void cwmAnnounceGetTransferItemGEN(Pointer cwm, Pointer callbackState,
-                                                            String hash, String uids, String sourceAddr, String targetAddr,
-                                                            String amount, String currency, String fee,
-                                                            long timestamp, long blockHeight);
+//  INDIRECT:   public static native void cwmAnnounceGetTransferItemGEN(Pointer cwm, Pointer callbackState,
+//                                                            String hash, String uids, String sourceAddr, String targetAddr,
+//                                                            String amount, String currency, String fee,
+//                                                            long timestamp, long blockHeight,
+//                                                            int attributesCount, Pointer arrayOfAttributeKeys, Pointer arrayOfAttributeVals);
     public static native void cwmAnnounceGetTransfersComplete(Pointer cwm, Pointer callbackState, int success);
     public static native void cwmAnnounceSubmitTransferSuccess(Pointer cwm, Pointer callbackState);
     public static native void cwmAnnounceSubmitTransferSuccessForHash(Pointer cwm, Pointer callbackState, String hash);

--- a/Java/corenative/src/main/java/com/breadwallet/corenative/CryptoLibraryIndirect.java
+++ b/Java/corenative/src/main/java/com/breadwallet/corenative/CryptoLibraryIndirect.java
@@ -34,6 +34,20 @@ public final class CryptoLibraryIndirect {
         return INSTANCE.cryptoWalletValidateTransferAttributes(wallet, countOfAttributes, attributes, validates);
     }
 
+    public static void cwmAnnounceGetTransferItemGEN(Pointer cwm, Pointer callbackState,
+                                                     String hash, String uids, String sourceAddr, String targetAddr,
+                                                     String amount, String currency, String fee,
+                                                     long timestamp, long blockHeight,
+                                                     SizeT attributesCount,
+                                                     String[] attributeKeys,
+                                                     String[] attributeVals) {
+        INSTANCE.cwmAnnounceGetTransferItemGEN(cwm, callbackState,
+                hash, uids, sourceAddr, targetAddr,
+                amount, currency, fee,
+                timestamp, blockHeight,
+                attributesCount, attributeKeys, attributeVals);
+    }
+
     public interface LibraryInterface extends Library {
 
         // crypto/BRCryptoNetwork.h
@@ -42,5 +56,14 @@ public final class CryptoLibraryIndirect {
         // crypto/BRCryptoWallet.h
         Pointer cryptoWalletCreateTransfer(Pointer wallet, Pointer target, Pointer amount, Pointer feeBasis, SizeT attributesCount, BRCryptoTransferAttribute[] attributes);
         int cryptoWalletValidateTransferAttributes(Pointer wallet, SizeT countOfAttributes, BRCryptoTransferAttribute[] attributes, IntByReference validates);
+
+        void cwmAnnounceGetTransferItemGEN(Pointer cwm, Pointer callbackState,
+                                           String hash, String uids, String sourceAddr, String targetAddr,
+                                           String amount, String currency, String fee,
+                                           long timestamp, long blockHeight,
+                                           SizeT attributesCount,
+                                           String[] attributeKeys,
+                                           String[] attributeVals);
+
     }
 }

--- a/Java/corenative/src/main/java/com/breadwallet/corenative/crypto/BRCryptoWalletManager.java
+++ b/Java/corenative/src/main/java/com/breadwallet/corenative/crypto/BRCryptoWalletManager.java
@@ -8,6 +8,7 @@
 package com.breadwallet.corenative.crypto;
 
 import com.breadwallet.corenative.CryptoLibraryDirect;
+import com.breadwallet.corenative.CryptoLibraryIndirect;
 import com.breadwallet.corenative.utility.Cookie;
 import com.breadwallet.corenative.utility.SizeT;
 import com.breadwallet.corenative.utility.SizeTByReference;
@@ -26,6 +27,7 @@ import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Map;
 
 import javax.annotation.Nullable;
 
@@ -383,10 +385,15 @@ public class BRCryptoWalletManager extends PointerType {
                                             String currency,
                                             String fee,
                                             UnsignedLong timestamp,
-                                            UnsignedLong blockHeight) {
+                                            UnsignedLong blockHeight,
+                                            Map<String, String> meta) {
         Pointer thisPtr = this.getPointer();
 
-        CryptoLibraryDirect.cwmAnnounceGetTransferItemGEN(
+        int metaCount = meta.size();
+        String[] metaKeys = meta.keySet().toArray(new String[metaCount]);
+        String[] metaVals = meta.values().toArray(new String[metaCount]);
+
+        CryptoLibraryIndirect.cwmAnnounceGetTransferItemGEN(
                 thisPtr,
                 callbackState.getPointer(),
                 hash,
@@ -397,7 +404,10 @@ public class BRCryptoWalletManager extends PointerType {
                 currency,
                 fee,
                 timestamp.longValue(),
-                blockHeight.longValue());
+                blockHeight.longValue(),
+                new SizeT(metaCount),
+                metaKeys,
+                metaVals);
     }
 
     public void announceGetTransfersComplete(BRCryptoCWMClientCallbackState callbackState, boolean success) {

--- a/Java/cryptodemo-android/src/main/java/com/breadwallet/cryptodemo/TransferDetailsActivity.java
+++ b/Java/cryptodemo-android/src/main/java/com/breadwallet/cryptodemo/TransferDetailsActivity.java
@@ -25,6 +25,7 @@ import android.widget.Toast;
 import com.breadwallet.crypto.Address;
 import com.breadwallet.crypto.System;
 import com.breadwallet.crypto.Transfer;
+import com.breadwallet.crypto.TransferAttribute;
 import com.breadwallet.crypto.TransferConfirmation;
 import com.breadwallet.crypto.TransferHash;
 import com.breadwallet.crypto.Wallet;
@@ -88,6 +89,7 @@ public class TransferDetailsActivity extends AppCompatActivity implements Defaul
     private View confirmationContainerView;
     private TextView stateView;
     private TextView directionView;
+    private TextView attributesView;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -123,6 +125,7 @@ public class TransferDetailsActivity extends AppCompatActivity implements Defaul
         confirmationContainerView = findViewById(R.id.confirmation_count_container_view);
         stateView = findViewById(R.id.state_view);
         directionView = findViewById(R.id.direction_view);
+        // attributesView = findViewById(R.id.attributes_view);
 
         Toolbar toolbar = findViewById(R.id.toolbar_view);
         setSupportActionBar(toolbar);
@@ -205,6 +208,9 @@ public class TransferDetailsActivity extends AppCompatActivity implements Defaul
 
         String directionText = viewModel.directionText();
         directionView.setText(directionText);
+
+        String attributesText = viewModel.attributesText();
+        // attributesView.setText(attributesText);
     }
 
     private void copyPlaintext(String label, CharSequence value) {
@@ -239,6 +245,7 @@ public class TransferDetailsActivity extends AppCompatActivity implements Defaul
         final boolean confirmationCountVisible;
         final String stateText;
         final String directionText;
+        final String attributesText;
 
         TransferViewModel(Transfer transfer) {
             this.transfer = transfer;
@@ -256,6 +263,25 @@ public class TransferDetailsActivity extends AppCompatActivity implements Defaul
             this.confirmationCountVisible = conf.isPresent();
             this.stateText = transfer.getState().toString();
             this.directionText = transfer.getDirection().toString();
+
+            StringBuffer sb = new StringBuffer();
+            String prefix = "";
+            for (TransferAttribute a : transfer.getAttributes()) {
+                sb.append(prefix);
+                sb.append(String.format("%s(%s):%s",
+                        ((TransferAttribute) a).getKey(),
+                        (((TransferAttribute) a).isRequired() ? "R" : "O"),
+                        ((TransferAttribute) a).getValue().or("")));
+                prefix = ", ";
+            }
+            this.attributesText = sb.toString();
+
+//            this.attributesText = transfer.getAttributes().stream()
+//                    .map(a -> String.format ("%s(%s):%s",
+//                            ((TransferAttribute) a).getKey(),
+//                            (((TransferAttribute) a).isRequired() ? "R" : "O"),
+//                            ((TransferAttribute) a).getValue().or("")))
+//                    .collect(Collectors.joining(", "));
         }
 
         String amountText() {
@@ -300,6 +326,10 @@ public class TransferDetailsActivity extends AppCompatActivity implements Defaul
 
         String directionText() {
             return directionText;
+        }
+
+        String attributesText () {
+            return attributesText;
         }
     }
 }

--- a/Swift/BRCrypto/BRCryptoSystem.swift
+++ b/Swift/BRCrypto/BRCryptoSystem.swift
@@ -1632,6 +1632,14 @@ extension System {
                                                                 .forEach { (arg: (transfer: BlockChainDB.Model.Transfer, fee: String?)) in
                                                                     let (transfer, fee) = arg
 
+                                                                    var metaKeysPtr = (transfer.metaData.map { Array($0.keys)   } ?? [])
+                                                                        .map { UnsafePointer<Int8>(strdup($0)) }
+                                                                    defer { metaKeysPtr.forEach { cryptoMemoryFree (UnsafeMutablePointer(mutating: $0)) } }
+
+                                                                    var metaValsPtr = (transfer.metaData.map { Array($0.values) } ?? [])
+                                                                        .map { UnsafePointer<Int8>(strdup($0)) }
+                                                                    defer { metaValsPtr.forEach { cryptoMemoryFree (UnsafeMutablePointer(mutating: $0)) } }
+
                                                                     // Use MetaData to extract TransferAttribute
                                                                     cwmAnnounceGetTransferItemGEN(cwm, sid, transaction.hash,
                                                                                                   transfer.id,
@@ -1641,7 +1649,10 @@ extension System {
                                                                                                   transfer.amountCurrency,
                                                                                                   fee,
                                                                                                   timestamp,
-                                                                                                  height)
+                                                                                                  height,
+                                                                                                  metaKeysPtr.count,
+                                                                                                  &metaKeysPtr,
+                                                                                                  &metaValsPtr)
                                                             }
                                                         }
                                                         cwmAnnounceGetTransfersComplete (cwm, sid, CRYPTO_TRUE) },

--- a/Swift/BRCrypto/BRCryptoSystem.swift
+++ b/Swift/BRCrypto/BRCryptoSystem.swift
@@ -1526,7 +1526,8 @@ extension System {
                             acknowledgements: transferWithFee.acknowledgements,
                             index: transferWithFee.index,
                             transactionId: transferWithFee.transactionId,
-                            blockchainId: transferWithFee.blockchainId)])
+                            blockchainId: transferWithFee.blockchainId,
+                            metaData: transferWithFee.metaData)])
 
                 // Hold the Id for the transfer that we'll add a fee to.
                 let transferForFeeId = transferMatchingFee.map { $0.id } ?? transferWithFee.id
@@ -1630,6 +1631,8 @@ extension System {
                                                             System.mergeTransfers (transaction.transfers, with: accountAddress)
                                                                 .forEach { (arg: (transfer: BlockChainDB.Model.Transfer, fee: String?)) in
                                                                     let (transfer, fee) = arg
+
+                                                                    // Use MetaData to extract TransferAttribute
                                                                     cwmAnnounceGetTransferItemGEN(cwm, sid, transaction.hash,
                                                                                                   transfer.id,
                                                                                                   transfer.source,

--- a/Swift/BRCrypto/common/BRBlockChainDB.swift
+++ b/Swift/BRCrypto/common/BRBlockChainDB.swift
@@ -339,7 +339,8 @@ public class BlockChainDB {
             acknowledgements: UInt64,
             index: UInt64,
             transactionId: String?,
-            blockchainId: String)
+            blockchainId: String,
+            metaData: Dictionary<String,String>?)
 
         static internal func asTransfer (json: JSON) -> Model.Transfer? {
             guard let id   = json.asString (name: "transfer_id"),
@@ -355,11 +356,13 @@ public class BlockChainDB {
             let source = json.asString (name: "from_address")
             let target = json.asString (name: "to_address")
             let tid    = json.asString (name: "transaction_id")
+            let meta   = json.asDict(name: "meta")?.mapValues { return $0 as! String }
 
             return (id: id, source: source, target: target,
                     amountValue: amountValue, amountCurrency: amountCurrency,
                     acknowledgements: acks, index: index,
-                    transactionId: tid, blockchainId: bid)
+                    transactionId: tid, blockchainId: bid,
+                    metaData: meta)
         }
 
         /// Transaction

--- a/crypto/BRCryptoWalletManager.c
+++ b/crypto/BRCryptoWalletManager.c
@@ -1394,19 +1394,6 @@ cryptoWalletManagerHandleTransferGEN (BRCryptoWalletManager cwm,
         // Create the generic transfer... `transferGeneric` owned by `transfer`
         transfer = cryptoTransferCreateAsGEN (unit, unitForFee, transferGeneric);
 
-        // Fill in any attributes
-        BRArrayOf(BRGenericTransferAttribute) genAttributes = genTransferGetAttributes(transferGeneric);
-        BRArrayOf(BRCryptoTransferAttribute)  attributes;
-        array_new(attributes, array_count(genAttributes));
-        for (size_t index = 0; index < array_count(genAttributes); index++) {
-            array_add (attributes,
-                       cryptoTransferAttributeCreate (genTransferAttributeGetKey(genAttributes[index]),
-                                                      genTransferAttributeGetVal(genAttributes[index]),
-                                                      AS_CRYPTO_BOOLEAN (genTransferAttributeIsRequired(genAttributes[index]))));
-        }
-        cryptoTransferSetAttributes (transfer, attributes);
-        array_free_all (attributes, cryptoTransferAttributeGive);
-
         transferWasCreated = 1;
     }
 
@@ -1422,6 +1409,19 @@ cryptoWalletManagerHandleTransferGEN (BRCryptoWalletManager cwm,
             genTransferSetUIDS (transferGenericOrig,
                                 genTransferGetUIDS (transferGeneric));
     }
+
+    // Fill in any attributes
+    BRArrayOf(BRGenericTransferAttribute) genAttributes = genTransferGetAttributes(transferGeneric);
+    BRArrayOf(BRCryptoTransferAttribute)  attributes;
+    array_new(attributes, array_count(genAttributes));
+    for (size_t index = 0; index < array_count(genAttributes); index++) {
+        array_add (attributes,
+                   cryptoTransferAttributeCreate (genTransferAttributeGetKey(genAttributes[index]),
+                                                  genTransferAttributeGetVal(genAttributes[index]),
+                                                  AS_CRYPTO_BOOLEAN (genTransferAttributeIsRequired(genAttributes[index]))));
+    }
+    cryptoTransferSetAttributes (transfer, attributes);
+    array_free_all (attributes, cryptoTransferAttributeGive);
 
     // Set the state from `transferGeneric`.  This is where we move from 'submitted' to 'included'
     BRCryptoTransferState oldState = cryptoTransferGetState (transfer);

--- a/crypto/BRCryptoWalletManagerP.h
+++ b/crypto/BRCryptoWalletManagerP.h
@@ -121,7 +121,7 @@ cryptoWalletManagerRemWallet (BRCryptoWalletManager cwm,
 
 extern void
 cryptoWalletManagerHandleTransferGEN (BRCryptoWalletManager cwm,
-                                      BRGenericTransfer transferGeneric);
+                                      OwnershipGiven BRGenericTransfer transferGeneric);
 
 private_extern void
 cryptoWalletManagerSetTransferStateGEN (BRCryptoWalletManager cwm,

--- a/generic/BRGeneric.c
+++ b/generic/BRGeneric.c
@@ -513,6 +513,50 @@ genWalletGetTransferAttributeAt (BRGenericWallet wallet,
 }
 
 extern BRCryptoBoolean
+genWalletHasTransferAttributeForKey (BRGenericWallet wallet,
+                                     BRGenericAddress target,
+                                     const char *key,
+                                     BRCryptoBoolean *isRequired) {
+    size_t countRequired, countOptional;
+    BRGenericAddressRef targetRef = (NULL == target ? NULL : target->ref);
+    const char **keysRequired = wallet->handlers.getTransactionAttributeKeys (wallet->ref, targetRef, 1, &countRequired);
+    const char **keysOptional = wallet->handlers.getTransactionAttributeKeys (wallet->ref, targetRef, 0, &countOptional);
+
+    if (NULL != keysRequired)
+        for (size_t index = 0; index < countRequired; index++)
+            if (0 == strcmp (key, keysRequired[index])) {
+                *isRequired = CRYPTO_TRUE;
+                return CRYPTO_TRUE;
+            }
+
+    if (NULL != keysOptional)
+        for (size_t index = 0; index < countOptional; index++)
+            if (0 == strcmp (key, keysOptional[index])) {
+                *isRequired = CRYPTO_FALSE;
+                return CRYPTO_TRUE;
+            }
+
+    *isRequired = CRYPTO_FALSE;
+    return CRYPTO_FALSE;
+}
+
+
+extern BRCryptoBoolean
+genWalletRequiresTransferAttributeForKey (BRGenericWallet wallet,
+                                          BRGenericAddress target,
+                                          const char *key) {
+    size_t countRequired;
+    BRGenericAddressRef targetRef = (NULL == target ? NULL : target->ref);
+    const char **keysRequired = wallet->handlers.getTransactionAttributeKeys (wallet->ref, targetRef, 1, &countRequired);
+
+    if (NULL != keysRequired)
+        for (size_t index = 0; NULL != keysRequired[index]; index++)
+            if (0 == strcmp (key, keysRequired[index]))
+                return CRYPTO_TRUE;
+    return CRYPTO_FALSE;
+}
+
+extern BRCryptoBoolean
 genWalletValidateTransferAttribute (BRGenericWallet wallet,
                                     BRGenericTransferAttribute attribute) {
     return AS_CRYPTO_BOOLEAN (wallet->handlers.validateTransactionAttribute (wallet->ref, attribute));

--- a/generic/BRGeneric.h
+++ b/generic/BRGeneric.h
@@ -226,6 +226,12 @@ extern "C" {
                                      size_t index);
 
     extern BRCryptoBoolean
+    genWalletHasTransferAttributeForKey (BRGenericWallet wallet,
+                                         BRGenericAddress target,
+                                         const char *key,
+                                         BRCryptoBoolean *isRequired);
+
+    extern BRCryptoBoolean
     genWalletValidateTransferAttribute (BRGenericWallet wid,
                                         BRGenericTransferAttribute attribute);
 

--- a/include/BRCryptoWalletManagerClient.h
+++ b/include/BRCryptoWalletManagerClient.h
@@ -266,7 +266,10 @@ extern "C" {
                                    OwnershipKept const char *currency,
                                    OwnershipKept const char *fee,
                                    uint64_t timestamp,
-                                   uint64_t blockHeight);
+                                   uint64_t blockHeight,
+                                   size_t attributesCount,
+                                   OwnershipKept const char **attributeKeys,
+                                   OwnershipKept const char **attributeVals);
 
     extern void
     cwmAnnounceGetTransactionsComplete (OwnershipKept BRCryptoWalletManager cwm,


### PR DESCRIPTION
[Currently built on CORE-805; I'll rebase once that PR is approved]

Needs a minimal change to update the Android UI for 'transfer detail' - add an 'Attributes' line.