### PR TITLE
CORE-815: Add 'status' to `cwmAnnounceGetTransferItemGEN()`

### DIFF
--- a/Java/corecrypto/src/main/java/com/breadwallet/corecrypto/System.java
+++ b/Java/corecrypto/src/main/java/com/breadwallet/corecrypto/System.java
@@ -2461,10 +2461,18 @@ final class System implements com.breadwallet.crypto.System {
                                             UnsignedLong blockHeight = transaction.getBlockHeight().or(UnsignedLong.ZERO);
                                             UnsignedLong timestamp = transaction.getTimestamp().transform(Utilities::dateAsUnixTimestamp).or(UnsignedLong.ZERO);
 
+                                            BRCryptoTransferStateType status = (transaction.getStatus().equals("confirmed")
+                                                    ? BRCryptoTransferStateType.CRYPTO_TRANSFER_STATE_INCLUDED
+                                                    : (transaction.getStatus().equals("submitted")
+                                                    ? BRCryptoTransferStateType.CRYPTO_TRANSFER_STATE_SUBMITTED
+                                                    : (transaction.getStatus().equals("failed")
+                                                    ? BRCryptoTransferStateType.CRYPTO_TRANSFER_STATE_ERRORED
+                                                    : BRCryptoTransferStateType.CRYPTO_TRANSFER_STATE_DELETED))); // Query API error
+
                                             merged = System.mergeTransfers(transaction, address);
                                             for (ObjectPair<com.breadwallet.crypto.blockchaindb.models.bdb.Transfer, String> o: merged) {
                                                 Log.log(Level.FINE, "BRCryptoCWMGenGetTransfersCallback  announcing " + o.o1.getId());
-                                                walletManager.getCoreBRCryptoWalletManager().announceGetTransfersItemGen(callbackState,
+                                                walletManager.getCoreBRCryptoWalletManager().announceGetTransfersItemGen(callbackState, status,
                                                         transaction.getHash(),
                                                         o.o1.getId(),
                                                         o.o1.getFromAddress().orNull(),

--- a/Java/corenative/src/main/java/com/breadwallet/corenative/CryptoLibraryDirect.java
+++ b/Java/corenative/src/main/java/com/breadwallet/corenative/CryptoLibraryDirect.java
@@ -373,7 +373,7 @@ public final class CryptoLibraryDirect {
                                            int status,
                                            byte[] transaction, SizeT transactionLength, long timestamp, long blockHeight);
     public static native void cwmAnnounceGetTransactionsComplete(Pointer cwm, Pointer callbackState, int success);
-//  INDIRECT:   public static native void cwmAnnounceGetTransferItemGEN(Pointer cwm, Pointer callbackState,
+//  INDIRECT:   public static native void cwmAnnounceGetTransferItemGEN(Pointer cwm, Pointer callbackState, int status,
 //                                                            String hash, String uids, String sourceAddr, String targetAddr,
 //                                                            String amount, String currency, String fee,
 //                                                            long timestamp, long blockHeight,

--- a/Java/corenative/src/main/java/com/breadwallet/corenative/CryptoLibraryIndirect.java
+++ b/Java/corenative/src/main/java/com/breadwallet/corenative/CryptoLibraryIndirect.java
@@ -40,7 +40,7 @@ public final class CryptoLibraryIndirect {
         return INSTANCE.cryptoWalletValidateTransferAttributes(wallet, countOfAttributes, attributes, validates);
     }
 
-    public static void cwmAnnounceGetTransferItemGEN(Pointer cwm, Pointer callbackState,
+    public static void cwmAnnounceGetTransferItemGEN(Pointer cwm, Pointer callbackState, int status,
                                                      String hash, String uids, String sourceAddr, String targetAddr,
                                                      String amount, String currency, String fee,
                                                      long timestamp, long blockHeight,
@@ -49,7 +49,7 @@ public final class CryptoLibraryIndirect {
                                                      String[] attributeVals) {
         attributeKeys = attributeKeys.length == 0 ? null : attributeKeys;
         attributeVals = attributeVals.length == 0 ? null : attributeVals;
-        INSTANCE.cwmAnnounceGetTransferItemGEN(cwm, callbackState,
+        INSTANCE.cwmAnnounceGetTransferItemGEN(cwm, callbackState, status,
                 hash, uids, sourceAddr, targetAddr,
                 amount, currency, fee,
                 timestamp, blockHeight,
@@ -65,7 +65,7 @@ public final class CryptoLibraryIndirect {
         Pointer cryptoWalletCreateTransfer(Pointer wallet, Pointer target, Pointer amount, Pointer feeBasis, SizeT attributesCount, BRCryptoTransferAttribute[] attributes);
         int cryptoWalletValidateTransferAttributes(Pointer wallet, SizeT countOfAttributes, BRCryptoTransferAttribute[] attributes, IntByReference validates);
 
-        void cwmAnnounceGetTransferItemGEN(Pointer cwm, Pointer callbackState,
+        void cwmAnnounceGetTransferItemGEN(Pointer cwm, Pointer callbackState, int status,
                                            String hash, String uids, String sourceAddr, String targetAddr,
                                            String amount, String currency, String fee,
                                            long timestamp, long blockHeight,

--- a/Java/corenative/src/main/java/com/breadwallet/corenative/crypto/BRCryptoWalletManager.java
+++ b/Java/corenative/src/main/java/com/breadwallet/corenative/crypto/BRCryptoWalletManager.java
@@ -376,7 +376,7 @@ public class BRCryptoWalletManager extends PointerType {
                 BRCryptoBoolean.CRYPTO_FALSE);
     }
 
-    public void announceGetTransfersItemGen(BRCryptoCWMClientCallbackState callbackState,
+    public void announceGetTransfersItemGen(BRCryptoCWMClientCallbackState callbackState, BRCryptoTransferStateType status,
                                             String hash,
                                             String uids,
                                             String from,
@@ -396,6 +396,7 @@ public class BRCryptoWalletManager extends PointerType {
         CryptoLibraryIndirect.cwmAnnounceGetTransferItemGEN(
                 thisPtr,
                 callbackState.getPointer(),
+                status.toCore(),
                 hash,
                 uids,
                 from,

--- a/crypto/BRCryptoWalletManagerClient.c
+++ b/crypto/BRCryptoWalletManagerClient.c
@@ -2148,7 +2148,8 @@ cwmAnnounceGetTransferItemGEN (BRCryptoWalletManager cwm,
         BRGenericTransfer genTransfer = genManagerRecoverTransfer (cwm->u.gen, genWallet, hash, uids,
                                                                    from, to,
                                                                    amount, currency, fee,
-                                                                   timestamp, blockHeight);
+                                                                   timestamp, blockHeight,
+                                                                   CRYPTO_TRANSFER_STATE_ERRORED == status);
 
         genTransferSetState (genTransfer, cwmAnnounceGetTransferStateGEN (genTransfer, status, timestamp, blockHeight));
 

--- a/crypto/BRCryptoWalletManagerClient.c
+++ b/crypto/BRCryptoWalletManagerClient.c
@@ -2014,6 +2014,30 @@ cwmAnnounceGetTransactionsItemETH (OwnershipKept BRCryptoWalletManager cwm,
     // DON'T free (callbackState);
 }
 
+static BRGenericTransferState
+cwmAnnounceGetTransferStateGEN (BRGenericTransfer transfer,
+                                BRCryptoTransferStateType status,
+                                uint64_t timestamp,
+                                uint64_t blockHeight) {
+    switch (status) {
+        case CRYPTO_TRANSFER_STATE_CREATED:
+            return genTransferStateCreateOther (GENERIC_TRANSFER_STATE_CREATED);
+        case CRYPTO_TRANSFER_STATE_SIGNED:
+            return genTransferStateCreateOther (GENERIC_TRANSFER_STATE_SIGNED);
+        case CRYPTO_TRANSFER_STATE_SUBMITTED:
+            return genTransferStateCreateOther (GENERIC_TRANSFER_STATE_SUBMITTED);
+        case CRYPTO_TRANSFER_STATE_INCLUDED:
+            return genTransferStateCreateIncluded (blockHeight,
+                                                   GENERIC_TRANSFER_TRANSACTION_INDEX_UNKNOWN,
+                                                   timestamp,
+                                                   genTransferGetFeeBasis (transfer));
+        case CRYPTO_TRANSFER_STATE_ERRORED:
+            return genTransferStateCreateErrored (GENERIC_TRANSFER_SUBMIT_ERROR_ONE);
+        case CRYPTO_TRANSFER_STATE_DELETED:
+            return genTransferStateCreateOther (GENERIC_TRANSFER_STATE_DELETED);
+    }
+}
+
 extern void
 cwmAnnounceGetTransactionsItemGEN (BRCryptoWalletManager cwm,
                                    BRCryptoCWMClientCallbackState callbackState,
@@ -2036,8 +2060,14 @@ cwmAnnounceGetTransactionsItemGEN (BRCryptoWalletManager cwm,
     if (transfers != NULL) {
         pthread_mutex_lock (&cwm->lock);
         for (size_t index = 0; index < array_count (transfers); index++) {
+            BRGenericTransfer genTransfer = transfers[index];
             // TODO: A BRGenericTransfer must allow us to determine the Wallet (via a Currency).
-            cryptoWalletManagerHandleTransferGEN (cwm, transfers[index]);
+
+            // Update the GEN state based on the `status`
+            genTransferSetState (genTransfer, cwmAnnounceGetTransferStateGEN (genTransfer, status, timestamp, blockHeight));
+
+            // Generate required events.
+            cryptoWalletManagerHandleTransferGEN (cwm, genTransfer);
         }
         pthread_mutex_unlock (&cwm->lock);
 
@@ -2085,6 +2115,7 @@ cwmAnnounceGetTransactionsComplete (OwnershipKept BRCryptoWalletManager cwm,
 extern void
 cwmAnnounceGetTransferItemGEN (BRCryptoWalletManager cwm,
                                BRCryptoCWMClientCallbackState callbackState,
+                               BRCryptoTransferStateType status,
                                OwnershipKept const char *hash,
                                OwnershipKept const char *uids,
                                OwnershipKept const char *from,
@@ -2118,6 +2149,8 @@ cwmAnnounceGetTransferItemGEN (BRCryptoWalletManager cwm,
                                                                    from, to,
                                                                    amount, currency, fee,
                                                                    timestamp, blockHeight);
+
+        genTransferSetState (genTransfer, cwmAnnounceGetTransferStateGEN (genTransfer, status, timestamp, blockHeight));
 
         // If we are passed in attribues, they will replace any attribute already held
         // in `genTransfer`.  Specifically, for example, if we created an XRP transfer, then

--- a/generic/BRGeneric.h
+++ b/generic/BRGeneric.h
@@ -301,7 +301,8 @@ extern "C" {
                                const char *currency,
                                const char *fee,
                                uint64_t timestamp,
-                               uint64_t blockHeight);
+                               uint64_t blockHeight,
+                               int error);
 
     extern void
     genManagerWipe (BRGenericNetwork network,

--- a/generic/BRGenericHandlers.h
+++ b/generic/BRGenericHandlers.h
@@ -180,7 +180,8 @@ extern "C" {
                                                                            const char *currency,
                                                                            const char *fee,
                                                                            uint64_t timestamp,
-                                                                           uint64_t blockHeight);
+                                                                           uint64_t blockHeight,
+                                                                           int error);
 
     typedef BRArrayOf(BRGenericTransferRef) (*BRGenericWalletManagerRecoverTransfersFromRawTransaction) (uint8_t *bytes,
                                                                                                          size_t   bytesCount);

--- a/generic/BRGenericManager.c
+++ b/generic/BRGenericManager.c
@@ -177,7 +177,8 @@ fileServiceTypeTransferV1Reader (BRFileServiceContext context,
                                                             currency,
                                                             strFee,
                                                             timestamp,
-                                                            blockHeight);
+                                                            blockHeight,
+                                                            GENERIC_TRANSFER_STATE_ERRORED == state.type);
 
     genTransferSetAttributes (transfer, attributes);
 
@@ -435,9 +436,10 @@ genManagerRecoverTransfer (BRGenericManager gwm,
                            const char *currency,
                            const char *fee,
                            uint64_t timestamp,
-                           uint64_t blockHeight) {
+                           uint64_t blockHeight,
+                           int error) {
     BRGenericTransfer transfer = genTransferAllocAndInit (gwm->handlers->type,
-                                                          gwm->handlers->manager.transferRecover (hash, from, to, amount, currency, fee, timestamp, blockHeight));
+                                                          gwm->handlers->manager.transferRecover (hash, from, to, amount, currency, fee, timestamp, blockHeight, error));
 
     transfer->uids = strdup (uids);
 

--- a/generic/BRGenericRipple.c
+++ b/generic/BRGenericRipple.c
@@ -390,7 +390,8 @@ genericRippleWalletManagerRecoverTransfer (const char *hash,
                                            const char *currency,
                                            const char *fee,
                                            uint64_t timestamp,
-                                           uint64_t blockHeight) {
+                                           uint64_t blockHeight,
+                                           int error) {
     BRRippleUnitDrops amountDrops, feeDrops = 0;
     sscanf(amount, "%llu", &amountDrops);
     if (NULL != fee) sscanf(fee,    "%llu", &feeDrops);
@@ -400,7 +401,7 @@ genericRippleWalletManagerRecoverTransfer (const char *hash,
     BRRippleTransactionHash txId;
     decodeHex(txId.bytes, sizeof(txId.bytes), hash, strlen(hash));
 
-    BRRippleTransfer transfer = rippleTransferCreate(fromAddress, toAddress, amountDrops, feeDrops, txId, timestamp, blockHeight);
+    BRRippleTransfer transfer = rippleTransferCreate(fromAddress, toAddress, amountDrops, feeDrops, txId, timestamp, blockHeight, error);
 
     rippleAddressFree (toAddress);
     rippleAddressFree (fromAddress);

--- a/include/BRCryptoWalletManagerClient.h
+++ b/include/BRCryptoWalletManagerClient.h
@@ -258,6 +258,7 @@ extern "C" {
     extern void
     cwmAnnounceGetTransferItemGEN (BRCryptoWalletManager cwm,
                                    BRCryptoCWMClientCallbackState callbackState,
+                                   BRCryptoTransferStateType status,
                                    OwnershipKept const char *hash,
                                    OwnershipKept const char *uids,
                                    OwnershipKept const char *from,

--- a/ripple/BRRipplePrivateStructs.h
+++ b/ripple/BRRipplePrivateStructs.h
@@ -112,6 +112,7 @@ struct BRRippleTransferRecord {
     BRRippleTransactionHash transactionId;
     uint64_t timestamp;
     uint64_t blockHeight;
+    int error;
     BRRippleTransaction transaction;
 };
 

--- a/ripple/BRRippleTransfer.c
+++ b/ripple/BRRippleTransfer.c
@@ -24,7 +24,8 @@ rippleTransferCreate(BRRippleAddress from, BRRippleAddress to,
                      BRRippleUnitDrops amount, // For now assume XRP drops.
                      BRRippleUnitDrops fee,
                      BRRippleTransactionHash hash,
-                     uint64_t timestamp, uint64_t blockHeight)
+                     uint64_t timestamp, uint64_t blockHeight,
+                     int error)
 {
     BRRippleTransfer transfer = (BRRippleTransfer) calloc (1, sizeof (struct BRRippleTransferRecord));
     transfer->sourceAddress = rippleAddressClone (from);
@@ -34,6 +35,7 @@ rippleTransferCreate(BRRippleAddress from, BRRippleAddress to,
     transfer->transactionId = hash;
     transfer->timestamp = timestamp;
     transfer->blockHeight = blockHeight;
+    transfer->error = error;
     transfer->transaction = NULL;
     return transfer;
 }
@@ -142,4 +144,9 @@ extern BRRippleTransaction rippleTransferGetTransaction(BRRippleTransfer transfe
 extern int rippleTransferHasSource (BRRippleTransfer transfer,
                                     BRRippleAddress source) {
     return rippleAddressEqual (transfer->sourceAddress, source);
+}
+
+extern int
+rippleTransferHasError(BRRippleTransfer transfer) {
+    return transfer->error;
 }

--- a/ripple/BRRippleTransfer.h
+++ b/ripple/BRRippleTransfer.h
@@ -26,7 +26,8 @@ rippleTransferCreate(BRRippleAddress from, BRRippleAddress to,
                     BRRippleUnitDrops amount, // For now assume XRP drops.
                     BRRippleUnitDrops fee,
                     BRRippleTransactionHash hash,
-                    uint64_t timestamp, uint64_t blockHeight);
+                    uint64_t timestamp, uint64_t blockHeight,
+                    int error);
 
 extern BRRippleTransfer rippleTransferClone (BRRippleTransfer transfer);
 extern void rippleTransferFree(BRRippleTransfer transfer);
@@ -42,6 +43,9 @@ rippleTransferGetSource(BRRippleTransfer transfer);
 
 extern BRRippleAddress // caller owns object, must free with rippleAddressFree
 rippleTransferGetTarget(BRRippleTransfer transfer);
+
+extern int
+rippleTransferHasError(BRRippleTransfer transfer);
 
 extern BRRippleTransaction rippleTransferGetTransaction(BRRippleTransfer transfer);
 

--- a/ripple/BRRippleWallet.c
+++ b/ripple/BRRippleWallet.c
@@ -199,7 +199,9 @@ extern void rippleWalletAddTransfer (BRRippleWallet wallet,
         array_add(wallet->transfers, transfer);
 
         // Update the balance
-        BRRippleUnitDrops amount = rippleTransferGetAmount(transfer);
+        BRRippleUnitDrops amount = (rippleTransferHasError(transfer)
+                                    ? 0
+                                    : rippleTransferGetAmount(transfer));
         BRRippleUnitDrops fee    = rippleTransferGetFee(transfer);
 
         BRRippleAddress accountAddress = rippleAccountGetAddress(wallet->account);
@@ -243,7 +245,10 @@ extern void rippleWalletRemTransfer (BRRippleWallet wallet,
             }
 
         // Update the balance
-        BRRippleUnitDrops amount = rippleTransferGetAmount(transfer);
+        BRRippleUnitDrops amount = (rippleTransferHasError(transfer)
+                                    ? 0
+                                    : rippleTransferGetAmount(transfer));
+
         BRRippleUnitDrops fee    = rippleTransferGetFee(transfer);
 
         BRRippleAddress accountAddress = rippleAccountGetAddress(wallet->account);


### PR DESCRIPTION
Propagate the BlockSet 'status' in Crypto C and then down to the GEN interface.  Add a `bool error` flag to XRP and account for an error when computing the GEN/XRP wallet's balance.