### PR TITLE
CORE-814: Set WALLET_EVENT_FEE_ESTIMATED status accordingly for failures

### DIFF
--- a/ethereum/ewm/BREthereumEWMClient.c
+++ b/ethereum/ewm/BREthereumEWMClient.c
@@ -291,11 +291,12 @@ ewmHandlGasEstimateFailure (BREthereumEWM ewm,
                             BREthereumWallet wallet,
                             BREthereumCookie cookie,
                             BREthereumStatus status) {
+    assert (SUCCESS != status);
     ewmSignalWalletEvent (ewm,
                           wallet,
                           (BREthereumWalletEvent) {
                               WALLET_EVENT_FEE_ESTIMATED,
-                              SUCCESS,
+                              status,
                               {.feeEstimate = {cookie}}
                           });
 }


### PR DESCRIPTION
Similar to CORE-811, hotfix requested by the Android guys. Amazingly, no reports from iOS for this issue despite it being in common code.