### PR TITLE
CORE-752: Standardize Ethereum Naming

### DIFF
--- a/Swift/CoreExplore/main.c
+++ b/Swift/CoreExplore/main.c
@@ -63,7 +63,7 @@ handleTrans (BRRlpCoder coder, const char *input) {
         input = &input[2];
 
     // Fill `data` and `item`
-    data.bytes = decodeHexCreate(&data.bytesCount, input, strlen (input));
+    data.bytes = hexDecodeCreate(&data.bytesCount, input, strlen (input));
     item = rlpGetItem (coder, data);
     rlpShow(data, "Trans:");
 
@@ -86,7 +86,7 @@ handleRLP (BRRlpCoder coder, const char *input) {
         input = &input[2];
 
     // Fill `data` and `item`
-    data.bytes = decodeHexCreate(&data.bytesCount, input, strlen (input));
+    data.bytes = hexDecodeCreate(&data.bytesCount, input, strlen (input));
     item = rlpGetItem (coder, data);
     rlpShowItem (coder, item, "RLP");
     rlpReleaseItem (coder, item);
@@ -102,7 +102,7 @@ if (bytesCount > 2 * 1024 * 1024) {
     FILE *foo = fopen ("/Users/ebg/les-item.txt", "w");
 
     BRRlpData data = rlpGetDataSharedDontRelease (node->coder.rlp, item);
-    char *dataAsHex = encodeHexCreate(NULL, data.bytes, data.bytesCount);
+    char *dataAsHex = hexEncodeCreate(NULL, data.bytes, data.bytesCount);
 
     size_t written = fwrite (dataAsHex , sizeof(char), strlen(dataAsHex), foo);
     assert (strlen(dataAsHex) == written);
@@ -125,7 +125,7 @@ handleRLPHuge (BRRlpCoder coder, const char *filename) {
         input = &input[2];
 
     // Fill `data` and `item`
-    data.bytes = decodeHexCreate(&data.bytesCount, input, strlen (input));
+    data.bytes = hexDecodeCreate(&data.bytesCount, input, strlen (input));
     item = rlpGetItem (coder, data);
 
 #if 0
@@ -171,7 +171,7 @@ handleRLPHuge (BRRlpCoder coder, const char *filename) {
 static void
 handleBitconTransactionHashReverse (const char *chars) {
     size_t bytesLen;
-    uint8_t *bytes = decodeHexCreate (&bytesLen, chars, strlen(chars));
+    uint8_t *bytes = hexDecodeCreate (&bytesLen, chars, strlen(chars));
     assert (bytesLen == 32);
 
     UInt256 hash;
@@ -179,14 +179,14 @@ handleBitconTransactionHashReverse (const char *chars) {
 
     UInt256 hashReversed = UInt256Reverse(hash);
     printf ("Hash Forward: %s\n", chars);
-    printf ("Hash Reverse: %s\n", encodeHexCreate(NULL, hashReversed.u8, 32));
+    printf ("Hash Reverse: %s\n", hexEncodeCreate(NULL, hashReversed.u8, 32));
 }
 
 #define BITCOIN_TX_PARSE_N "0100000000010195603c95b906c613da65825ae978d396027d3afba127ccb3e17f168250acc93600000000232200201f7babec88c8bd38c26a41abada201282b95cdd448c407af01529a0edb0b8101ffffffff02ce0acf010000000017a91425dba4104eeaf2a6c18888cc98e74e33ce58579a87a8932700000000001976a914bebb7325352454d51f430aedd584614dd0e5778d88ac0a0047304402204094574ae42312cacd982d467ab042d7247be753f44b679524e25b0ab20c7c9402203971031fffd999704f2e55977625be3363a0daefd16efb94deed72b305c3f73501483045022100cf88682953e6aca362e2f9c24a63ef1a2256e1ef81ab37151486e08f8183343702201b59a4db648f0645811d33558ceebbb43527b0d12766da1cebfb85e9f2a82c920169522103d46657769cefd69484dc2811ffdd355102c146b56a3097d79a96feca1e6375e621034aefa9486d6dd43506f3417dbd1fe062a7a4e6747ae1dccddbca29c951593ea2210229ee8d328be97fd28b1cc66a6febba28c38e3b61e0552a0a982b14ca6b93b72953ae000000009f7e0800720ddd21"
 static void
 handleBitcoinTransactionParse (const char *chars) {
     size_t bytesLen;
-    uint8_t *bytes = decodeHexCreate (&bytesLen, chars, strlen(chars));
+    uint8_t *bytes = hexDecodeCreate (&bytesLen, chars, strlen(chars));
     
     BRTransaction *tx = BRTransactionParse(bytes, bytesLen);
     assert (NULL != tx);
@@ -242,7 +242,7 @@ void *assertThread (void *ignore) {
 static BREthereumAddress
 handleEthTransactionDecode1 (BRRlpCoder coder, const char *rlpString) {
     size_t rlpBytesCount;
-    uint8_t *rlpBytes = decodeHexCreate (&rlpBytesCount, rlpString, strlen (rlpString));
+    uint8_t *rlpBytes = hexDecodeCreate (&rlpBytesCount, rlpString, strlen (rlpString));
 
     BRRlpData  data  = { rlpBytesCount, rlpBytes };
     BRRlpItem  item  = rlpGetItem(coder, data);
@@ -336,7 +336,7 @@ handleRippleAccount (void) {
 
     // Expected result
     size_t pubKeyResultLen;
-    uint8_t *pubKeyResult = decodeHexCreate(&pubKeyResultLen, IAN_COLEMAN_RIPPLE_DEX0_PUBKEY, strlen(IAN_COLEMAN_RIPPLE_DEX0_PUBKEY));
+    uint8_t *pubKeyResult = hexDecodeCreate(&pubKeyResultLen, IAN_COLEMAN_RIPPLE_DEX0_PUBKEY, strlen(IAN_COLEMAN_RIPPLE_DEX0_PUBKEY));
     assert (33 == pubKeyResultLen);
 
     // Confirm
@@ -362,7 +362,7 @@ handleStringFromHex (const char *hex) {
         hex += 2;
 
     size_t   bytesCount;
-    uint8_t *bytes = decodeHexCreate(&bytesCount, hex, strlen(hex));
+    uint8_t *bytes = hexDecodeCreate(&bytesCount, hex, strlen(hex));
 
     char string[bytesCount + 1];
     for (size_t index = 0; index < bytesCount; index++)

--- a/Swift/CoreExplore/main.c
+++ b/Swift/CoreExplore/main.c
@@ -268,7 +268,7 @@ handleEthTransactionDecode (BRRlpCoder coder) {
 
     BREthereumAddress addr1 = handleEthTransactionDecode1 (coder, ETH_TRANS1);
     BREthereumAddress addr2 = handleEthTransactionDecode1 (coder, ETH_TRANS2);
-    assert (ETHEREUM_BOOLEAN_TRUE == addressEqual (addr1, addr2));
+    assert (ETHEREUM_BOOLEAN_TRUE == ethAddressEqual (addr1, addr2));
 }
 
 //
@@ -374,9 +374,9 @@ handleStringFromHex (const char *hex) {
 
 static void
 handleAddressFromString (const char *hex, BRRlpCoder coder) {
-    BREthereumAddress address = addressCreate(hex);
+    BREthereumAddress address = ethAddressCreate(hex);
 
-    BRRlpItem item = addressRlpEncode(address, coder);
+    BRRlpItem item = ethAddressRlpEncode(address, coder);
     rlpItemShow(coder, item, "ADDR");
     rlpItemRelease(coder, item);
 }

--- a/Swift/CoreExplore/main.c
+++ b/Swift/CoreExplore/main.c
@@ -46,8 +46,8 @@ handlePaperKeyToAccount (void) {
 
     printf ("Read: %s\n", paperKey);
 
-    BREthereumAccount account = createAccount(paperKey);
-    char *publicAddress = accountGetPrimaryAddressString(account);
+    BREthereumAccount account = ethAccountCreate (paperKey);
+    char *publicAddress = ethAccountGetPrimaryAddressString(account);
     printf ("Public Address: %s\n", publicAddress);
     free (publicAddress);
 
@@ -253,8 +253,8 @@ handleEthTransactionDecode1 (BRRlpCoder coder, const char *rlpString) {
     BREthereumAddress   add1 = transactionExtractAddress (transaction, ethereumMainnet, coder);
 
     BREthereumTransfer transfer = transferCreateWithTransactionOriginating (transaction, TRANSFER_BASIS_TRANSACTION);
-    BREthereumAccount  account = createAccount(ETH_PAPER_KEY);
-    BREthereumAddress  address = accountGetPrimaryAddress (account);
+    BREthereumAccount  account = ethAccountCreate (ETH_PAPER_KEY);
+    BREthereumAddress  address = ethAccountGetPrimaryAddress (account);
 
     transferSign (transfer, ethereumMainnet, account, address, ETH_PAPER_KEY);
     BREthereumSignature sig2 = transactionGetSignature (transferGetOriginatingTransaction(transfer));

--- a/Swift/CoreExplore/main.c
+++ b/Swift/CoreExplore/main.c
@@ -68,7 +68,7 @@ handleTrans (BRRlpCoder coder, const char *input) {
     rlpDataShow(data, "Trans:");
 
     // Extract a transaction
-    BREthereumTransaction transaction = transactionRlpDecode (item, ethereumTestnet, RLP_TYPE_TRANSACTION_SIGNED, coder);
+    BREthereumTransaction transaction = transactionRlpDecode (item, ethNetworkTestnet, RLP_TYPE_TRANSACTION_SIGNED, coder);
 
     transactionShow(transaction, "EXP");
     eth_log ("EXP", "    Raw   : %s", input);
@@ -248,17 +248,17 @@ handleEthTransactionDecode1 (BRRlpCoder coder, const char *rlpString) {
     BRRlpItem  item  = rlpDataGetItem(coder, data);
     rlpItemShow(coder, item, "FOO");
 
-    BREthereumTransaction transaction = transactionRlpDecode (item, ethereumMainnet, RLP_TYPE_TRANSACTION_SIGNED, coder);
+    BREthereumTransaction transaction = transactionRlpDecode (item, ethNetworkMainnet, RLP_TYPE_TRANSACTION_SIGNED, coder);
     BREthereumSignature sig1 = transactionGetSignature(transaction);
-    BREthereumAddress   add1 = transactionExtractAddress (transaction, ethereumMainnet, coder);
+    BREthereumAddress   add1 = transactionExtractAddress (transaction, ethNetworkMainnet, coder);
 
     BREthereumTransfer transfer = transferCreateWithTransactionOriginating (transaction, TRANSFER_BASIS_TRANSACTION);
     BREthereumAccount  account = ethAccountCreate (ETH_PAPER_KEY);
     BREthereumAddress  address = ethAccountGetPrimaryAddress (account);
 
-    transferSign (transfer, ethereumMainnet, account, address, ETH_PAPER_KEY);
+    transferSign (transfer, ethNetworkMainnet, account, address, ETH_PAPER_KEY);
     BREthereumSignature sig2 = transactionGetSignature (transferGetOriginatingTransaction(transfer));
-    BREthereumAddress   add2 = transactionExtractAddress (transferGetOriginatingTransaction(transfer), ethereumMainnet, coder);
+    BREthereumAddress   add2 = transactionExtractAddress (transferGetOriginatingTransaction(transfer), ethNetworkMainnet, coder);
 
     return add2;
 }

--- a/Swift/CoreExplore/main.c
+++ b/Swift/CoreExplore/main.c
@@ -64,8 +64,8 @@ handleTrans (BRRlpCoder coder, const char *input) {
 
     // Fill `data` and `item`
     data.bytes = hexDecodeCreate(&data.bytesCount, input, strlen (input));
-    item = rlpGetItem (coder, data);
-    rlpShow(data, "Trans:");
+    item = rlpDataGetItem (coder, data);
+    rlpDataShow(data, "Trans:");
 
     // Extract a transaction
     BREthereumTransaction transaction = transactionRlpDecode (item, ethereumTestnet, RLP_TYPE_TRANSACTION_SIGNED, coder);
@@ -87,9 +87,9 @@ handleRLP (BRRlpCoder coder, const char *input) {
 
     // Fill `data` and `item`
     data.bytes = hexDecodeCreate(&data.bytesCount, input, strlen (input));
-    item = rlpGetItem (coder, data);
-    rlpShowItem (coder, item, "RLP");
-    rlpReleaseItem (coder, item);
+    item = rlpDataGetItem (coder, data);
+    rlpItemShow (coder, item, "RLP");
+    rlpItemRelease (coder, item);
     rlpDataRelease(data);
 }
 
@@ -126,7 +126,7 @@ handleRLPHuge (BRRlpCoder coder, const char *filename) {
 
     // Fill `data` and `item`
     data.bytes = hexDecodeCreate(&data.bytesCount, input, strlen (input));
-    item = rlpGetItem (coder, data);
+    item = rlpDataGetItem (coder, data);
 
 #if 0
     // use to debug sub-itens
@@ -161,7 +161,7 @@ handleRLPHuge (BRRlpCoder coder, const char *filename) {
     eth_log("EXP", "L6...%s", "");
 #endif
     //    rlpShow(data, "RLP:");
-    rlpReleaseItem(coder, item);
+    rlpItemRelease(coder, item);
     eth_log("EXP", "released%s", "");
 }
 
@@ -245,8 +245,8 @@ handleEthTransactionDecode1 (BRRlpCoder coder, const char *rlpString) {
     uint8_t *rlpBytes = hexDecodeCreate (&rlpBytesCount, rlpString, strlen (rlpString));
 
     BRRlpData  data  = { rlpBytesCount, rlpBytes };
-    BRRlpItem  item  = rlpGetItem(coder, data);
-    rlpShowItem(coder, item, "FOO");
+    BRRlpItem  item  = rlpDataGetItem(coder, data);
+    rlpItemShow(coder, item, "FOO");
 
     BREthereumTransaction transaction = transactionRlpDecode (item, ethereumMainnet, RLP_TYPE_TRANSACTION_SIGNED, coder);
     BREthereumSignature sig1 = transactionGetSignature(transaction);
@@ -377,8 +377,8 @@ handleAddressFromString (const char *hex, BRRlpCoder coder) {
     BREthereumAddress address = addressCreate(hex);
 
     BRRlpItem item = addressRlpEncode(address, coder);
-    rlpShowItem(coder, item, "ADDR");
-    rlpReleaseItem(coder, item);
+    rlpItemShow(coder, item, "ADDR");
+    rlpItemRelease(coder, item);
 }
 void handleLogDecode (BRRlpCoder coder) {
     FILE *foo = fopen ("/Users/ebg/log-item", "r");
@@ -390,11 +390,11 @@ void handleLogDecode (BRRlpCoder coder) {
 
     BRRlpData data = { bytesCount, bytes };
 
-    BRRlpItem  item  = rlpGetItem (coder, data);
+    BRRlpItem  item  = rlpDataGetItem (coder, data);
 
     BREthereumLog log = logRlpDecode(item, RLP_TYPE_ARCHIVE, coder);
 
-    rlpReleaseItem (coder, item);
+    rlpItemRelease (coder, item);
 
     logRelease(log);
 }

--- a/Swift/CorePerf/main.c
+++ b/Swift/CorePerf/main.c
@@ -40,7 +40,7 @@ runSyncMany (BREthereumNetwork newtork,
 
         assert (phraseLen == BRBIP39Encode(phrase, sizeof(phrase), BRBIP39WordsEn, entropy.u8, sizeof(entropy)));
 
-        BREthereumAccount account = createAccount(phrase);
+        BREthereumAccount account = ethAccountCreate (phrase);
 
         char storagePath[100];
         sprintf (storagePath, "many%d", i);
@@ -84,7 +84,7 @@ int main(int argc, const char * argv[]) {
     BRCryptoSyncMode mode = CRYPTO_SYNC_MODE_API_WITH_P2P_SEND;
 
     const char *paperKey = (argc > 1 ? argv[1] : "0xa9de3dbd7d561e67527bc1ecb025c59d53b9f7ef");
-    BREthereumAccount account = createAccount(paperKey);
+    BREthereumAccount account = ethAccountCreate (paperKey);
     BREthereumTimestamp timestamp = 1539330275; // ETHEREUM_TIMESTAMP_UNKNOWN;
     const char *path = "core";
 

--- a/Swift/CorePerf/main.c
+++ b/Swift/CorePerf/main.c
@@ -54,7 +54,7 @@ runSyncMany (BREthereumNetwork newtork,
 
         clients[i] = runEWM_createClient();
 
-        ewm = ewmCreate (ethereumMainnet, account, timestamp, mode, clients[i], storagePath, 0, 6);
+        ewm = ewmCreate (ethNetworkMainnet, account, timestamp, mode, clients[i], storagePath, 0, 6);
         ewms[i] = ewm;
 
         char *address = ewmGetAccountPrimaryAddress(ewm);
@@ -89,7 +89,7 @@ int main(int argc, const char * argv[]) {
     const char *path = "core";
 
 
-    runSyncTest (ethereumMainnet,  account, mode, timestamp,  5 * 60, path);
+    runSyncTest (ethNetworkMainnet,  account, mode, timestamp,  5 * 60, path);
 
 //    runSyncMany(ethereumMainnet, mode, 10 * 60, 1000);
 

--- a/Swift/CoreTests/CoreTests.swift
+++ b/Swift/CoreTests/CoreTests.swift
@@ -106,7 +106,7 @@ class CoreTests: XCTestCase {
             ? accountSpecification.paperKey
             : "ginger settle marine tissue robot crane night number ramp coast roast critic")
 
-        account = createAccount (nil != accountSpecification
+        account = ethAccountCreate (nil != accountSpecification
             ? accountSpecification.paperKey
             : fakeEthAccount)
 
@@ -130,7 +130,7 @@ class CoreTests: XCTestCase {
             fakeEthAccount = "0x8fB4CB96F7C15F9C39B3854595733F728E1963Bc"
         }
 
-        account = createAccount (nil != paperKey ? paperKey : fakeEthAccount)
+        account = ethAccountCreate (nil != paperKey ? paperKey : fakeEthAccount)
 
         #endif
         coreDataDir = FileManager.default

--- a/crypto/BRCryptoAccount.c
+++ b/crypto/BRCryptoAccount.c
@@ -99,7 +99,7 @@ cryptoAccountCreateFromSeedInternal (UInt512 seed,
     cryptoAccountInstall();
 
     return cryptoAccountCreateInternal (BRBIP32MasterPubKey (seed.u8, sizeof (seed.u8)),
-                                        createAccountWithBIP32Seed(seed),
+                                        ethAccountCreateWithBIP32Seed(seed),
                                         genAccountCreate (genericRippleHandlers->type, seed),
                                         timestamp,
                                         uids);
@@ -190,7 +190,7 @@ if (bytesPtr > bytesEnd) return NULL; /* overkill */ \
     BRKey ethPublicKey;
     BRKeySetPubKey(&ethPublicKey, bytesPtr, 65);
     BYTES_PTR_INCR_AND_CHECK (65);
-    BREthereumAccount eth = createAccountWithPublicKey(ethPublicKey);
+    BREthereumAccount eth = ethAccountCreateWithPublicKey(ethPublicKey);
 
     // XRP
     size_t xrpSize = UInt32GetBE(bytesPtr);
@@ -205,7 +205,7 @@ if (bytesPtr > bytesEnd) return NULL; /* overkill */ \
 
 static void
 cryptoAccountRelease (BRCryptoAccount account) {
-    accountFree(account->eth);
+    ethAccountRelease(account->eth);
     genAccountRelease(account->xrp);
 
     free (account->uids);
@@ -242,7 +242,7 @@ cryptoAccountSerialize (BRCryptoAccount account, size_t *bytesCount) {
     size_t mpkSize = BRBIP32SerializeMasterPubKey (NULL, 0, account->btc);
 
     // ETH
-    BRKey ethPublicKey = accountGetPrimaryAddressPublicKey (account->eth);
+    BRKey ethPublicKey = ethAccountGetPrimaryAddressPublicKey (account->eth);
     ethPublicKey.compressed = 0;
     size_t ethSize = BRKeyPubKey (&ethPublicKey, NULL, 0);
 
@@ -385,7 +385,7 @@ cryptoAccountAsGEN (BRCryptoAccount account,
 
 private_extern const char *
 cryptoAccountAddressAsETH (BRCryptoAccount account) {
-    return accountGetPrimaryAddressString (account->eth);
+    return ethAccountGetPrimaryAddressString (account->eth);
 }
 
 private_extern BRMasterPubKey

--- a/crypto/BRCryptoAddress.c
+++ b/crypto/BRCryptoAddress.c
@@ -110,9 +110,9 @@ static BRCryptoAddress
 cryptoAddressCreateFromStringAsETH (const char *ethAddress) {
     assert (ethAddress);
     BRCryptoAddress address = NULL;
-    if (ETHEREUM_BOOLEAN_TRUE == addressValidateString (ethAddress)) {
+    if (ETHEREUM_BOOLEAN_TRUE == ethAddressValidateString (ethAddress)) {
         address = cryptoAddressCreate (BLOCK_CHAIN_TYPE_ETH);
-        address->u.eth = addressCreate (ethAddress);
+        address->u.eth = ethAddressCreate (ethAddress);
     }
     return address;
 }
@@ -157,7 +157,7 @@ cryptoAddressAsString (BRCryptoAddress address) {
                 return result;
             }
         case BLOCK_CHAIN_TYPE_ETH:
-            return addressGetEncodedString(address->u.eth, 1);
+            return ethAddressGetEncodedString(address->u.eth, 1);
         case BLOCK_CHAIN_TYPE_GEN:
             return genAddressAsString (address->u.gen);
     }
@@ -171,7 +171,7 @@ cryptoAddressIsIdentical (BRCryptoAddress a1,
                                (a1->type == BLOCK_CHAIN_TYPE_BTC
                                 ? (0 == strcmp (a1->u.btc.addr.s, a2->u.btc.addr.s) && a1->u.btc.isBitcoinAddr == a2->u.btc.isBitcoinAddr)
                                 : ( a1->type == BLOCK_CHAIN_TYPE_ETH
-                                   ? ETHEREUM_BOOLEAN_IS_TRUE (addressEqual (a1->u.eth, a2->u.eth))
+                                   ? ETHEREUM_BOOLEAN_IS_TRUE (ethAddressEqual (a1->u.eth, a2->u.eth))
                                    : genAddressEqual (a1->u.gen, a2->u.gen)))));
 }
 

--- a/crypto/BRCryptoCoder.c
+++ b/crypto/BRCryptoCoder.c
@@ -65,7 +65,7 @@ cryptoCoderEncodeLength (BRCryptoCoder coder,
 
     switch (coder->type) {
         case CRYPTO_CODER_HEX: {
-            length = encodeHexLength (srcLen);
+            length = hexEncodeLength (srcLen);
             break;
         }
         case CRYPTO_CODER_BASE58: {
@@ -103,7 +103,7 @@ cryptoCoderEncode (BRCryptoCoder coder,
 
     switch (coder->type) {
         case CRYPTO_CODER_HEX: {
-            encodeHex (dst, dstLen, src, srcLen);
+            hexEncode (dst, dstLen, src, srcLen);
             result = CRYPTO_TRUE;
             break;
         }
@@ -138,7 +138,7 @@ cryptoCoderDecodeLength (BRCryptoCoder coder,
     switch (coder->type) {
         case CRYPTO_CODER_HEX: {
             size_t strLen = strlen (src);
-            length = (0 == strLen % 2) ? decodeHexLength (strLen) : 0;
+            length = (0 == strLen % 2) ? hexDecodeLength (strLen) : 0;
             break;
         }
         case CRYPTO_CODER_BASE58: {
@@ -176,7 +176,7 @@ cryptoCoderDecode (BRCryptoCoder coder,
 
     switch (coder->type) {
         case CRYPTO_CODER_HEX: {
-            decodeHex (dst, dstLen, src, strlen (src));
+            hexDecode (dst, dstLen, src, strlen (src));
             result = CRYPTO_TRUE;
             break;
         }

--- a/crypto/BRCryptoFeeBasis.c
+++ b/crypto/BRCryptoFeeBasis.c
@@ -163,7 +163,7 @@ cryptoFeeBasisIsIdentical (BRCryptoFeeBasis feeBasis1,
                                       feeBasis1->u.btc.sizeInByte == feeBasis2->u.btc.sizeInByte);
 
         case BLOCK_CHAIN_TYPE_ETH:
-            return AS_CRYPTO_BOOLEAN (ETHEREUM_BOOLEAN_IS_TRUE (feeBasisEqual (&feeBasis1->u.eth, &feeBasis2->u.eth)));
+            return AS_CRYPTO_BOOLEAN (ETHEREUM_BOOLEAN_IS_TRUE (ethFeeBasisEqual (&feeBasis1->u.eth, &feeBasis2->u.eth)));
 
         case BLOCK_CHAIN_TYPE_GEN:
             return AS_CRYPTO_BOOLEAN (genFeeBasisIsEqual (&feeBasis1->u.gen, &feeBasis2->u.gen));

--- a/crypto/BRCryptoFeeBasis.c
+++ b/crypto/BRCryptoFeeBasis.c
@@ -82,7 +82,7 @@ static UInt256
 cryptoFeeBasisGetPricePerCostFactorAsUInt256 (BRCryptoFeeBasis feeBasis) {
     switch (feeBasis->type) {
         case BLOCK_CHAIN_TYPE_BTC:
-            return createUInt256(feeBasis->u.btc.feePerKB);
+            return uint256Create(feeBasis->u.btc.feePerKB);
 
         case BLOCK_CHAIN_TYPE_ETH:
             return feeBasis->u.eth.u.gas.price.etherPerGas.valueInWEI;
@@ -126,7 +126,7 @@ cryptoFeeBasisGetFee (BRCryptoFeeBasis feeBasis) {
             double fee = (((double) feeBasis->u.btc.feePerKB) * feeBasis->u.btc.sizeInByte) / 1000.0;
             return cryptoAmountCreateInternal (feeBasis->unit,
                                                CRYPTO_FALSE,
-                                               createUInt256 (round (fee)),
+                                               uint256Create (round (fee)),
                                                1);
         }
             
@@ -138,7 +138,7 @@ cryptoFeeBasisGetFee (BRCryptoFeeBasis feeBasis) {
             int overflow = 0, negative = 0;
             double rem;
 
-            UInt256 value = mulUInt256_Double (pricePerCostFactor, costFactor, &overflow, &negative, &rem);
+            UInt256 value = uint256Mul_Double (pricePerCostFactor, costFactor, &overflow, &negative, &rem);
 
             return (overflow
                     ? NULL

--- a/crypto/BRCryptoHash.c
+++ b/crypto/BRCryptoHash.c
@@ -73,7 +73,7 @@ extern BRCryptoBoolean
 cryptoHashEqual (BRCryptoHash h1, BRCryptoHash h2) {
     return (h1->type == h2->type &&
             ((BLOCK_CHAIN_TYPE_BTC == h1->type && UInt256Eq (h1->u.btc, h2->u.btc)) ||
-             (BLOCK_CHAIN_TYPE_ETH == h1->type && ETHEREUM_BOOLEAN_TRUE ==  hashEqual (h1->u.eth, h2->u.eth)) ||
+             (BLOCK_CHAIN_TYPE_ETH == h1->type && ETHEREUM_BOOLEAN_TRUE ==  ethHashEqual (h1->u.eth, h2->u.eth)) ||
              (BLOCK_CHAIN_TYPE_GEN == h1->type && genericHashEqual (h1->u.gen, h2->u.gen)))
             ? CRYPTO_TRUE
             : CRYPTO_FALSE);
@@ -96,7 +96,7 @@ cryptoHashString (BRCryptoHash hash) {
             return _cryptoHashAddPrefix (hexEncodeCreate(NULL, reversedHash.u8, sizeof(reversedHash.u8)), 1);
         }
         case BLOCK_CHAIN_TYPE_ETH: {
-            return hashAsString (hash->u.eth);
+            return ethHashAsString (hash->u.eth);
         }
         case BLOCK_CHAIN_TYPE_GEN: {
             return _cryptoHashAddPrefix (genericHashAsString(hash->u.gen), 1);
@@ -111,7 +111,7 @@ cryptoHashGetHashValue (BRCryptoHash hash) {
             return hash->u.btc.u32[0];
 
         case BLOCK_CHAIN_TYPE_ETH:
-            return hashSetValue (&hash->u.eth);
+            return ethHashSetValue (&hash->u.eth);
 
         case BLOCK_CHAIN_TYPE_GEN:
             return genericHashSetValue (hash->u.gen);

--- a/crypto/BRCryptoHash.c
+++ b/crypto/BRCryptoHash.c
@@ -93,7 +93,7 @@ cryptoHashString (BRCryptoHash hash) {
     switch (hash->type) {
         case BLOCK_CHAIN_TYPE_BTC: {
             UInt256 reversedHash = UInt256Reverse (hash->u.btc);
-            return _cryptoHashAddPrefix (encodeHexCreate(NULL, reversedHash.u8, sizeof(reversedHash.u8)), 1);
+            return _cryptoHashAddPrefix (hexEncodeCreate(NULL, reversedHash.u8, sizeof(reversedHash.u8)), 1);
         }
         case BLOCK_CHAIN_TYPE_ETH: {
             return hashAsString (hash->u.eth);

--- a/crypto/BRCryptoKey.c
+++ b/crypto/BRCryptoKey.c
@@ -153,7 +153,7 @@ extern BRCryptoKey
 cryptoKeyCreateFromStringPublic (const char *string) {
     size_t  targetLen = strlen (string) / 2;
     uint8_t target [targetLen];
-    decodeHex(target, targetLen, string, strlen (string));
+    hexDecode(target, targetLen, string, strlen (string));
 
     BRKey core;
     BRCryptoKey result = (1 == BRKeySetPubKey (&core, target, targetLen)
@@ -317,7 +317,7 @@ cryptoKeyEncodePublic (BRCryptoKey key) {
     uint8_t encoded[encodedLength];
 
     BRKeyPubKey(&key->core, encoded, encodedLength);
-    return encodeHexCreate (NULL, encoded, encodedLength);
+    return hexEncodeCreate (NULL, encoded, encodedLength);
 }
 
 extern BRCryptoSecret

--- a/crypto/BRCryptoNetwork.c
+++ b/crypto/BRCryptoNetwork.c
@@ -264,7 +264,7 @@ cryptoNetworkIsMainnet (BRCryptoNetwork network) {
             return AS_CRYPTO_BOOLEAN (network->u.btc == BRMainNetParams ||
                                       network->u.btc == BRBCashParams);
         case BLOCK_CHAIN_TYPE_ETH:
-            return AS_CRYPTO_BOOLEAN (network->u.eth == ethereumMainnet);
+            return AS_CRYPTO_BOOLEAN (network->u.eth == ethNetworkMainnet);
         case BLOCK_CHAIN_TYPE_GEN:
             return AS_CRYPTO_BOOLEAN (genNetworkIsMainnet (network->u.gen));
     }
@@ -611,7 +611,7 @@ cryptoNetworkRequiresMigration (BRCryptoNetwork network) {
 extern const char *
 cryptoNetworkGetETHNetworkName (BRCryptoNetwork network) {
     BREthereumNetwork ethNetwork = cryptoNetworkAsETH(network);
-    return networkGetName(ethNetwork);
+    return ethNetworkGetName (ethNetwork);
 }
 
 // TODO(discuss): Is it safe to give out this pointer?
@@ -658,11 +658,11 @@ cryptoNetworkCreateBuiltin (const char *symbol,
     else if (0 == strcmp ("bchTestnet", symbol))
         network = cryptoNetworkCreateAsBCH (uids, name, BRBCashTestNetParams);
     else if (0 == strcmp ("ethMainnet", symbol))
-        network = cryptoNetworkCreateAsETH (uids, name, ethereumMainnet);
+        network = cryptoNetworkCreateAsETH (uids, name, ethNetworkMainnet);
     else if (0 == strcmp ("ethRopsten", symbol))
-        network = cryptoNetworkCreateAsETH (uids, name, ethereumTestnet);
+        network = cryptoNetworkCreateAsETH (uids, name, ethNetworkTestnet);
     else if (0 == strcmp ("ethRinkeby", symbol))
-        network = cryptoNetworkCreateAsETH (uids, name, ethereumRinkeby);
+        network = cryptoNetworkCreateAsETH (uids, name, ethNetworkRinkeby);
     else if (0 == strcmp ("xrpMainnet", symbol))
         network = cryptoNetworkCreateAsGEN (uids, name, GEN_NETWORK_TYPE_XRP, 1, CRYPTO_NETWORK_TYPE_XRP);
     else if (0 == strcmp ("xrpTestnet", symbol))

--- a/crypto/BRCryptoNetwork.c
+++ b/crypto/BRCryptoNetwork.c
@@ -99,7 +99,7 @@ cryptoNetworkFeeAsBTC (BRCryptoNetworkFee networkFee) {
 private_extern BREthereumGasPrice
 cryptoNetworkFeeAsETH (BRCryptoNetworkFee networkFee) {
     UInt256 value = cryptoAmountGetValue (networkFee->pricePerCostFactor);
-    return gasPriceCreate (etherCreate(value));
+    return ethGasPriceCreate (etherCreate(value));
 }
 
 private_extern uint64_t

--- a/crypto/BRCryptoNetwork.c
+++ b/crypto/BRCryptoNetwork.c
@@ -402,7 +402,7 @@ cryptoNetworkGetCurrencyforTokenETH (BRCryptoNetwork network,
         BRCryptoCurrency currency = network->associations[index].currency;
         const char *address = cryptoCurrencyGetIssuer (currency);
 
-        if (NULL != address && ETHEREUM_BOOLEAN_IS_TRUE (tokenHasAddress (token, address))) {
+        if (NULL != address && ETHEREUM_BOOLEAN_IS_TRUE (ethTokenHasAddress (token, address))) {
             tokenCurrency = cryptoCurrencyTake (currency);
             break;
         }

--- a/crypto/BRCryptoNetwork.c
+++ b/crypto/BRCryptoNetwork.c
@@ -99,7 +99,7 @@ cryptoNetworkFeeAsBTC (BRCryptoNetworkFee networkFee) {
 private_extern BREthereumGasPrice
 cryptoNetworkFeeAsETH (BRCryptoNetworkFee networkFee) {
     UInt256 value = cryptoAmountGetValue (networkFee->pricePerCostFactor);
-    return ethGasPriceCreate (etherCreate(value));
+    return ethGasPriceCreate (ethEtherCreate(value));
 }
 
 private_extern uint64_t

--- a/crypto/BRCryptoPayment.c
+++ b/crypto/BRCryptoPayment.c
@@ -776,7 +776,7 @@ cryptoPaymentProtocolPaymentEncode(BRCryptoPaymentProtocolPayment protoPay,
                 uint8_t *transactionBuf = malloc (transactionBufLen);
                 BRTransactionSerialize (protoPay->u.btcBitPay.transaction, transactionBuf, transactionBufLen);
                 size_t transactionHexLen = 0;
-                char *transactionHex = encodeHexCreate (&transactionHexLen, transactionBuf, transactionBufLen);
+                char *transactionHex = hexEncodeCreate (&transactionHexLen, transactionBuf, transactionBufLen);
 
                 array_add_array (encodedArray, transactionHex, transactionHexLen - 1);
 

--- a/crypto/BRCryptoPayment.c
+++ b/crypto/BRCryptoPayment.c
@@ -403,7 +403,7 @@ cryptoPaymentProtocolRequestGetTotalAmount (BRCryptoPaymentProtocolRequest proto
             }
 
             BRCryptoUnit baseUnit = cryptoNetworkGetUnitAsBase (protoReq->cryptoNetwork, protoReq->cryptoCurrency);
-            amount = cryptoAmountCreate (baseUnit, CRYPTO_FALSE, createUInt256 (satoshis));
+            amount = cryptoAmountCreate (baseUnit, CRYPTO_FALSE, uint256Create (satoshis));
             cryptoUnitGive (baseUnit);
             break;
         }

--- a/crypto/BRCryptoTransfer.c
+++ b/crypto/BRCryptoTransfer.c
@@ -570,8 +570,8 @@ cryptoTransferGetDirection (BRCryptoTransfer transfer) {
             BREthereumAddress source = ewmTransferGetSource (ewm, tid);
             BREthereumAddress target = ewmTransferGetTarget (ewm, tid);
 
-            BREthereumBoolean accountIsSource = addressEqual (source, transfer->u.eth.accountAddress);
-            BREthereumBoolean accountIsTarget = addressEqual (target, transfer->u.eth.accountAddress);
+            BREthereumBoolean accountIsSource = ethAddressEqual (source, transfer->u.eth.accountAddress);
+            BREthereumBoolean accountIsTarget = ethAddressEqual (target, transfer->u.eth.accountAddress);
 
             if (accountIsSource == ETHEREUM_BOOLEAN_TRUE && accountIsTarget == ETHEREUM_BOOLEAN_TRUE) {
                 return CRYPTO_TRANSFER_RECOVERED;

--- a/crypto/BRCryptoTransfer.c
+++ b/crypto/BRCryptoTransfer.c
@@ -179,7 +179,7 @@ cryptoTransferCreateAsETH (BRCryptoUnit unit,
 
     // cache the values that require the ewm
     BREthereumAccount account = ewmGetAccount (ewm);
-    transfer->u.eth.accountAddress = accountGetPrimaryAddress (account);
+    transfer->u.eth.accountAddress = ethAccountGetPrimaryAddress (account);
 
     // This function `cryptoTransferCreateAsETH()` includes an argument as
     // `BRCryptoFeeBasis feeBasisEstimated` whereas the analogous function

--- a/crypto/BRCryptoTransfer.c
+++ b/crypto/BRCryptoTransfer.c
@@ -319,7 +319,7 @@ cryptoTransferGetAmountAsSign (BRCryptoTransfer transfer, BRCryptoBoolean isNega
                 case AMOUNT_ETHER:
                     amount = cryptoAmountCreate (transfer->unit,
                                                  isNegative,
-                                                 etherGetValue(ethAmountGetEther(ethAmount), WEI));
+                                                 ethEtherGetValue(ethAmountGetEther(ethAmount), WEI));
                     break;
 
                 case AMOUNT_TOKEN:

--- a/crypto/BRCryptoTransfer.c
+++ b/crypto/BRCryptoTransfer.c
@@ -292,19 +292,19 @@ cryptoTransferGetAmountAsSign (BRCryptoTransfer transfer, BRCryptoBoolean isNega
                 case CRYPTO_TRANSFER_RECOVERED:
                     amount = cryptoAmountCreate (transfer->unit,
                                                  isNegative,
-                                                 createUInt256(send));
+                                                 uint256Create(send));
                     break;
 
                 case CRYPTO_TRANSFER_SENT:
                     amount = cryptoAmountCreate (transfer->unit,
                                                  isNegative,
-                                                 createUInt256(send - fee - recv));
+                                                 uint256Create(send - fee - recv));
                     break;
 
                 case CRYPTO_TRANSFER_RECEIVED:
                     amount = cryptoAmountCreate (transfer->unit,
                                                  isNegative,
-                                                 createUInt256(recv));
+                                                 uint256Create(recv));
                     break;
 
                 default: assert(0);
@@ -466,11 +466,11 @@ cryptoTransferGetFee (BRCryptoTransfer transfer) { // Pass in 'currency' as bloc
                 case CRYPTO_TRANSFER_RECOVERED:
                     return cryptoAmountCreate (transfer->currency,
                                                CRYPTO_FALSE,
-                                               createUInt256(fee));
+                                               uint256Create(fee));
                 case CRYPTO_TRANSFER_SENT:
                     return cryptoAmountCreate (transfer->currency,
                                                CRYPTO_FALSE,
-                                               createUInt256(fee));
+                                               uint256Create(fee));
                 case CRYPTO_TRANSFER_RECEIVED:
                     return cryptoAmountCreate (transfer->currency,
                                                CRYPTO_FALSE,

--- a/crypto/BRCryptoTransfer.c
+++ b/crypto/BRCryptoTransfer.c
@@ -609,7 +609,7 @@ cryptoTransferGetHash (BRCryptoTransfer transfer) {
             BREthereumTransfer tid = transfer->u.eth.tid;
 
             BREthereumHash hash = ewmTransferGetOriginatingTransactionHash (ewm, tid);
-            return (ETHEREUM_BOOLEAN_TRUE == hashEqual(hash, hashCreateEmpty())
+            return (ETHEREUM_BOOLEAN_TRUE == ethHashEqual(hash, ethHashCreateEmpty())
                     ? NULL
                     : cryptoHashCreateAsETH (hash));
         }

--- a/crypto/BRCryptoTransfer.c
+++ b/crypto/BRCryptoTransfer.c
@@ -315,17 +315,17 @@ cryptoTransferGetAmountAsSign (BRCryptoTransfer transfer, BRCryptoBoolean isNega
         case BLOCK_CHAIN_TYPE_ETH: {
             BREthereumAmount ethAmount = ewmTransferGetAmount (transfer->u.eth.ewm,
                                                                transfer->u.eth.tid);
-            switch (amountGetType(ethAmount)) {
+            switch (ethAmountGetType(ethAmount)) {
                 case AMOUNT_ETHER:
                     amount = cryptoAmountCreate (transfer->unit,
                                                  isNegative,
-                                                 etherGetValue(amountGetEther(ethAmount), WEI));
+                                                 etherGetValue(ethAmountGetEther(ethAmount), WEI));
                     break;
 
                 case AMOUNT_TOKEN:
                     amount = cryptoAmountCreate (transfer->unit,
                                                isNegative,
-                                               amountGetTokenQuantity(ethAmount).valueAsInteger);
+                                               ethAmountGetTokenQuantity(ethAmount).valueAsInteger);
                     break;
 
                 default: assert(0);

--- a/crypto/BRCryptoWallet.c
+++ b/crypto/BRCryptoWallet.c
@@ -154,7 +154,7 @@ cryptoWalletGetBalance (BRCryptoWallet wallet) {
         case BLOCK_CHAIN_TYPE_BTC: {
             BRWallet *wid = wallet->u.btc.wid;
 
-            UInt256 value = createUInt256 (BRWalletBalance (wid));
+            UInt256 value = uint256Create (BRWalletBalance (wid));
             BRCryptoAmount amount = cryptoAmountCreate (wallet->unit, CRYPTO_FALSE, value);
             return amount;
         }
@@ -179,10 +179,10 @@ extern BRCryptoAmount /* nullable */
 cryptoWalletGetBalanceMinimum (BRCryptoWallet wallet) {
     switch (wallet->type) {
         case BLOCK_CHAIN_TYPE_BTC:
-            return cryptoAmountCreate (wallet->unit, CRYPTO_FALSE, createUInt256(0));
+            return cryptoAmountCreate (wallet->unit, CRYPTO_FALSE, uint256Create(0));
 
         case BLOCK_CHAIN_TYPE_ETH:
-            return cryptoAmountCreate (wallet->unit, CRYPTO_FALSE, createUInt256(0));
+            return cryptoAmountCreate (wallet->unit, CRYPTO_FALSE, uint256Create(0));
 
         case BLOCK_CHAIN_TYPE_GEN: {
             BRCryptoBoolean hasLimit = 0;
@@ -801,7 +801,7 @@ cryptoWalletCreateFeeBasis (BRCryptoWallet wallet,
 
             // Expect all other fields in `value` to be zero
             value.u32[0] = 0;
-            if (!eqUInt256 (value, UINT256_ZERO)) return NULL;
+            if (!uint256EQL (value, UINT256_ZERO)) return NULL;
 
             uint32_t sizeInBytes = (uint32_t) (1000 * costFactor);
 
@@ -1037,7 +1037,7 @@ cryptoWalletSweeperGetBalance (BRCryptoWalletSweeper sweeper) {
 
     switch (sweeper->type) {
         case BLOCK_CHAIN_TYPE_BTC: {
-            UInt256 value = createUInt256 (BRWalletSweeperGetBalance (sweeper->u.btc.sweeper));
+            UInt256 value = uint256Create (BRWalletSweeperGetBalance (sweeper->u.btc.sweeper));
             amount = cryptoAmountCreate (sweeper->unit, CRYPTO_FALSE, value);
             break;
         }

--- a/crypto/BRCryptoWallet.c
+++ b/crypto/BRCryptoWallet.c
@@ -334,7 +334,7 @@ cryptoWalletGetAddress (BRCryptoWallet wallet,
             assert (CRYPTO_ADDRESS_SCHEME_ETH_DEFAULT == addressScheme);
             BREthereumEWM ewm = wallet->u.eth.ewm;
 
-            BREthereumAddress ethAddress = accountGetPrimaryAddress (ewmGetAccount(ewm));
+            BREthereumAddress ethAddress = ethAccountGetPrimaryAddress (ewmGetAccount(ewm));
             return cryptoAddressCreateAsETH (ethAddress);
         }
 

--- a/crypto/BRCryptoWallet.c
+++ b/crypto/BRCryptoWallet.c
@@ -809,8 +809,8 @@ cryptoWalletCreateFeeBasis (BRCryptoWallet wallet,
         }
 
         case BLOCK_CHAIN_TYPE_ETH: {
-            BREthereumGas gas = gasCreate((uint64_t) costFactor);
-            BREthereumGasPrice gasPrice = gasPriceCreate (etherCreate(value));
+            BREthereumGas gas = ethGasCreate((uint64_t) costFactor);
+            BREthereumGasPrice gasPrice = ethGasPriceCreate (etherCreate(value));
 
             return cryptoFeeBasisCreateAsETH (wallet->unitForFee, gas, gasPrice);
         }

--- a/crypto/BRCryptoWallet.c
+++ b/crypto/BRCryptoWallet.c
@@ -627,7 +627,7 @@ cryptoWalletCreateTransfer (BRCryptoWallet  wallet,
             UInt256 ethValue  = cryptoAmountGetValue (amount);
             BREthereumToken  ethToken  = ewmWalletGetToken (ewm, wid);
             BREthereumAmount ethAmount = (NULL != ethToken
-                                          ? amountCreateToken (createTokenQuantity (ethToken, ethValue))
+                                          ? amountCreateToken (ethTokenQuantityCreate (ethToken, ethValue))
                                           : amountCreateEther (etherCreate (ethValue)));
             BREthereumFeeBasis ethFeeBasis = cryptoFeeBasisAsETH (estimatedFeeBasis);
 

--- a/crypto/BRCryptoWallet.c
+++ b/crypto/BRCryptoWallet.c
@@ -627,8 +627,8 @@ cryptoWalletCreateTransfer (BRCryptoWallet  wallet,
             UInt256 ethValue  = cryptoAmountGetValue (amount);
             BREthereumToken  ethToken  = ewmWalletGetToken (ewm, wid);
             BREthereumAmount ethAmount = (NULL != ethToken
-                                          ? amountCreateToken (ethTokenQuantityCreate (ethToken, ethValue))
-                                          : amountCreateEther (etherCreate (ethValue)));
+                                          ? ethAmountCreateToken (ethTokenQuantityCreate (ethToken, ethValue))
+                                          : ethAmountCreateEther (etherCreate (ethValue)));
             BREthereumFeeBasis ethFeeBasis = cryptoFeeBasisAsETH (estimatedFeeBasis);
 
             char *addr = cryptoAddressAsString(target); // Target address

--- a/crypto/BRCryptoWallet.c
+++ b/crypto/BRCryptoWallet.c
@@ -628,7 +628,7 @@ cryptoWalletCreateTransfer (BRCryptoWallet  wallet,
             BREthereumToken  ethToken  = ewmWalletGetToken (ewm, wid);
             BREthereumAmount ethAmount = (NULL != ethToken
                                           ? ethAmountCreateToken (ethTokenQuantityCreate (ethToken, ethValue))
-                                          : ethAmountCreateEther (etherCreate (ethValue)));
+                                          : ethAmountCreateEther (ethEtherCreate (ethValue)));
             BREthereumFeeBasis ethFeeBasis = cryptoFeeBasisAsETH (estimatedFeeBasis);
 
             char *addr = cryptoAddressAsString(target); // Target address
@@ -810,7 +810,7 @@ cryptoWalletCreateFeeBasis (BRCryptoWallet wallet,
 
         case BLOCK_CHAIN_TYPE_ETH: {
             BREthereumGas gas = ethGasCreate((uint64_t) costFactor);
-            BREthereumGasPrice gasPrice = ethGasPriceCreate (etherCreate(value));
+            BREthereumGasPrice gasPrice = ethGasPriceCreate (ethEtherCreate(value));
 
             return cryptoFeeBasisCreateAsETH (wallet->unitForFee, gas, gasPrice);
         }

--- a/crypto/BRCryptoWalletManager.c
+++ b/crypto/BRCryptoWalletManager.c
@@ -1187,7 +1187,7 @@ cryptoWalletManagerEstimateFeeBasis (BRCryptoWalletManager cwm,
 
             BREthereumToken  ethToken  = ewmWalletGetToken (ewm, wid);
             BREthereumAmount ethAmount = (NULL != ethToken
-                                          ? amountCreateToken (createTokenQuantity (ethToken, ethValue))
+                                          ? amountCreateToken (ethTokenQuantityCreate (ethToken, ethValue))
                                           : amountCreateEther (etherCreate (ethValue)));
 
             ewmWalletEstimateTransferFeeForTransfer (ewm,

--- a/crypto/BRCryptoWalletManager.c
+++ b/crypto/BRCryptoWalletManager.c
@@ -608,7 +608,7 @@ cryptoWalletManagerInstallETHTokensForCurrencies (BRCryptoWalletManager cwm) {
                     const char *address = cryptoCurrencyGetIssuer(c);
                     if (NULL != address) {
                         BREthereumGas      ethGasLimit = gasCreate(TOKEN_BRD_DEFAULT_GAS_LIMIT);
-                        BREthereumGasPrice ethGasPrice = gasPriceCreate(etherCreate(createUInt256(TOKEN_BRD_DEFAULT_GAS_PRICE_IN_WEI_UINT64)));
+                        BREthereumGasPrice ethGasPrice = gasPriceCreate(etherCreate(uint256Create(TOKEN_BRD_DEFAULT_GAS_PRICE_IN_WEI_UINT64)));
 
                         // This has the perhaps surprising side-effect of updating the properties
                         // of an existing token.  That is, `address` is used to locate a token and
@@ -1073,7 +1073,7 @@ cryptoWalletManagerEstimateLimit (BRCryptoWalletManager cwm,
             if (amountInSAT + fee > balance)
                 amountInSAT = 0;
 
-            amount = createUInt256(amountInSAT);
+            amount = uint256Create(amountInSAT);
             break;
         }
 
@@ -1085,7 +1085,7 @@ cryptoWalletManagerEstimateLimit (BRCryptoWalletManager cwm,
             *needEstimate = CRYPTO_TRUE;
 
             if (CRYPTO_FALSE == asMaximum)
-                amount = createUInt256(0);
+                amount = uint256Create(0);
             else {
                 BREthereumAmount ethAmount = ewmWalletGetBalance (ewm, wid);
 
@@ -1103,7 +1103,7 @@ cryptoWalletManagerEstimateLimit (BRCryptoWalletManager cwm,
             *needEstimate = CRYPTO_FALSE;
 
             if (CRYPTO_FALSE == asMaximum)
-                amount = createUInt256(0);
+                amount = uint256Create(0);
             else {
                 int negative = 0, overflow = 0;
 
@@ -1116,7 +1116,7 @@ cryptoWalletManagerEstimateLimit (BRCryptoWalletManager cwm,
                 UInt256 balanceMinimum = genWalletGetBalanceLimit (wallet->u.gen, CRYPTO_FALSE, &hasMinimum);
 
                 if (CRYPTO_TRUE == hasMinimum) {
-                    balance = subUInt256_Negative(balance, balanceMinimum, &negative);
+                    balance = uint256Sub_Negative(balance, balanceMinimum, &negative);
                     if (negative) balance = UINT256_ZERO;
                 }
 
@@ -1134,7 +1134,7 @@ cryptoWalletManagerEstimateLimit (BRCryptoWalletManager cwm,
                 UInt256 fee = genFeeBasisGetFee (&feeBasis, &overflow);
                 assert (!overflow);
 
-                amount = subUInt256_Negative (balance, fee, &negative);
+                amount = uint256Sub_Negative (balance, fee, &negative);
                 if (negative) amount = UINT256_ZERO;
 
                 genAddressRelease(address);
@@ -1208,7 +1208,7 @@ cryptoWalletManagerEstimateFeeBasis (BRCryptoWalletManager cwm,
             BRGenericAddress genAddress = cryptoAddressAsGEN (target);
 
             UInt256 genValue = cryptoAmountGetValue(amount);
-            UInt256 genPricePerCostFactor = createUInt256 (cryptoNetworkFeeAsGEN(fee));
+            UInt256 genPricePerCostFactor = uint256Create (cryptoNetworkFeeAsGEN(fee));
 
             BRGenericFeeBasis genFeeBasis = genWalletEstimateTransferFee (genWallet,
                                                                           genAddress,

--- a/crypto/BRCryptoWalletManager.c
+++ b/crypto/BRCryptoWalletManager.c
@@ -534,7 +534,7 @@ cryptoWalletManagerRegisterWallet (BRCryptoWalletManager cwm,
 
             case BLOCK_CHAIN_TYPE_ETH: {
                 const char *issuer = cryptoCurrencyGetIssuer (currency);
-                BREthereumAddress ethAddress = addressCreate (issuer);
+                BREthereumAddress ethAddress = ethAddressCreate (issuer);
                 BREthereumToken ethToken = ewmLookupToken (cwm->u.eth, ethAddress);
                 assert (NULL != ethToken);
                 ewmGetWalletHoldingToken (cwm->u.eth, ethToken);

--- a/crypto/BRCryptoWalletManager.c
+++ b/crypto/BRCryptoWalletManager.c
@@ -607,8 +607,8 @@ cryptoWalletManagerInstallETHTokensForCurrencies (BRCryptoWalletManager cwm) {
                 case BLOCK_CHAIN_TYPE_ETH: {
                     const char *address = cryptoCurrencyGetIssuer(c);
                     if (NULL != address) {
-                        BREthereumGas      ethGasLimit = gasCreate(TOKEN_BRD_DEFAULT_GAS_LIMIT);
-                        BREthereumGasPrice ethGasPrice = gasPriceCreate(etherCreate(uint256Create(TOKEN_BRD_DEFAULT_GAS_PRICE_IN_WEI_UINT64)));
+                        BREthereumGas      ethGasLimit = ethGasCreate(TOKEN_BRD_DEFAULT_GAS_LIMIT);
+                        BREthereumGasPrice ethGasPrice = ethGasPriceCreate(etherCreate(uint256Create(TOKEN_BRD_DEFAULT_GAS_PRICE_IN_WEI_UINT64)));
 
                         // This has the perhaps surprising side-effect of updating the properties
                         // of an existing token.  That is, `address` is used to locate a token and

--- a/crypto/BRCryptoWalletManager.c
+++ b/crypto/BRCryptoWalletManager.c
@@ -1091,9 +1091,9 @@ cryptoWalletManagerEstimateLimit (BRCryptoWalletManager cwm,
 
                 // NOTE: We know ETH has a minimum balance of zero.
 
-                amount = (AMOUNT_ETHER == amountGetType(ethAmount)
-                          ? amountGetEther(ethAmount).valueInWEI
-                          : amountGetTokenQuantity(ethAmount).valueAsInteger);
+                amount = (AMOUNT_ETHER == ethAmountGetType(ethAmount)
+                          ? ethAmountGetEther(ethAmount).valueInWEI
+                          : ethAmountGetTokenQuantity(ethAmount).valueAsInteger);
             }
             break;
         }
@@ -1187,8 +1187,8 @@ cryptoWalletManagerEstimateFeeBasis (BRCryptoWalletManager cwm,
 
             BREthereumToken  ethToken  = ewmWalletGetToken (ewm, wid);
             BREthereumAmount ethAmount = (NULL != ethToken
-                                          ? amountCreateToken (ethTokenQuantityCreate (ethToken, ethValue))
-                                          : amountCreateEther (etherCreate (ethValue)));
+                                          ? ethAmountCreateToken (ethTokenQuantityCreate (ethToken, ethValue))
+                                          : ethAmountCreateEther (etherCreate (ethValue)));
 
             ewmWalletEstimateTransferFeeForTransfer (ewm,
                                                      wid,

--- a/crypto/BRCryptoWalletManager.c
+++ b/crypto/BRCryptoWalletManager.c
@@ -608,7 +608,7 @@ cryptoWalletManagerInstallETHTokensForCurrencies (BRCryptoWalletManager cwm) {
                     const char *address = cryptoCurrencyGetIssuer(c);
                     if (NULL != address) {
                         BREthereumGas      ethGasLimit = ethGasCreate(TOKEN_BRD_DEFAULT_GAS_LIMIT);
-                        BREthereumGasPrice ethGasPrice = ethGasPriceCreate(etherCreate(uint256Create(TOKEN_BRD_DEFAULT_GAS_PRICE_IN_WEI_UINT64)));
+                        BREthereumGasPrice ethGasPrice = ethGasPriceCreate(ethEtherCreate(uint256Create(TOKEN_BRD_DEFAULT_GAS_PRICE_IN_WEI_UINT64)));
 
                         // This has the perhaps surprising side-effect of updating the properties
                         // of an existing token.  That is, `address` is used to locate a token and
@@ -1188,7 +1188,7 @@ cryptoWalletManagerEstimateFeeBasis (BRCryptoWalletManager cwm,
             BREthereumToken  ethToken  = ewmWalletGetToken (ewm, wid);
             BREthereumAmount ethAmount = (NULL != ethToken
                                           ? ethAmountCreateToken (ethTokenQuantityCreate (ethToken, ethValue))
-                                          : ethAmountCreateEther (etherCreate (ethValue)));
+                                          : ethAmountCreateEther (ethEtherCreate (ethValue)));
 
             ewmWalletEstimateTransferFeeForTransfer (ewm,
                                                      wid,

--- a/crypto/BRCryptoWalletManagerClient.c
+++ b/crypto/BRCryptoWalletManagerClient.c
@@ -158,7 +158,7 @@ cwmSubmitTransactionAsBTC (BRWalletManagerClientContext context,
     callbackState->rid = rid;
 
     UInt256 txHash = UInt256Reverse (transactionHash);
-    char *hashAsHex = encodeHexCreate (NULL, txHash.u8, sizeof(txHash.u8));
+    char *hashAsHex = hexEncodeCreate (NULL, txHash.u8, sizeof(txHash.u8));
 
     cwm->client.funcSubmitTransaction (cwm->client.context,
                                        cryptoWalletManagerTake (cwm),

--- a/crypto/BRCryptoWalletManagerClient.c
+++ b/crypto/BRCryptoWalletManagerClient.c
@@ -1032,9 +1032,9 @@ cwmWalletEventAsETH (BREthereumClientContext context,
                 BREthereumAmount amount = ewmWalletGetBalance(cwm->u.eth, wid);
 
                 // ... and then the 'raw integer' (UInt256) value
-                UInt256 value = (AMOUNT_ETHER == amountGetType(amount)
-                                 ? amountGetEther(amount).valueInWEI
-                                 : amountGetTokenQuantity(amount).valueAsInteger);
+                UInt256 value = (AMOUNT_ETHER == ethAmountGetType(amount)
+                                 ? ethAmountGetEther(amount).valueInWEI
+                                 : ethAmountGetTokenQuantity(amount).valueAsInteger);
 
                 // Create a cryptoAmount in the wallet's unit.
                 BRCryptoAmount cryptoAmount = cryptoAmountCreate (unit, CRYPTO_FALSE, value);

--- a/crypto/BRCryptoWalletManagerClient.c
+++ b/crypto/BRCryptoWalletManagerClient.c
@@ -1300,8 +1300,8 @@ cwmTransactionEventAsETH (BREthereumClientContext context,
 
                 BRCryptoUnit unit = cryptoTransferGetUnitForFee(transfer);
                 BRCryptoFeeBasis feeBasisConfirmed = cryptoFeeBasisCreateAsETH (unit,
-                                                                                feeBasisGetGasLimit(ethFeeBasis),
-                                                                                feeBasisGetGasPrice(ethFeeBasis));
+                                                                                ethFeeBasisGetGasLimit(ethFeeBasis),
+                                                                                ethFeeBasisGetGasPrice(ethFeeBasis));
 
                 ewmTransferExtractStatusIncluded(ewm, tid, NULL, &blockNumber, &blockTransactionIndex, &blockTimestamp, &gasUsed);
                 BRCryptoTransferState newState = cryptoTransferStateIncludedInit (blockNumber,

--- a/crypto/BRCryptoWalletManagerClient.c
+++ b/crypto/BRCryptoWalletManagerClient.c
@@ -1423,7 +1423,7 @@ cwmGetBalanceAsETH (BREthereumClientContext context,
                                 cryptoWalletManagerTake (cwm),
                                 callbackState,
                                 &address, 1,
-                                (NULL == token ? NULL : tokenGetAddress (token)));
+                                (NULL == token ? NULL : ethTokenGetAddress (token)));
 
     cryptoWalletManagerGive (cwm);
 }

--- a/crypto/BRCryptoWalletManagerClient.c
+++ b/crypto/BRCryptoWalletManagerClient.c
@@ -1443,7 +1443,7 @@ cwmGetGasPriceAsETH (BREthereumClientContext context,
     callbackState->rid = rid;
 
     BREthereumNetwork network = ewmGetNetwork (ewm);
-    char *networkName = networkCopyNameAsLowercase (network);
+    char *networkName = ethNetworkCopyNameAsLowercase (network);
 
     cwm->client.funcGetGasPriceETH (cwm->client.context,
                                     cryptoWalletManagerTake (cwm),
@@ -1476,7 +1476,7 @@ cwmGetGasEstimateAsETH (BREthereumClientContext context,
     callbackState->rid = rid;
 
     BREthereumNetwork network = ewmGetNetwork (ewm);
-    char *networkName = networkCopyNameAsLowercase (network);
+    char *networkName = ethNetworkCopyNameAsLowercase (network);
 
     cwm->client.funcEstimateGasETH (cwm->client.context,
                                     cryptoWalletManagerTake (cwm),
@@ -1591,7 +1591,7 @@ cwmGetBlocksAsETH (BREthereumClientContext context,
     callbackState->rid = rid;
 
     BREthereumNetwork network = ewmGetNetwork (ewm);
-    char *networkName = networkCopyNameAsLowercase (network);
+    char *networkName = ethNetworkCopyNameAsLowercase (network);
 
     cwm->client.funcGetBlocksETH (cwm->client.context,
                                   cryptoWalletManagerTake (cwm),
@@ -1658,7 +1658,7 @@ cwmGetNonceAsETH (BREthereumClientContext context,
     callbackState->rid = rid;
 
     BREthereumNetwork network = ewmGetNetwork (ewm);
-    char *networkName = networkCopyNameAsLowercase (network);
+    char *networkName = ethNetworkCopyNameAsLowercase (network);
 
     cwm->client.funcGetNonceETH (cwm->client.context,
                                  cryptoWalletManagerTake (cwm),

--- a/crypto/testCrypto.c
+++ b/crypto/testCrypto.c
@@ -210,7 +210,7 @@ transferTestsBalance (void) {
         BRCryptoTransferTest *test = &transferTests[index];
 
         size_t   testRawSize;
-        uint8_t *testRawBytes = decodeHexCreate(&testRawSize, test->rawChars, strlen (test->rawChars));
+        uint8_t *testRawBytes = hexDecodeCreate(&testRawSize, test->rawChars, strlen (test->rawChars));
 
         transactions[index] = BRTransactionParse (testRawBytes, testRawSize);
         transactions[index]->blockHeight = test->blockHeight;
@@ -267,7 +267,7 @@ transferTestsAddress (void) {
         BRCryptoTransferTest *test = &transferTests[index];
 
         size_t   testRawSize;
-        uint8_t *testRawBytes = decodeHexCreate(&testRawSize, test->rawChars, strlen (test->rawChars));
+        uint8_t *testRawBytes = hexDecodeCreate(&testRawSize, test->rawChars, strlen (test->rawChars));
 
         BRTransaction *tid = BRTransactionParse (testRawBytes, testRawSize);
         tid->blockHeight = test->blockHeight;

--- a/ethereum/base/BREthereumAddress.c
+++ b/ethereum/base/BREthereumAddress.c
@@ -20,8 +20,8 @@
 // Address Raw
 //
 extern BREthereumAddress
-addressCreate (const char *address) {
-    if (ETHEREUM_BOOLEAN_IS_FALSE(addressValidateString(address))) return EMPTY_ADDRESS_INIT;
+ethAddressCreate (const char *address) {
+    if (ETHEREUM_BOOLEAN_IS_FALSE(ethAddressValidateString(address))) return EMPTY_ADDRESS_INIT;
 
     BREthereumAddress raw;
     if (0 == strncmp ("0x", address, 2)) address = &address[2];
@@ -30,7 +30,7 @@ addressCreate (const char *address) {
 }
 
 extern BREthereumBoolean
-addressValidateString(const char *string) {
+ethAddressValidateString(const char *string) {
     return 42 == strlen(string)
            && '0' == string[0]
            && 'x' == string[1]
@@ -40,7 +40,7 @@ addressValidateString(const char *string) {
 }
 
 extern BREthereumAddress
-addressCreateKey (const BRKey *key) {
+ethAddressCreateKey (const BRKey *key) {
     BREthereumAddress address;
 
     // We interrupt your regularly scheduled programming...
@@ -74,14 +74,14 @@ addressCreateKey (const BRKey *key) {
 
 
 extern char *
-addressGetEncodedString (BREthereumAddress address, int useChecksum) {
+ethAddressGetEncodedString (BREthereumAddress address, int useChecksum) {
     char *string = calloc (1, ADDRESS_ENCODED_CHARS);
-    addressFillEncodedString(address, useChecksum, string);
+    ethAddressFillEncodedString(address, useChecksum, string);
     return string;
 }
 
 extern void
-addressFillEncodedString (BREthereumAddress address,
+ethAddressFillEncodedString (BREthereumAddress address,
                           int useChecksum,
                           char *string) {
 
@@ -148,13 +148,13 @@ addressFillEncodedString (BREthereumAddress address,
 }
 
 extern BREthereumHash
-addressGetHash (BREthereumAddress address) {
+ethAddressGetHash (BREthereumAddress address) {
     BRRlpData data = { 20, address.bytes };
     return ethHashCreateFromData(data);
 }
 
 extern BREthereumAddress
-addressRlpDecode (BRRlpItem item, BRRlpCoder coder) {
+ethAddressRlpDecode (BRRlpItem item, BRRlpCoder coder) {
     BREthereumAddress address = EMPTY_ADDRESS_INIT;
 
     BRRlpData data = rlpDecodeBytes(coder, item);
@@ -168,13 +168,13 @@ addressRlpDecode (BRRlpItem item, BRRlpCoder coder) {
 }
 
 extern BRRlpItem
-addressRlpEncode(BREthereumAddress address,
+ethAddressRlpEncode(BREthereumAddress address,
                  BRRlpCoder coder) {
     return rlpEncodeBytes(coder, address.bytes, 20);
 }
 
 extern BREthereumBoolean
-addressEqual (BREthereumAddress address1,
+ethAddressEqual (BREthereumAddress address1,
               BREthereumAddress address2) {
     return (0 == memcmp(address1.bytes, address2.bytes, 20)
             ? ETHEREUM_BOOLEAN_TRUE

--- a/ethereum/base/BREthereumAddress.c
+++ b/ethereum/base/BREthereumAddress.c
@@ -150,7 +150,7 @@ addressFillEncodedString (BREthereumAddress address,
 extern BREthereumHash
 addressGetHash (BREthereumAddress address) {
     BRRlpData data = { 20, address.bytes };
-    return hashCreateFromData(data);
+    return ethHashCreateFromData(data);
 }
 
 extern BREthereumAddress

--- a/ethereum/base/BREthereumAddress.c
+++ b/ethereum/base/BREthereumAddress.c
@@ -25,7 +25,7 @@ addressCreate (const char *address) {
 
     BREthereumAddress raw;
     if (0 == strncmp ("0x", address, 2)) address = &address[2];
-    decodeHex(raw.bytes, sizeof(raw.bytes), address, strlen(address));
+    hexDecode(raw.bytes, sizeof(raw.bytes), address, strlen(address));
     return raw;
 }
 
@@ -34,7 +34,7 @@ addressValidateString(const char *string) {
     return 42 == strlen(string)
            && '0' == string[0]
            && 'x' == string[1]
-           && encodeHexValidate (&string[2])
+           && hexEncodeValidate (&string[2])
            ? ETHEREUM_BOOLEAN_TRUE
            : ETHEREUM_BOOLEAN_FALSE;
 }
@@ -90,7 +90,7 @@ addressFillEncodedString (BREthereumAddress address,
     string[1] = 'x';
 
     // Offset '2' into address->string and account for the '\0' terminator.
-    encodeHex(&string[2], 40 + 1, address.bytes, 20);
+    hexEncode(&string[2], 40 + 1, address.bytes, 20);
 
     if (!useChecksum) return;
 
@@ -139,7 +139,7 @@ addressFillEncodedString (BREthereumAddress address,
     for (int i = 0; i < checksumAddrLen; i++) {
         // We should hex-encode the hash and then look character by character.  Instead
         // we'll extract 4 bits as the upper or lower nibble and compare to 8.  This is the
-        // same extracting that encodeHex performs, ultimately.
+        // same extracting that hexEncode performs, ultimately.
         int value = 0x0f & (hash[i / 2] >> ((0 == i % 2) ? 4 : 0));
         checksumAddr[i] = (value < 8
                            ? (char) tolower(checksumAddr[i])

--- a/ethereum/base/BREthereumAddress.h
+++ b/ethereum/base/BREthereumAddress.h
@@ -47,16 +47,16 @@ typedef struct {
 (_hexu((s)[36]) << 4) | _hexu((s)[37]), (_hexu((s)[38]) << 4) | _hexu((s)[39]) } })
 
 extern BREthereumAddress
-addressCreate (const char *address);
+ethAddressCreate (const char *address);
 
 extern BREthereumBoolean
-addressValidateString(const char *string);
+ethAddressValidateString(const char *string);
 
 /**
  * Create an EtherumAddress from a `key` - a BRKey that already has the PubKey provided!
  */
 extern BREthereumAddress
-addressCreateKey (const BRKey *keyWithPubKeyProvided);
+ethAddressCreateKey (const BRKey *keyWithPubKeyProvided);
 
 #define ADDRESS_ENCODED_CHARS    (2*ADDRESS_BYTES + 2 + 1)  // "0x" prefaced
 
@@ -65,11 +65,11 @@ addressCreateKey (const BRKey *keyWithPubKeyProvided);
  *
  * @param address
  * @param useChecksum if true(1) return an address with checksummed characters.
- * 
+ *
  * @return newly allocated memory of char*
  */
 extern char *
-addressGetEncodedString (BREthereumAddress address, int useChecksum);
+ethAddressGetEncodedString (BREthereumAddress address, int useChecksum);
 
 
 /**
@@ -81,33 +81,33 @@ addressGetEncodedString (BREthereumAddress address, int useChecksum);
  * @param string target to fill
  */
 extern void
-addressFillEncodedString (BREthereumAddress address,
-                          int useChecksum,
-                          char *string);
+ethAddressFillEncodedString (BREthereumAddress address,
+                             int useChecksum,
+                             char *string);
 
 extern BREthereumHash
-addressGetHash (BREthereumAddress address);
+ethAddressGetHash (BREthereumAddress address);
 
 extern BREthereumAddress
-addressRlpDecode (BRRlpItem item,
+ethAddressRlpDecode (BRRlpItem item,
                      BRRlpCoder coder);
 
 extern BRRlpItem
-addressRlpEncode(BREthereumAddress address,
+ethAddressRlpEncode(BREthereumAddress address,
                     BRRlpCoder coder);
 
 extern BREthereumBoolean
-addressEqual (BREthereumAddress address1,
+ethAddressEqual (BREthereumAddress address1,
                  BREthereumAddress address2);
 
 static inline int
-addressHashValue (BREthereumAddress address) {
+ethAddressHashValue (BREthereumAddress address) {
     return ((UInt160 *) &address)->u32[0];
 }
 
 static inline int
-addressHashEqual (BREthereumAddress address1,
-                  BREthereumAddress address2) {
+ethAddressHashEqual (BREthereumAddress address1,
+                     BREthereumAddress address2) {
     return 0 == memcmp (address1.bytes, address2.bytes, 20);
 }
 

--- a/ethereum/base/BREthereumData.c
+++ b/ethereum/base/BREthereumData.c
@@ -82,7 +82,7 @@ hashDataPairCreate (BREthereumHash hash,
 extern BREthereumHashDataPair
 hashDataPairCreateFromString (const char *hashString,
                               const char *dataString) {
-    return hashDataPairCreate (hashCreate (hashString),
+    return hashDataPairCreate (ethHashCreate (hashString),
                                dataCreateFromString (dataString));
 }
 
@@ -100,7 +100,7 @@ hashDataPairGetHash (BREthereumHashDataPair pair) {
 // The hex-encoded hash.  You own this.
 extern char *
 hashDataPairGetHashAsString (BREthereumHashDataPair pair) {
-    return hashAsString (pair->hash);
+    return ethHashAsString (pair->hash);
 }
 
 // YOU DO NOT OWN THE RETURNED DATA
@@ -125,14 +125,14 @@ hashDataPairExtractStrings (BREthereumHashDataPair pair,
 extern size_t
 hashDataPairHashValue (const void *t)
 {
-    return hashSetValue(&((BREthereumHashDataPair) t)->hash);
+    return ethHashSetValue(&((BREthereumHashDataPair) t)->hash);
 }
 
 
 extern int
 hashDataPairHashEqual (const void *t1,
                        const void *t2) {
-    return t1 == t2 || hashSetEqual (&((BREthereumHashDataPair) t1)->hash,
+    return t1 == t2 || ethHashSetEqual (&((BREthereumHashDataPair) t1)->hash,
                                      &((BREthereumHashDataPair) t2)->hash);
 }
 

--- a/ethereum/base/BREthereumData.c
+++ b/ethereum/base/BREthereumData.c
@@ -8,7 +8,7 @@
 //  See the LICENSE file at the project root for license information.
 //  See the CONTRIBUTORS file at the project root for a list of contributors.
 
-#include "ethereum/util/BRUtil.h" // encodeHexCreate()
+#include "ethereum/util/BRUtil.h" // hexEncodeCreate()
 #include "BREthereumData.h"
 
 /// MARK: - Data
@@ -35,7 +35,7 @@ dataCreateFromRlpData (BRRlpData rlp,
 extern BREthereumData
 dataCreateFromString (const char *string) {
     BREthereumData data;
-    data.bytes = decodeHexCreate(&data.count, string, strlen (string));
+    data.bytes = hexDecodeCreate(&data.count, string, strlen (string));
     return data;
 }
 
@@ -51,7 +51,7 @@ dataRelease (BREthereumData data) {
 
 extern char *
 dataAsString (BREthereumData data) {
-    return encodeHexCreate (NULL, data.bytes, data.count);
+    return hexEncodeCreate (NULL, data.bytes, data.count);
 }
 
 extern BRRlpData

--- a/ethereum/base/BREthereumData.c
+++ b/ethereum/base/BREthereumData.c
@@ -14,48 +14,48 @@
 /// MARK: - Data
 
 extern BREthereumData
-dataCreateFromBytes (size_t count, uint8_t *bytes, int takeBytes) {
+ethDataCreateFromBytes (size_t count, uint8_t *bytes, int takeBytes) {
     uint8_t *data = bytes;  // take the bytes...
-
+    
     // ... oops, we can't, so copy.
     if (!takeBytes) {
         data = malloc (count);
         memcpy (data, bytes, count);
     }
-
+    
     return (BREthereumData) { count, data };
 }
 
 extern BREthereumData
-dataCreateFromRlpData (BRRlpData rlp,
-                       int takeBytes) {
-    return dataCreateFromBytes (rlp.bytesCount, rlp.bytes, takeBytes);
+ethDataCreateFromRlpData (BRRlpData rlp,
+                          int takeBytes) {
+    return ethDataCreateFromBytes (rlp.bytesCount, rlp.bytes, takeBytes);
 }
 
 extern BREthereumData
-dataCreateFromString (const char *string) {
+ethDataCreateFromString (const char *string) {
     BREthereumData data;
     data.bytes = hexDecodeCreate(&data.count, string, strlen (string));
     return data;
 }
 
 extern BREthereumData
-dataCopy (BREthereumData data) {
-    return dataCreateFromBytes (data.count, data.bytes, 1);
+ethDataCopy (BREthereumData data) {
+    return ethDataCreateFromBytes (data.count, data.bytes, 1);
 }
 
 extern void
-dataRelease (BREthereumData data) {
+ethDataRelease (BREthereumData data) {
     if (NULL != data.bytes) free (data.bytes);
 }
 
 extern char *
-dataAsString (BREthereumData data) {
+ethDataAsString (BREthereumData data) {
     return hexEncodeCreate (NULL, data.bytes, data.count);
 }
 
 extern BRRlpData
-dataAsRlpData (BREthereumData data) {
+ethDataAsRlpData (BREthereumData data) {
     BRRlpData rlp = { data.count, malloc (data.count) };
     memcpy (rlp.bytes, data.bytes, data.count);
     return rlp;
@@ -69,109 +69,109 @@ struct BREthereumHashDataPairRecord {
 };
 
 extern BREthereumHashDataPair
-hashDataPairCreate (BREthereumHash hash,
-                    BREthereumData data) {
+ethHashDataPairCreate (BREthereumHash hash,
+                       BREthereumData data) {
     BREthereumHashDataPair pair = malloc (sizeof (struct BREthereumHashDataPairRecord));
-
+    
     pair->hash = hash;
     pair->data = data;
-
+    
     return pair;
 }
 
 extern BREthereumHashDataPair
-hashDataPairCreateFromString (const char *hashString,
-                              const char *dataString) {
-    return hashDataPairCreate (ethHashCreate (hashString),
-                               dataCreateFromString (dataString));
+ethHashDataPairCreateFromString (const char *hashString,
+                                 const char *dataString) {
+    return ethHashDataPairCreate (ethHashCreate (hashString),
+                                  ethDataCreateFromString (dataString));
 }
 
 extern void
-hashDataPairRelease (BREthereumHashDataPair pair) {
-    dataRelease (pair->data);
+ethHashDataPairRelease (BREthereumHashDataPair pair) {
+    ethDataRelease (pair->data);
     free (pair);
 }
 
 extern BREthereumHash
-hashDataPairGetHash (BREthereumHashDataPair pair) {
+ethHashDataPairGetHash (BREthereumHashDataPair pair) {
     return pair->hash;
 }
 
 // The hex-encoded hash.  You own this.
 extern char *
-hashDataPairGetHashAsString (BREthereumHashDataPair pair) {
+ethHashDataPairGetHashAsString (BREthereumHashDataPair pair) {
     return ethHashAsString (pair->hash);
 }
 
 // YOU DO NOT OWN THE RETURNED DATA
 extern BREthereumData
-hashDataPairGetData (BREthereumHashDataPair pair) {
+ethHashDataPairGetData (BREthereumHashDataPair pair) {
     return pair->data;
 }
 
 extern char *
-hashDataPairGetDataAsString (BREthereumHashDataPair pair) {
-    return dataAsString (pair->data);
+ethHashDataPairGetDataAsString (BREthereumHashDataPair pair) {
+    return ethDataAsString (pair->data);
 }
 
 extern void
-hashDataPairExtractStrings (BREthereumHashDataPair pair,
-                            char **hashAsString,
-                            char **dataAsString) {
-    if (NULL != hashAsString) *hashAsString = hashDataPairGetHashAsString (pair);
-    if (NULL != dataAsString) *dataAsString = hashDataPairGetDataAsString (pair);
+ethHashDataPairExtractStrings (BREthereumHashDataPair pair,
+                               char **hashAsString,
+                               char **dataAsString) {
+    if (NULL != hashAsString) *hashAsString = ethHashDataPairGetHashAsString (pair);
+    if (NULL != dataAsString) *dataAsString = ethHashDataPairGetDataAsString (pair);
 }
 
 extern size_t
-hashDataPairHashValue (const void *t)
+ethHashDataPairHashValue (const void *t)
 {
     return ethHashSetValue(&((BREthereumHashDataPair) t)->hash);
 }
 
 
 extern int
-hashDataPairHashEqual (const void *t1,
-                       const void *t2) {
+ethHashDataPairHashEqual (const void *t1,
+                          const void *t2) {
     return t1 == t2 || ethHashSetEqual (&((BREthereumHashDataPair) t1)->hash,
-                                     &((BREthereumHashDataPair) t2)->hash);
+                                        &((BREthereumHashDataPair) t2)->hash);
 }
 
 /// MARK: - Hash Data Pair Set
 extern BRSetOf (BREthereumHashDataPair)
-hashDataPairSetCreateEmpty(size_t count) {
-    return BRSetNew (hashDataPairHashValue,
-                     hashDataPairHashEqual,
+ethHashDataPairSetCreateEmpty(size_t count) {
+    return BRSetNew (ethHashDataPairHashValue,
+                     ethHashDataPairHashEqual,
                      count);
 }
 
 extern BRSetOf (BREthereumHashDataPair)
-hashDataPairSetCreate (BRArrayOf(BREthereumHashDataPair) pairs) {
+ethHashDataPairSetCreate (BRArrayOf(BREthereumHashDataPair) pairs) {
     size_t count = array_count (pairs);
-    BRSetOf(BREthereumHashDataPair) set = hashDataPairSetCreateEmpty (count);
-
+    BRSetOf(BREthereumHashDataPair) set = ethHashDataPairSetCreateEmpty (count);
+    
     for (size_t index = 0; index < count; index++)
         BRSetAdd (set, pairs[index]);
-
+    
     array_free (pairs);
     return set;
 }
 
 extern void
-hashDataPairSetRelease (BRSetOf (BREthereumHashDataPair) set) {
+ethHashDataPairSetRelease (BRSetOf (BREthereumHashDataPair) set) {
     size_t itemsCount = BRSetCount (set);
     void  *itemsAll [itemsCount];
-
+    
     BRSetAll (set, itemsAll,  itemsCount);
     for (size_t index = 0; index < itemsCount; index++)
-        hashDataPairRelease ((BREthereumHashDataPair) itemsAll[index]);
+        ethHashDataPairRelease ((BREthereumHashDataPair) itemsAll[index]);
     
     BRSetClear (set);
     BRSetFree  (set);
 }
 
 extern void
-hashDataPairAdd (BRSetOf(BREthereumHashDataPair) set,
-                 const char *hash,
-                 const char *data) {
-    BRSetAdd (set, hashDataPairCreateFromString(hash, data));
+ethHashDataPairAdd (BRSetOf(BREthereumHashDataPair) set,
+                    const char *hash,
+                    const char *data) {
+    BRSetAdd (set, ethHashDataPairCreateFromString(hash, data));
 }

--- a/ethereum/base/BREthereumData.c
+++ b/ethereum/base/BREthereumData.c
@@ -16,13 +16,13 @@
 extern BREthereumData
 ethDataCreateFromBytes (size_t count, uint8_t *bytes, int takeBytes) {
     uint8_t *data = bytes;  // take the bytes...
-    
+
     // ... oops, we can't, so copy.
     if (!takeBytes) {
         data = malloc (count);
         memcpy (data, bytes, count);
     }
-    
+
     return (BREthereumData) { count, data };
 }
 
@@ -72,10 +72,10 @@ extern BREthereumHashDataPair
 ethHashDataPairCreate (BREthereumHash hash,
                        BREthereumData data) {
     BREthereumHashDataPair pair = malloc (sizeof (struct BREthereumHashDataPairRecord));
-    
+
     pair->hash = hash;
     pair->data = data;
-    
+
     return pair;
 }
 
@@ -148,10 +148,10 @@ extern BRSetOf (BREthereumHashDataPair)
 ethHashDataPairSetCreate (BRArrayOf(BREthereumHashDataPair) pairs) {
     size_t count = array_count (pairs);
     BRSetOf(BREthereumHashDataPair) set = ethHashDataPairSetCreateEmpty (count);
-    
+
     for (size_t index = 0; index < count; index++)
         BRSetAdd (set, pairs[index]);
-    
+
     array_free (pairs);
     return set;
 }
@@ -160,7 +160,7 @@ extern void
 ethHashDataPairSetRelease (BRSetOf (BREthereumHashDataPair) set) {
     size_t itemsCount = BRSetCount (set);
     void  *itemsAll [itemsCount];
-    
+
     BRSetAll (set, itemsAll,  itemsCount);
     for (size_t index = 0; index < itemsCount; index++)
         ethHashDataPairRelease ((BREthereumHashDataPair) itemsAll[index]);

--- a/ethereum/base/BREthereumData.h
+++ b/ethereum/base/BREthereumData.h
@@ -31,29 +31,29 @@ typedef struct {
 } BREthereumData;
 
 extern BREthereumData
-dataCreateFromBytes (size_t count,
-                     uint8_t *bytes,
-                     int takeBytes);
+ethDataCreateFromBytes (size_t count,
+                        uint8_t *bytes,
+                        int takeBytes);
 
 extern BREthereumData
-dataCreateFromRlpData (BRRlpData rlp,
-                       int takeBytes);
+ethDataCreateFromRlpData (BRRlpData rlp,
+                          int takeBytes);
 
 extern BREthereumData // invert dataAsString()
-dataCreateFromString (const char *string) ;
+ethDataCreateFromString (const char *string) ;
 
 extern BREthereumData
-dataCopy (BREthereumData data);
+ethDataCopy (BREthereumData data);
 
 extern void
-dataRelease (BREthereumData data);
+ethDataRelease (BREthereumData data);
 
 // hex-encoded data; you own this.
 extern char *
-dataAsString (BREthereumData data);
+ethDataAsString (BREthereumData data);
 
 extern BRRlpData
-dataAsRlpData (BREthereumData data);
+ethDataAsRlpData (BREthereumData data);
 
 /// MARK: - Hash Data Pair
 
@@ -67,59 +67,59 @@ typedef struct BREthereumHashDataPairRecord *BREthereumHashDataPair;
  * Create a BREthereumHashDataPair
  *
  * @note Takes ownership of `data` which must have been created with `takeBytes` (because
- * on `hashDataPairRelease()` the `data` will itself be released.
+ * on `ethHashDataPairRelease()` the `data` will itself be released.
  *
  * @param hash the hash
  * @param data the data
  * @return the hash-data-pair
  */
 extern BREthereumHashDataPair
-hashDataPairCreate (BREthereumHash hash,
-                    BREthereumData data);
+ethHashDataPairCreate (BREthereumHash hash,
+                       BREthereumData data);
 
 extern BREthereumHashDataPair
-hashDataPairCreateFromString (const char *hashString,
-                              const char *dataString);
+ethHashDataPairCreateFromString (const char *hashString,
+                                 const char *dataString);
 
 extern void
-hashDataPairRelease (BREthereumHashDataPair pair);
+ethHashDataPairRelease (BREthereumHashDataPair pair);
 
 static inline void
-hashDataPairReleaseForSet (void *ignore, void *item) {
-    hashDataPairRelease((BREthereumHashDataPair) item);
+ethHashDataPairReleaseForSet (void *ignore, void *item) {
+    ethHashDataPairRelease((BREthereumHashDataPair) item);
 }
 
 extern BREthereumHash
-hashDataPairGetHash (BREthereumHashDataPair pair);
+ethHashDataPairGetHash (BREthereumHashDataPair pair);
 
 // The hex-encoded hash.  You own this.
 extern char *
-hashDataPairGetHashAsString (BREthereumHashDataPair pair);
+ethHashDataPairGetHashAsString (BREthereumHashDataPair pair);
 
 // YOU DO NOT OWN THE RETURNED DATA
 extern BREthereumData
-hashDataPairGetData (BREthereumHashDataPair pair);
+ethHashDataPairGetData (BREthereumHashDataPair pair);
 
 // The hex-encoded data.  You own this.
 extern char *
-hashDataPairGetDataAsString (BREthereumHashDataPair pair);
+ethHashDataPairGetDataAsString (BREthereumHashDataPair pair);
 
 extern void
-hashDataPairExtractStrings (BREthereumHashDataPair pair,
-                            char **hashAsString,
-                            char **dataAsString);
+ethHashDataPairExtractStrings (BREthereumHashDataPair pair,
+                               char **hashAsString,
+                               char **dataAsString);
 
 extern size_t
-hashDataPairHashValue (const void *t);
+ethHashDataPairHashValue (const void *t);
 
 extern int
-hashDataPairHashEqual (const void *t1,
-                       const void *t2);
+ethHashDataPairHashEqual (const void *t1,
+                          const void *t2);
 
 /// MARK: - Hash Data Pair Set
 
 extern BRSetOf (BREthereumHashDataPair)
-hashDataPairSetCreateEmpty (size_t count);
+ethHashDataPairSetCreateEmpty (size_t count);
 
 /**
  * Create a BRSet of BREthereumHashDataPair.
@@ -131,15 +131,15 @@ hashDataPairSetCreateEmpty (size_t count);
  * @return a BRSET of BREthereumHashDataPair
  */
 extern BRSetOf (BREthereumHashDataPair)
-hashDataPairSetCreate (BRArrayOf(BREthereumHashDataPair) pairs);;
+ethHashDataPairSetCreate (BRArrayOf(BREthereumHashDataPair) pairs);;
 
 extern void
-hashDataPairSetRelease (BRSetOf (BREthereumHashDataPair) set);
+ethHashDataPairSetRelease (BRSetOf (BREthereumHashDataPair) set);
 
 extern void
-hashDataPairAdd (BRSetOf(BREthereumHashDataPair) set,
-                 const char *hash,
-                 const char *data);
+ethHashDataPairAdd (BRSetOf(BREthereumHashDataPair) set,
+                    const char *hash,
+                    const char *data);
 
 #ifdef __cplusplus
 }

--- a/ethereum/base/BREthereumEther.c
+++ b/ethereum/base/BREthereumEther.c
@@ -57,7 +57,7 @@ etherCreateUnit(const UInt256 value, BREthereumEtherUnit unit, int *overflow) {
             *overflow = 0;
             break;
         default: {
-            ether.valueInWEI = mulUInt256_Overflow(value, etherUnitScaleFactor[unit], overflow);
+            ether.valueInWEI = uint256Mul_Overflow(value, etherUnitScaleFactor[unit], overflow);
             break;
         }
     }
@@ -82,7 +82,7 @@ extern BREthereumEther
 etherCreateString(const char *number, BREthereumEtherUnit unit, BRCoreParseStatus *status) {
     int decimals = 3 * unit;
     
-    UInt256 value = createUInt256ParseDecimal(number, decimals, status);
+    UInt256 value = uint256CreateParseDecimal(number, decimals, status);
     return etherCreate(value);
 }
 
@@ -101,7 +101,7 @@ etherGetValue(const BREthereumEther ether,
 
 extern char * // Perhaps can be done. 1 WEI -> 1e-18 Ether
 etherGetValueString(const BREthereumEther ether, BREthereumEtherUnit unit) {
-    return coerceStringDecimal(ether.valueInWEI, 3 * unit);
+    return uint256CoerceStringDecimal(ether.valueInWEI, 3 * unit);
 }
 
 extern BRRlpItem
@@ -117,14 +117,14 @@ etherRlpDecode (BRRlpItem item, BRRlpCoder coder) {
 extern BREthereumEther
 etherAdd (BREthereumEther e1, BREthereumEther e2, int *overflow) {
     BREthereumEther result;
-    result.valueInWEI = addUInt256_Overflow(e1.valueInWEI, e2.valueInWEI, overflow);
+    result.valueInWEI = uint256Add_Overflow(e1.valueInWEI, e2.valueInWEI, overflow);
     return result;
 }
 
 extern BREthereumEther
 etherSub (BREthereumEther e1, BREthereumEther e2, int *negative) {
     BREthereumEther result;
-    result.valueInWEI = subUInt256_Negative(e1.valueInWEI, e2.valueInWEI, negative);
+    result.valueInWEI = uint256Sub_Negative(e1.valueInWEI, e2.valueInWEI, negative);
     return result;
     
 }
@@ -134,27 +134,27 @@ etherSub (BREthereumEther e1, BREthereumEther e2, int *negative) {
 //
 extern BREthereumBoolean
 etherIsEQ (BREthereumEther e1, BREthereumEther e2) {
-    return eqUInt256 (e1.valueInWEI, e2.valueInWEI) ? ETHEREUM_BOOLEAN_TRUE : ETHEREUM_BOOLEAN_FALSE;
+    return uint256EQL (e1.valueInWEI, e2.valueInWEI) ? ETHEREUM_BOOLEAN_TRUE : ETHEREUM_BOOLEAN_FALSE;
 }
 
 extern BREthereumBoolean
 etherIsGT (BREthereumEther e1, BREthereumEther e2) {
-    return gtUInt256(e1.valueInWEI, e2.valueInWEI) ? ETHEREUM_BOOLEAN_TRUE : ETHEREUM_BOOLEAN_FALSE;
+    return uint256GT(e1.valueInWEI, e2.valueInWEI) ? ETHEREUM_BOOLEAN_TRUE : ETHEREUM_BOOLEAN_FALSE;
 }
 
 extern BREthereumBoolean
 etherIsGE (BREthereumEther e1, BREthereumEther e2) {
-    return geUInt256(e1.valueInWEI, e2.valueInWEI) ? ETHEREUM_BOOLEAN_TRUE : ETHEREUM_BOOLEAN_FALSE;
+    return uint256GE(e1.valueInWEI, e2.valueInWEI) ? ETHEREUM_BOOLEAN_TRUE : ETHEREUM_BOOLEAN_FALSE;
 }
 
 extern BREthereumBoolean
 etherIsLT (BREthereumEther e1, BREthereumEther e2) {
-    return ltUInt256(e1.valueInWEI, e2.valueInWEI) ? ETHEREUM_BOOLEAN_TRUE : ETHEREUM_BOOLEAN_FALSE;
+    return uint256LT(e1.valueInWEI, e2.valueInWEI) ? ETHEREUM_BOOLEAN_TRUE : ETHEREUM_BOOLEAN_FALSE;
 }
 
 extern BREthereumBoolean
 etherIsLE (BREthereumEther e1, BREthereumEther e2) {
-    return leUInt256(e1.valueInWEI, e2.valueInWEI) ? ETHEREUM_BOOLEAN_TRUE : ETHEREUM_BOOLEAN_FALSE;
+    return uint256LE(e1.valueInWEI, e2.valueInWEI) ? ETHEREUM_BOOLEAN_TRUE : ETHEREUM_BOOLEAN_FALSE;
 }
 
 extern BREthereumBoolean
@@ -164,7 +164,7 @@ etherIsZero (BREthereumEther e) {
 
 extern BREthereumComparison
 etherCompare (BREthereumEther e1, BREthereumEther e2) {
-    switch (compareUInt256(e1.valueInWEI, e2.valueInWEI))
+    switch (uint256Compare(e1.valueInWEI, e2.valueInWEI))
     {
         case -1: return ETHEREUM_COMPARISON_LT;
         case  0: return ETHEREUM_COMPARISON_EQ;

--- a/ethereum/base/BREthereumEther.c
+++ b/ethereum/base/BREthereumEther.c
@@ -40,14 +40,14 @@ static UInt256 etherUnitScaleFactor [NUMBER_OF_ETHER_UNITS] = {   /* LITTLE ENDI
 };
 
 extern BREthereumEther
-etherCreate(const UInt256 value) {
+ethEtherCreate(const UInt256 value) {
     BREthereumEther ether;
     ether.valueInWEI = value;
     return ether;
 }
 
 extern BREthereumEther
-etherCreateUnit(const UInt256 value, BREthereumEtherUnit unit, int *overflow) {
+ethEtherCreateUnit(const UInt256 value, BREthereumEtherUnit unit, int *overflow) {
     assert (NULL != overflow);
     
     BREthereumEther ether;
@@ -65,30 +65,30 @@ etherCreateUnit(const UInt256 value, BREthereumEtherUnit unit, int *overflow) {
 }
 
 extern BREthereumEther
-etherCreateNumber (uint64_t number, BREthereumEtherUnit unit) {
+ethEtherCreateNumber (uint64_t number, BREthereumEtherUnit unit) {
     int overflow;
     UInt256 value = { .u64 = { number, 0, 0, 0 } };
-    BREthereumEther ether = etherCreateUnit(value, unit, &overflow);
+    BREthereumEther ether = ethEtherCreateUnit(value, unit, &overflow);
     assert (0 == overflow);
     return ether;
 }
 
 extern BREthereumEther
-etherCreateZero(void) {
-    return etherCreate(UINT256_ZERO);
+ethEtherCreateZero(void) {
+    return ethEtherCreate(UINT256_ZERO);
 }
 
 extern BREthereumEther
-etherCreateString(const char *number, BREthereumEtherUnit unit, BRCoreParseStatus *status) {
+ethEtherCreateString(const char *number, BREthereumEtherUnit unit, BRCoreParseStatus *status) {
     int decimals = 3 * unit;
     
     UInt256 value = uint256CreateParseDecimal(number, decimals, status);
-    return etherCreate(value);
+    return ethEtherCreate(value);
 }
 
 
 extern UInt256 // Can't be done: 1 WEI in ETHER... not representable as UInt256
-etherGetValue(const BREthereumEther ether,
+ethEtherGetValue(const BREthereumEther ether,
               BREthereumEtherUnit unit) {
     switch (unit) {
         case WEI:
@@ -100,29 +100,29 @@ etherGetValue(const BREthereumEther ether,
 }
 
 extern char * // Perhaps can be done. 1 WEI -> 1e-18 Ether
-etherGetValueString(const BREthereumEther ether, BREthereumEtherUnit unit) {
+ethEtherGetValueString(const BREthereumEther ether, BREthereumEtherUnit unit) {
     return uint256CoerceStringDecimal(ether.valueInWEI, 3 * unit);
 }
 
 extern BRRlpItem
-etherRlpEncode (const BREthereumEther ether, BRRlpCoder coder) {
+ethEtherRlpEncode (const BREthereumEther ether, BRRlpCoder coder) {
     return rlpEncodeUInt256(coder, ether.valueInWEI, 1);
 }
 
 extern BREthereumEther
-etherRlpDecode (BRRlpItem item, BRRlpCoder coder) {
-    return etherCreate(rlpDecodeUInt256(coder, item, 1));
+ethEtherRlpDecode (BRRlpItem item, BRRlpCoder coder) {
+    return ethEtherCreate(rlpDecodeUInt256(coder, item, 1));
 }
 
 extern BREthereumEther
-etherAdd (BREthereumEther e1, BREthereumEther e2, int *overflow) {
+ethEtherAdd (BREthereumEther e1, BREthereumEther e2, int *overflow) {
     BREthereumEther result;
     result.valueInWEI = uint256Add_Overflow(e1.valueInWEI, e2.valueInWEI, overflow);
     return result;
 }
 
 extern BREthereumEther
-etherSub (BREthereumEther e1, BREthereumEther e2, int *negative) {
+ethEtherSub (BREthereumEther e1, BREthereumEther e2, int *negative) {
     BREthereumEther result;
     result.valueInWEI = uint256Sub_Negative(e1.valueInWEI, e2.valueInWEI, negative);
     return result;
@@ -133,37 +133,37 @@ etherSub (BREthereumEther e1, BREthereumEther e2, int *negative) {
 // Comparisons
 //
 extern BREthereumBoolean
-etherIsEQ (BREthereumEther e1, BREthereumEther e2) {
+ethEtherIsEQ (BREthereumEther e1, BREthereumEther e2) {
     return uint256EQL (e1.valueInWEI, e2.valueInWEI) ? ETHEREUM_BOOLEAN_TRUE : ETHEREUM_BOOLEAN_FALSE;
 }
 
 extern BREthereumBoolean
-etherIsGT (BREthereumEther e1, BREthereumEther e2) {
+ethEtherIsGT (BREthereumEther e1, BREthereumEther e2) {
     return uint256GT(e1.valueInWEI, e2.valueInWEI) ? ETHEREUM_BOOLEAN_TRUE : ETHEREUM_BOOLEAN_FALSE;
 }
 
 extern BREthereumBoolean
-etherIsGE (BREthereumEther e1, BREthereumEther e2) {
+ethEtherIsGE (BREthereumEther e1, BREthereumEther e2) {
     return uint256GE(e1.valueInWEI, e2.valueInWEI) ? ETHEREUM_BOOLEAN_TRUE : ETHEREUM_BOOLEAN_FALSE;
 }
 
 extern BREthereumBoolean
-etherIsLT (BREthereumEther e1, BREthereumEther e2) {
+ethEtherIsLT (BREthereumEther e1, BREthereumEther e2) {
     return uint256LT(e1.valueInWEI, e2.valueInWEI) ? ETHEREUM_BOOLEAN_TRUE : ETHEREUM_BOOLEAN_FALSE;
 }
 
 extern BREthereumBoolean
-etherIsLE (BREthereumEther e1, BREthereumEther e2) {
+ethEtherIsLE (BREthereumEther e1, BREthereumEther e2) {
     return uint256LE(e1.valueInWEI, e2.valueInWEI) ? ETHEREUM_BOOLEAN_TRUE : ETHEREUM_BOOLEAN_FALSE;
 }
 
 extern BREthereumBoolean
-etherIsZero (BREthereumEther e) {
+ethEtherIsZero (BREthereumEther e) {
     return UInt256IsZero (e.valueInWEI) ? ETHEREUM_BOOLEAN_TRUE : ETHEREUM_BOOLEAN_FALSE;
 }
 
 extern BREthereumComparison
-etherCompare (BREthereumEther e1, BREthereumEther e2) {
+ethEtherCompare (BREthereumEther e1, BREthereumEther e2) {
     switch (uint256Compare(e1.valueInWEI, e2.valueInWEI))
     {
         case -1: return ETHEREUM_COMPARISON_LT;

--- a/ethereum/base/BREthereumEther.h
+++ b/ethereum/base/BREthereumEther.h
@@ -63,16 +63,16 @@ typedef struct BREthereumEtherStruct {
 #define EMPTY_ETHER_INIT  ((const BREthereumEther) { UINT256_ZERO })
     
 extern BREthereumEther
-etherCreateZero (void);
+ethEtherCreateZero (void);
 
 extern BREthereumEther
-etherCreate(const UInt256 value);
+ethEtherCreate(const UInt256 value);
 
 extern BREthereumEther
-etherCreateUnit(const UInt256 value, BREthereumEtherUnit unit, int *overflow);
+ethEtherCreateUnit(const UInt256 value, BREthereumEtherUnit unit, int *overflow);
 
 extern BREthereumEther
-etherCreateNumber (uint64_t number, BREthereumEtherUnit unit);
+ethEtherCreateNumber (uint64_t number, BREthereumEtherUnit unit);
 
 /**
  * Create Ether from a decimal string in unit.  The `number` must be either an integer or have
@@ -83,10 +83,10 @@ etherCreateNumber (uint64_t number, BREthereumEtherUnit unit);
  *
  */
 extern BREthereumEther
-etherCreateString(const char *string, BREthereumEtherUnit unit, BRCoreParseStatus *status);
+ethEtherCreateString(const char *string, BREthereumEtherUnit unit, BRCoreParseStatus *status);
 
 extern UInt256
-etherGetValue(const BREthereumEther ether, BREthereumEtherUnit unit);
+ethEtherGetValue(const BREthereumEther ether, BREthereumEtherUnit unit);
 
 /**
  * Return a decimal string representing `ether` in `unit`.
@@ -97,43 +97,43 @@ etherGetValue(const BREthereumEther ether, BREthereumEtherUnit unit);
  * @return A newly allocated string (you own it).
  */
 extern char *
-etherGetValueString(const BREthereumEther ether, BREthereumEtherUnit unit);
+ethEtherGetValueString(const BREthereumEther ether, BREthereumEtherUnit unit);
 
 extern BRRlpItem
-etherRlpEncode (const BREthereumEther ether, BRRlpCoder coder);
+ethEtherRlpEncode (const BREthereumEther ether, BRRlpCoder coder);
 
 extern BREthereumEther
-etherRlpDecode (BRRlpItem item, BRRlpCoder coder);
+ethEtherRlpDecode (BRRlpItem item, BRRlpCoder coder);
     
 extern BREthereumEther
-etherAdd (BREthereumEther e1, BREthereumEther e2, int *overflow);
+ethEtherAdd (BREthereumEther e1, BREthereumEther e2, int *overflow);
 
 extern BREthereumEther
-etherSub (BREthereumEther e1, BREthereumEther e2, int *negative);
+ethEtherSub (BREthereumEther e1, BREthereumEther e2, int *negative);
 
 //
 // Comparisons
 //
 extern BREthereumBoolean
-etherIsEQ (BREthereumEther e1, BREthereumEther e2);
+ethEtherIsEQ (BREthereumEther e1, BREthereumEther e2);
 
 extern BREthereumBoolean
-etherIsGT (BREthereumEther e1, BREthereumEther e2);
+ethEtherIsGT (BREthereumEther e1, BREthereumEther e2);
 
 extern BREthereumBoolean
-etherIsGE (BREthereumEther e1, BREthereumEther e2);
+ethEtherIsGE (BREthereumEther e1, BREthereumEther e2);
 
 extern BREthereumBoolean
-etherIsLT (BREthereumEther e1, BREthereumEther e2);
+ethEtherIsLT (BREthereumEther e1, BREthereumEther e2);
 
 extern BREthereumBoolean
-etherIsLE (BREthereumEther e1, BREthereumEther e2);
+ethEtherIsLE (BREthereumEther e1, BREthereumEther e2);
 
 extern BREthereumBoolean
-etherIsZero (BREthereumEther e);
+ethEtherIsZero (BREthereumEther e);
 
 extern BREthereumComparison
-etherCompare (BREthereumEther e1, BREthereumEther e2);
+ethEtherCompare (BREthereumEther e1, BREthereumEther e2);
 
 #ifdef __cplusplus
 }

--- a/ethereum/base/BREthereumFeeBasis.c
+++ b/ethereum/base/BREthereumFeeBasis.c
@@ -38,8 +38,8 @@ feeBasisGetFee (BREthereumFeeBasis feeBasis, int *overflow) {  // BREthereumBool
             return etherCreateZero();
 
         case FEE_BASIS_GAS:
-            return etherCreate (mulUInt256_Overflow (feeBasis.u.gas.price.etherPerGas.valueInWEI,
-                                                     createUInt256 (feeBasis.u.gas.limit.amountOfGas),
+            return etherCreate (uint256Mul_Overflow (feeBasis.u.gas.price.etherPerGas.valueInWEI,
+                                                     uint256Create (feeBasis.u.gas.limit.amountOfGas),
                                                      overflow));
     }
 }

--- a/ethereum/base/BREthereumFeeBasis.c
+++ b/ethereum/base/BREthereumFeeBasis.c
@@ -21,12 +21,12 @@ feeBasisCreate (BREthereumGas limit,
 
 extern BREthereumGas
 feeBasisGetGasLimit (BREthereumFeeBasis basis) {
-    return (FEE_BASIS_GAS == basis.type ? basis.u.gas.limit : gasCreate(0));
+    return (FEE_BASIS_GAS == basis.type ? basis.u.gas.limit : ethGasCreate(0));
 }
 
 extern BREthereumGasPrice
 feeBasisGetGasPrice (BREthereumFeeBasis basis) {
-    return (FEE_BASIS_GAS == basis.type ? basis.u.gas.price : gasPriceCreate(etherCreateZero()));
+    return (FEE_BASIS_GAS == basis.type ? basis.u.gas.price : ethGasPriceCreate(etherCreateZero()));
 }
 
 extern BREthereumEther
@@ -54,7 +54,7 @@ feeBasisEqual (const BREthereumFeeBasis *feeBasis1,
             return ETHEREUM_BOOLEAN_TRUE;
 
         case FEE_BASIS_GAS:
-            return AS_ETHEREUM_BOOLEAN (ETHEREUM_COMPARISON_EQ == gasCompare (feeBasis1->u.gas.limit, feeBasis2->u.gas.limit) &&
-                                        ETHEREUM_COMPARISON_EQ == gasPriceCompare(feeBasis1->u.gas.price, feeBasis2->u.gas.price));
+            return AS_ETHEREUM_BOOLEAN (ETHEREUM_COMPARISON_EQ == ethGasCompare (feeBasis1->u.gas.limit, feeBasis2->u.gas.limit) &&
+                                        ETHEREUM_COMPARISON_EQ == ethGasPriceCompare(feeBasis1->u.gas.price, feeBasis2->u.gas.price));
     }
 }

--- a/ethereum/base/BREthereumFeeBasis.c
+++ b/ethereum/base/BREthereumFeeBasis.c
@@ -26,7 +26,7 @@ ethFeeBasisGetGasLimit (BREthereumFeeBasis basis) {
 
 extern BREthereumGasPrice
 ethFeeBasisGetGasPrice (BREthereumFeeBasis basis) {
-    return (FEE_BASIS_GAS == basis.type ? basis.u.gas.price : ethGasPriceCreate(etherCreateZero()));
+    return (FEE_BASIS_GAS == basis.type ? basis.u.gas.price : ethGasPriceCreate(ethEtherCreateZero()));
 }
 
 extern BREthereumEther
@@ -35,10 +35,10 @@ ethFeeBasisGetFee (BREthereumFeeBasis feeBasis, int *overflow) {  // BREthereumB
 
     switch (feeBasis.type) {
         case FEE_BASIS_NONE:
-            return etherCreateZero();
+            return ethEtherCreateZero();
 
         case FEE_BASIS_GAS:
-            return etherCreate (uint256Mul_Overflow (feeBasis.u.gas.price.etherPerGas.valueInWEI,
+            return ethEtherCreate (uint256Mul_Overflow (feeBasis.u.gas.price.etherPerGas.valueInWEI,
                                                      uint256Create (feeBasis.u.gas.limit.amountOfGas),
                                                      overflow));
     }

--- a/ethereum/base/BREthereumFeeBasis.c
+++ b/ethereum/base/BREthereumFeeBasis.c
@@ -11,8 +11,8 @@
 #include "BREthereumFeeBasis.h"
 
 extern BREthereumFeeBasis
-feeBasisCreate (BREthereumGas limit,
-                BREthereumGasPrice price) {
+ethFeeBasisCreate (BREthereumGas limit,
+                   BREthereumGasPrice price) {
     return (BREthereumFeeBasis) {
         FEE_BASIS_GAS,
         { .gas = { limit, price }}
@@ -20,17 +20,17 @@ feeBasisCreate (BREthereumGas limit,
 }
 
 extern BREthereumGas
-feeBasisGetGasLimit (BREthereumFeeBasis basis) {
+ethFeeBasisGetGasLimit (BREthereumFeeBasis basis) {
     return (FEE_BASIS_GAS == basis.type ? basis.u.gas.limit : ethGasCreate(0));
 }
 
 extern BREthereumGasPrice
-feeBasisGetGasPrice (BREthereumFeeBasis basis) {
+ethFeeBasisGetGasPrice (BREthereumFeeBasis basis) {
     return (FEE_BASIS_GAS == basis.type ? basis.u.gas.price : ethGasPriceCreate(etherCreateZero()));
 }
 
 extern BREthereumEther
-feeBasisGetFee (BREthereumFeeBasis feeBasis, int *overflow) {  // BREthereumBoolean
+ethFeeBasisGetFee (BREthereumFeeBasis feeBasis, int *overflow) {  // BREthereumBoolean
     *overflow = 0;
 
     switch (feeBasis.type) {
@@ -45,8 +45,8 @@ feeBasisGetFee (BREthereumFeeBasis feeBasis, int *overflow) {  // BREthereumBool
 }
 
 extern BREthereumBoolean
-feeBasisEqual (const BREthereumFeeBasis *feeBasis1,
-               const BREthereumFeeBasis *feeBasis2) {
+ethFeeBasisEqual (const BREthereumFeeBasis *feeBasis1,
+                  const BREthereumFeeBasis *feeBasis2) {
     if (feeBasis1 == feeBasis2) return ETHEREUM_BOOLEAN_TRUE;
     if (feeBasis1->type != feeBasis2->type) return ETHEREUM_BOOLEAN_FALSE;
     switch (feeBasis1->type) {

--- a/ethereum/base/BREthereumFeeBasis.h
+++ b/ethereum/base/BREthereumFeeBasis.h
@@ -29,20 +29,20 @@ typedef struct {
 } BREthereumFeeBasis;
 
 extern BREthereumFeeBasis
-feeBasisCreate (BREthereumGas limit,
-                BREthereumGasPrice price);
+ethFeeBasisCreate (BREthereumGas limit,
+                   BREthereumGasPrice price);
 
 extern BREthereumGas
-feeBasisGetGasLimit (BREthereumFeeBasis basis);
+ethFeeBasisGetGasLimit (BREthereumFeeBasis basis);
 
 extern BREthereumGasPrice
-feeBasisGetGasPrice (BREthereumFeeBasis basis);
+ethFeeBasisGetGasPrice (BREthereumFeeBasis basis);
 
 extern BREthereumEther
-feeBasisGetFee (BREthereumFeeBasis feeBasis, int *overflow);
+ethFeeBasisGetFee (BREthereumFeeBasis feeBasis, int *overflow);
 
 extern BREthereumBoolean
-feeBasisEqual (const BREthereumFeeBasis *feeBasis1,
-               const BREthereumFeeBasis *feeBasis2);
+ethFeeBasisEqual (const BREthereumFeeBasis *feeBasis1,
+                  const BREthereumFeeBasis *feeBasis2);
 
 #endif /* BR_Ethereum_Fee_Basis_h */

--- a/ethereum/base/BREthereumGas.c
+++ b/ethereum/base/BREthereumGas.c
@@ -52,24 +52,24 @@ ethGasPriceCreate(BREthereumEther ether) {
 
 extern BREthereumComparison
 ethGasPriceCompare (BREthereumGasPrice e1, BREthereumGasPrice e2) {
-    return etherCompare(e1.etherPerGas, e2.etherPerGas);
+    return ethEtherCompare(e1.etherPerGas, e2.etherPerGas);
 }
 
 extern BREthereumEther
 ethGasPriceGetGasCost(BREthereumGasPrice price, BREthereumGas gas, int *overflow) {
     assert (NULL != overflow);
     
-    return etherCreate (uint256Mul_Overflow (uint256Create(gas.amountOfGas), // gas
+    return ethEtherCreate (uint256Mul_Overflow (uint256Create(gas.amountOfGas), // gas
                                              price.etherPerGas.valueInWEI,   // WEI/gas
                                              overflow));
 }
 
 extern BRRlpItem
 ethGasPriceRlpEncode (BREthereumGasPrice price, BRRlpCoder coder) {
-    return etherRlpEncode(price.etherPerGas, coder);
+    return ethEtherRlpEncode(price.etherPerGas, coder);
 }
 
 extern BREthereumGasPrice
 ethGasPriceRlpDecode (BRRlpItem item, BRRlpCoder coder) {
-    return ethGasPriceCreate(etherRlpDecode(item, coder));
+    return ethGasPriceCreate(ethEtherRlpDecode(item, coder));
 }

--- a/ethereum/base/BREthereumGas.c
+++ b/ethereum/base/BREthereumGas.c
@@ -15,14 +15,14 @@
 // Gas
 //
 extern BREthereumGas
-gasCreate(uint64_t amountOfGas) {
+ethGasCreate(uint64_t amountOfGas) {
     BREthereumGas gas;
     gas.amountOfGas = amountOfGas;
     return gas;
 }
 
 extern BREthereumComparison
-gasCompare (BREthereumGas e1, BREthereumGas e2) {
+ethGasCompare (BREthereumGas e1, BREthereumGas e2) {
     return (e1.amountOfGas == e2.amountOfGas
             ? ETHEREUM_COMPARISON_EQ
             : (e1.amountOfGas > e2.amountOfGas
@@ -31,32 +31,32 @@ gasCompare (BREthereumGas e1, BREthereumGas e2) {
 }
 
 extern BRRlpItem
-gasRlpEncode (BREthereumGas gas, BRRlpCoder coder) {
+ethGasRlpEncode (BREthereumGas gas, BRRlpCoder coder) {
     return rlpEncodeUInt64(coder, gas.amountOfGas, 1);
 }
 
 extern BREthereumGas
-gasRlpDecode (BRRlpItem item, BRRlpCoder coder) {
-    return gasCreate(rlpDecodeUInt64(coder, item, 1));
+ethGasRlpDecode (BRRlpItem item, BRRlpCoder coder) {
+    return ethGasCreate(rlpDecodeUInt64(coder, item, 1));
 }
 
 //
 // Gas Price
 //
 extern BREthereumGasPrice
-gasPriceCreate(BREthereumEther ether) {
+ethGasPriceCreate(BREthereumEther ether) {
     BREthereumGasPrice gasPrice;
     gasPrice.etherPerGas = ether;
     return gasPrice;
 }
 
 extern BREthereumComparison
-gasPriceCompare (BREthereumGasPrice e1, BREthereumGasPrice e2) {
+ethGasPriceCompare (BREthereumGasPrice e1, BREthereumGasPrice e2) {
     return etherCompare(e1.etherPerGas, e2.etherPerGas);
 }
 
 extern BREthereumEther
-gasPriceGetGasCost(BREthereumGasPrice price, BREthereumGas gas, int *overflow) {
+ethGasPriceGetGasCost(BREthereumGasPrice price, BREthereumGas gas, int *overflow) {
     assert (NULL != overflow);
     
     return etherCreate (uint256Mul_Overflow (uint256Create(gas.amountOfGas), // gas
@@ -65,11 +65,11 @@ gasPriceGetGasCost(BREthereumGasPrice price, BREthereumGas gas, int *overflow) {
 }
 
 extern BRRlpItem
-gasPriceRlpEncode (BREthereumGasPrice price, BRRlpCoder coder) {
+ethGasPriceRlpEncode (BREthereumGasPrice price, BRRlpCoder coder) {
     return etherRlpEncode(price.etherPerGas, coder);
 }
 
 extern BREthereumGasPrice
-gasPriceRlpDecode (BRRlpItem item, BRRlpCoder coder) {
-    return gasPriceCreate(etherRlpDecode(item, coder));
+ethGasPriceRlpDecode (BRRlpItem item, BRRlpCoder coder) {
+    return ethGasPriceCreate(etherRlpDecode(item, coder));
 }

--- a/ethereum/base/BREthereumGas.c
+++ b/ethereum/base/BREthereumGas.c
@@ -59,7 +59,7 @@ extern BREthereumEther
 gasPriceGetGasCost(BREthereumGasPrice price, BREthereumGas gas, int *overflow) {
     assert (NULL != overflow);
     
-    return etherCreate (mulUInt256_Overflow (createUInt256(gas.amountOfGas), // gas
+    return etherCreate (uint256Mul_Overflow (uint256Create(gas.amountOfGas), // gas
                                              price.etherPerGas.valueInWEI,   // WEI/gas
                                              overflow));
 }

--- a/ethereum/base/BREthereumGas.h
+++ b/ethereum/base/BREthereumGas.h
@@ -27,16 +27,16 @@ typedef struct BREthereumGasStruct {
 } BREthereumGas;
 
 extern BREthereumGas
-gasCreate(uint64_t gas);
+ethGasCreate(uint64_t gas);
 
 extern BREthereumComparison
-gasCompare (BREthereumGas e1, BREthereumGas e2);
+ethGasCompare (BREthereumGas e1, BREthereumGas e2);
 
 extern BRRlpItem
-gasRlpEncode (BREthereumGas gas, BRRlpCoder coder);
+ethGasRlpEncode (BREthereumGas gas, BRRlpCoder coder);
 
 extern BREthereumGas
-gasRlpDecode (BRRlpItem item, BRRlpCoder coder);
+ethGasRlpDecode (BRRlpItem item, BRRlpCoder coder);
 
 /**
  * Ethereum Gas Price is the amount of Ether for one Gas - aka Ether/Gas.  The total cost for
@@ -57,10 +57,10 @@ typedef struct BREthereumGasPriceStruct {
  * @return
  */
 extern BREthereumGasPrice
-gasPriceCreate(BREthereumEther ether);
+ethGasPriceCreate(BREthereumEther ether);
 
 extern BREthereumComparison
-gasPriceCompare (BREthereumGasPrice e1, BREthereumGasPrice e2);
+ethGasPriceCompare (BREthereumGasPrice e1, BREthereumGasPrice e2);
 
 /**
  * Compute the Gas Cost (in Ether) for a given Gas Price and Gas.  This can overflow; on overflow
@@ -72,13 +72,13 @@ gasPriceCompare (BREthereumGasPrice e1, BREthereumGasPrice e2);
  * @return
  */
 extern BREthereumEther
-gasPriceGetGasCost(BREthereumGasPrice price, BREthereumGas gas, int *overflow);
+ethGasPriceGetGasCost(BREthereumGasPrice price, BREthereumGas gas, int *overflow);
 
 extern BRRlpItem
-gasPriceRlpEncode (BREthereumGasPrice price, BRRlpCoder coder);
+ethGasPriceRlpEncode (BREthereumGasPrice price, BRRlpCoder coder);
 
 extern BREthereumGasPrice
-gasPriceRlpDecode (BRRlpItem item, BRRlpCoder coder);
+ethGasPriceRlpDecode (BRRlpItem item, BRRlpCoder coder);
     
 #ifdef __cplusplus
 }

--- a/ethereum/base/BREthereumHash.c
+++ b/ethereum/base/BREthereumHash.c
@@ -22,8 +22,8 @@ static BREthereumHash emptyHash;
  * begin with '0x'.
  */
 extern BREthereumHash
-hashCreate (const char *string) {
-    if (NULL == string || '\0' == string[0] || 0 == strcmp (string, "0x")) return hashCreateEmpty();
+ethHashCreate (const char *string) {
+    if (NULL == string || '\0' == string[0] || 0 == strcmp (string, "0x")) return ethHashCreateEmpty();
 
     assert (0 == strncmp (string, "0x", 2)
             && (2 + 2 * ETHEREUM_HASH_BYTES) == strlen (string));
@@ -37,7 +37,7 @@ hashCreate (const char *string) {
  * Create an empty (all zeros) Hash
  */
 extern BREthereumHash
-hashCreateEmpty (void) {
+ethHashCreateEmpty (void) {
     return emptyHash;
 }
 
@@ -45,7 +45,7 @@ hashCreateEmpty (void) {
  * Creata a Hash by computing it from a arbitrary data set (using Keccak256)
  */
 extern BREthereumHash
-hashCreateFromData (BRRlpData data) {
+ethHashCreateFromData (BRRlpData data) {
     BREthereumHash hash;
     BRKeccak256(hash.bytes, data.bytes, data.bytesCount);
     return hash;
@@ -55,7 +55,7 @@ hashCreateFromData (BRRlpData data) {
  * Return the hex-encoded string
  */
 extern char *
-hashAsString (BREthereumHash hash) {
+ethHashAsString (BREthereumHash hash) {
     char result [2 + 2 * ETHEREUM_HASH_BYTES + 1];
     result[0] = '0';
     result[1] = 'x';
@@ -64,12 +64,12 @@ hashAsString (BREthereumHash hash) {
 }
 
 extern BREthereumHash
-hashCopy(BREthereumHash hash) {
+ethHashCopy(BREthereumHash hash) {
     return hash;
 }
 
 extern BREthereumComparison
-hashCompare(BREthereumHash hash1, BREthereumHash hash2) {
+ethHashCompare(BREthereumHash hash1, BREthereumHash hash2) {
     for (int i = 0; i < ETHEREUM_HASH_BYTES; i++) {
         if (hash1.bytes[i] > hash2.bytes[i]) return ETHEREUM_COMPARISON_GT;
         else if (hash1.bytes[i] < hash2.bytes[i]) return ETHEREUM_COMPARISON_LT;
@@ -78,17 +78,17 @@ hashCompare(BREthereumHash hash1, BREthereumHash hash2) {
 }
 
 extern BREthereumBoolean
-hashEqual (BREthereumHash hash1, BREthereumHash hash2) {
+ethHashEqual (BREthereumHash hash1, BREthereumHash hash2) {
     return AS_ETHEREUM_BOOLEAN (0 == memcmp (hash1.bytes, hash2.bytes, ETHEREUM_HASH_BYTES));
 }
 
 extern BRRlpItem
-hashRlpEncode(BREthereumHash hash, BRRlpCoder coder) {
+ethHashRlpEncode(BREthereumHash hash, BRRlpCoder coder) {
     return rlpEncodeBytes(coder, hash.bytes, ETHEREUM_HASH_BYTES);
 }
 
 extern BREthereumHash
-hashRlpDecode (BRRlpItem item, BRRlpCoder coder) {
+ethHashRlpDecode (BRRlpItem item, BRRlpCoder coder) {
     BREthereumHash hash;
 
     BRRlpData data = rlpDecodeBytes(coder, item);
@@ -101,24 +101,24 @@ hashRlpDecode (BRRlpItem item, BRRlpCoder coder) {
 }
 
 extern BRRlpItem
-hashEncodeList (BRArrayOf (BREthereumHash) hashes, BRRlpCoder coder) {
+ethHashEncodeList (BRArrayOf (BREthereumHash) hashes, BRRlpCoder coder) {
     size_t itemCount = array_count(hashes);
     BRRlpItem items[itemCount];
     for (size_t index = 0; index < itemCount; index++)
-        items[index] = hashRlpEncode(hashes[index], coder);
+        items[index] = ethHashRlpEncode(hashes[index], coder);
     return rlpEncodeListItems (coder, items, itemCount);
 }
 
 extern void
-hashFillString (BREthereumHash hash,
-                BREthereumHashString string) {
+ethHashFillString (BREthereumHash hash,
+                   BREthereumHashString string) {
     string[0] = '0';
     string[1] = 'x';
     hexEncode(&string[2], 2 * ETHEREUM_HASH_BYTES + 1, hash.bytes, ETHEREUM_HASH_BYTES);
 }
 
 extern BRArrayOf(BREthereumHash)
-hashesCopy (BRArrayOf(BREthereumHash) hashes) {
+ethHashesCopy (BRArrayOf(BREthereumHash) hashes) {
     BRArrayOf(BREthereumHash) result;
     array_new (result, array_count(hashes));
     array_add_array (result, hashes, array_count(hashes));
@@ -126,10 +126,10 @@ hashesCopy (BRArrayOf(BREthereumHash) hashes) {
 }
 
 extern ssize_t
-hashesIndex (BRArrayOf(BREthereumHash) hashes,
-              BREthereumHash hash) {
+ethHashesIndex (BRArrayOf(BREthereumHash) hashes,
+                BREthereumHash hash) {
     for (size_t index = 0; index < array_count(hashes); index++)
-        if (ETHEREUM_BOOLEAN_IS_TRUE (hashEqual (hash, hashes[index])))
+        if (ETHEREUM_BOOLEAN_IS_TRUE (ethHashEqual (hash, hashes[index])))
             return index;
     return -1;
 }

--- a/ethereum/base/BREthereumHash.c
+++ b/ethereum/base/BREthereumHash.c
@@ -29,7 +29,7 @@ hashCreate (const char *string) {
             && (2 + 2 * ETHEREUM_HASH_BYTES) == strlen (string));
 
     BREthereumHash hash;
-    decodeHex(hash.bytes, ETHEREUM_HASH_BYTES, &string[2], 2 * ETHEREUM_HASH_BYTES);
+    hexDecode(hash.bytes, ETHEREUM_HASH_BYTES, &string[2], 2 * ETHEREUM_HASH_BYTES);
     return hash;
 }
 
@@ -59,7 +59,7 @@ hashAsString (BREthereumHash hash) {
     char result [2 + 2 * ETHEREUM_HASH_BYTES + 1];
     result[0] = '0';
     result[1] = 'x';
-    encodeHex(&result[2], 2 * ETHEREUM_HASH_BYTES + 1, hash.bytes, ETHEREUM_HASH_BYTES);
+    hexEncode(&result[2], 2 * ETHEREUM_HASH_BYTES + 1, hash.bytes, ETHEREUM_HASH_BYTES);
     return strdup (result);
 }
 
@@ -114,7 +114,7 @@ hashFillString (BREthereumHash hash,
                 BREthereumHashString string) {
     string[0] = '0';
     string[1] = 'x';
-    encodeHex(&string[2], 2 * ETHEREUM_HASH_BYTES + 1, hash.bytes, ETHEREUM_HASH_BYTES);
+    hexEncode(&string[2], 2 * ETHEREUM_HASH_BYTES + 1, hash.bytes, ETHEREUM_HASH_BYTES);
 }
 
 extern BRArrayOf(BREthereumHash)

--- a/ethereum/base/BREthereumHash.h
+++ b/ethereum/base/BREthereumHash.h
@@ -59,54 +59,54 @@ typedef struct {
  * begin with '0x'.
  */
 extern BREthereumHash
-hashCreate (const char *string);
+ethHashCreate (const char *string);
 
 /**
  * Create an empty (all zeros) Hash
  */
 extern BREthereumHash
-hashCreateEmpty (void);
+ethHashCreateEmpty (void);
 
 /**
  * Creata a Hash by computing it, using Keccak256, from a arbitrary data set
  */
 extern BREthereumHash
-hashCreateFromData (BRRlpData data);
+ethHashCreateFromData (BRRlpData data);
 
 /**
  * Return the hex-encoded string
  */
 extern char *
-hashAsString (BREthereumHash hash);
+ethHashAsString (BREthereumHash hash);
 
 extern BREthereumHash
-hashCopy(BREthereumHash hash);
+ethHashCopy(BREthereumHash hash);
 
 extern BREthereumComparison
-hashCompare(BREthereumHash hash1, BREthereumHash hash2);
+ethHashCompare(BREthereumHash hash1, BREthereumHash hash2);
 
 extern BREthereumBoolean
-hashEqual (BREthereumHash hash1, BREthereumHash hash2);
+ethHashEqual (BREthereumHash hash1, BREthereumHash hash2);
 
 extern BRRlpItem
-hashRlpEncode(BREthereumHash hash, BRRlpCoder coder);
+ethHashRlpEncode(BREthereumHash hash, BRRlpCoder coder);
 
 extern BREthereumHash
-hashRlpDecode (BRRlpItem item, BRRlpCoder coder);
+ethHashRlpDecode (BRRlpItem item, BRRlpCoder coder);
 
 extern BRRlpItem
-hashEncodeList (BRArrayOf(BREthereumHash) hashes, BRRlpCoder coder);
+ethHashEncodeList (BRArrayOf(BREthereumHash) hashes, BRRlpCoder coder);
 
 // BRSet Support
 inline static int
-hashSetValue (const BREthereumHash *hash) {
+ethHashSetValue (const BREthereumHash *hash) {
     return ((UInt256 *) hash->bytes)->u32[0];
 }
 
 // BRSet Support
 inline static int
-hashSetEqual (const BREthereumHash *hash1,
-              const BREthereumHash *hash2) {
+ethHashSetEqual (const BREthereumHash *hash1,
+                 const BREthereumHash *hash2) {
     return hash1 == hash2 || 0 == memcmp (hash1->bytes, hash2->bytes, ETHEREUM_HASH_BYTES);
 }
 
@@ -116,18 +116,18 @@ hashSetEqual (const BREthereumHash *hash1,
 typedef char BREthereumHashString[2 * ETHEREUM_HASH_BYTES + 3];
 
 extern void
-hashFillString (BREthereumHash hash,
-                BREthereumHashString string);
+ethHashFillString (BREthereumHash hash,
+                   BREthereumHashString string);
 
 //
 // Hash Array
 //
 extern BRArrayOf(BREthereumHash)
-hashesCopy (BRArrayOf(BREthereumHash) hashes);
+ethHashesCopy (BRArrayOf(BREthereumHash) hashes);
 
 extern ssize_t
-hashesIndex (BRArrayOf(BREthereumHash) hashes,
-             BREthereumHash hash);
+ethHashesIndex (BRArrayOf(BREthereumHash) hashes,
+                BREthereumHash hash);
 
 #ifdef __cplusplus
 }

--- a/ethereum/base/BREthereumSignature.c
+++ b/ethereum/base/BREthereumSignature.c
@@ -123,7 +123,7 @@ signatureExtractAddress(const BREthereumSignature signature,
 
     return (0 == *success
             ? (BREthereumAddress) EMPTY_ADDRESS_INIT
-            : addressCreateKey(&key));
+            : ethAddressCreateKey(&key));
 }
 
 extern void

--- a/ethereum/base/BREthereumSignature.c
+++ b/ethereum/base/BREthereumSignature.c
@@ -16,10 +16,10 @@
 // Signature
 //
 extern BREthereumSignature
-signatureCreate(BREthereumSignatureType type,
-                uint8_t *bytes,
-                size_t bytesCount,
-                BRKey privateKeyUncompressed) {
+ethSignatureCreate(BREthereumSignatureType type,
+                   uint8_t *bytes,
+                   size_t bytesCount,
+                   BRKey privateKeyUncompressed) {
     BREthereumSignature signature;
 
     // Save the type.
@@ -87,7 +87,7 @@ signatureCreate(BREthereumSignatureType type,
 }
 
 extern BREthereumBoolean
-signatureEqual (BREthereumSignature s1, BREthereumSignature s2) {
+ethSignatureEqual (BREthereumSignature s1, BREthereumSignature s2) {
     return (s1.type == s2.type &&
             s1.sig.vrs.v == s2.sig.vrs.v &&
             0 == memcmp (s1.sig.vrs.r, s2.sig.vrs.r, 32) &&
@@ -97,10 +97,10 @@ signatureEqual (BREthereumSignature s1, BREthereumSignature s2) {
 }
 
 extern BREthereumAddress
-signatureExtractAddress(const BREthereumSignature signature,
-                        const uint8_t *bytes,
-                        size_t bytesCount,
-                        int *success) {
+ethSignatureExtractAddress(const BREthereumSignature signature,
+                           const uint8_t *bytes,
+                           size_t bytesCount,
+                           int *success) {
     assert (NULL != success);
 
     UInt256 digest;
@@ -127,8 +127,8 @@ signatureExtractAddress(const BREthereumSignature signature,
 }
 
 extern void
-signatureClear (BREthereumSignature *s,
-                BREthereumSignatureType type) {
+ethSignatureClear (BREthereumSignature *s,
+                   BREthereumSignatureType type) {
     memset (s, 0, sizeof (BREthereumSignature));
     s->type = type;
 }

--- a/ethereum/base/BREthereumSignature.h
+++ b/ethereum/base/BREthereumSignature.h
@@ -81,23 +81,23 @@ typedef struct {
 } BREthereumSignature;
 
 extern BREthereumSignature
-signatureCreate (BREthereumSignatureType type,
-                 uint8_t *bytes,
-                 size_t bytesCount,
-                 BRKey privateKeyUncompressed);
+ethSignatureCreate (BREthereumSignatureType type,
+                    uint8_t *bytes,
+                    size_t bytesCount,
+                    BRKey privateKeyUncompressed);
 
 extern BREthereumAddress
-signatureExtractAddress (const BREthereumSignature signature,
-                         const uint8_t *bytes,
-                         size_t bytesCount,
-                         int *success);
+ethSignatureExtractAddress (const BREthereumSignature signature,
+                            const uint8_t *bytes,
+                            size_t bytesCount,
+                            int *success);
 
 extern BREthereumBoolean
-signatureEqual (BREthereumSignature s1, BREthereumSignature s2);
+ethSignatureEqual (BREthereumSignature s1, BREthereumSignature s2);
 
 extern void
-signatureClear (BREthereumSignature *s,
-                BREthereumSignatureType type);
+ethSignatureClear (BREthereumSignature *s,
+                   BREthereumSignatureType type);
 
 #ifdef __cplusplus
 }

--- a/ethereum/base/testBase.c
+++ b/ethereum/base/testBase.c
@@ -174,7 +174,7 @@ static void runSignatureTests1 (void) {
 
     // VRS
     printf ("      SigVRS\n");
-    BREthereumSignature sigVRS = signatureCreate (SIGNATURE_TYPE_RECOVERABLE_VRS_EIP,
+    BREthereumSignature sigVRS = ethSignatureCreate (SIGNATURE_TYPE_RECOVERABLE_VRS_EIP,
                                                   signingBytes, signingBytesCount,
                                                   privateKeyUncompressed);
 
@@ -182,13 +182,13 @@ static void runSignatureTests1 (void) {
     assert (0 == memcmp (sigVRS.sig.vrs.r, sigRData, sigRDataLen));
     assert (0 == memcmp (sigVRS.sig.vrs.s, sigSData, sigSDataLen));
 
-    BREthereumAddress addrVRS = signatureExtractAddress (sigVRS, signingBytes, signingBytesCount, &success);
+    BREthereumAddress addrVRS = ethSignatureExtractAddress (sigVRS, signingBytes, signingBytesCount, &success);
     assert (1 ==  success);
 
 
     // RSV
     printf ("      SigRSV\n");
-    BREthereumSignature sigRSV = signatureCreate (SIGNATURE_TYPE_RECOVERABLE_RSV,
+    BREthereumSignature sigRSV = ethSignatureCreate (SIGNATURE_TYPE_RECOVERABLE_RSV,
                                                   signingBytes, signingBytesCount,
                                                   privateKeyUncompressed);
 
@@ -196,7 +196,7 @@ static void runSignatureTests1 (void) {
     assert (0 == memcmp (sigRSV.sig.rsv.r, sigRData, sigRDataLen));
     assert (0 == memcmp (sigRSV.sig.rsv.s, sigSData, sigSDataLen));
 
-    BREthereumAddress addrRSV = signatureExtractAddress (sigRSV, signingBytes, signingBytesCount, &success);
+    BREthereumAddress addrRSV = ethSignatureExtractAddress (sigRSV, signingBytes, signingBytesCount, &success);
     assert (1 == success);
 
     assert (ETHEREUM_BOOLEAN_TRUE == ethAddressEqual (addrVRS, addrRSV));

--- a/ethereum/base/testBase.c
+++ b/ethereum/base/testBase.c
@@ -134,11 +134,11 @@ static void runSignatureTests1 (void) {
     char *signingHash = SIGNATURE_SIGNING_HASH;
 
     size_t   signingBytesCount = 0;
-    uint8_t *signingBytes = decodeHexCreate(&signingBytesCount, signingData, strlen (signingData));
+    uint8_t *signingBytes = hexDecodeCreate(&signingBytesCount, signingData, strlen (signingData));
 
     BRKeccak256(&digest, signingBytes, signingBytesCount);
 
-    char *digestString = encodeHexCreate(NULL, (uint8_t *) &digest, sizeof(UInt256));
+    char *digestString = hexEncodeCreate(NULL, (uint8_t *) &digest, sizeof(UInt256));
     printf ("      Hex: %s\n", digestString);
     assert (0 == strcmp (digestString, signingHash));
 
@@ -156,7 +156,7 @@ static void runSignatureTests1 (void) {
                                     digest);
     assert (65 == signatureLen);
 
-    char *signatureHex = encodeHexCreate(NULL, signatureBytes, signatureLen);
+    char *signatureHex = hexEncodeCreate(NULL, signatureBytes, signatureLen);
     printf ("      SigRaw: %s\n", signatureHex);
     assert (130 == strlen(signatureHex));
     assert (0 == strncmp (&signatureHex[ 0], SIGNATURE_V, 2));
@@ -168,8 +168,8 @@ static void runSignatureTests1 (void) {
     size_t sigRDataLen, sigSDataLen;
     uint8_t *sigRData, *sigSData;
 
-    sigRData = decodeHexCreate(&sigRDataLen, SIGNATURE_R, strlen (SIGNATURE_R));
-    sigSData = decodeHexCreate(&sigSDataLen, SIGNATURE_S, strlen (SIGNATURE_S));
+    sigRData = hexDecodeCreate(&sigRDataLen, SIGNATURE_R, strlen (SIGNATURE_R));
+    sigSData = hexDecodeCreate(&sigSDataLen, SIGNATURE_S, strlen (SIGNATURE_S));
     assert (32 == sigRDataLen & 32 == sigSDataLen);
 
     // VRS
@@ -212,11 +212,11 @@ static void runSignatureTests2 (void) {
     char *signingHash = SIGNING_HASH_2;
 
     size_t   signingBytesCount = 0;
-    uint8_t *signingBytes = decodeHexCreate(&signingBytesCount, signingData, strlen (signingData));
+    uint8_t *signingBytes = hexDecodeCreate(&signingBytesCount, signingData, strlen (signingData));
 
     BRKeccak256(&digest, signingBytes, signingBytesCount);
 
-    char *digestString = encodeHexCreate(NULL, (uint8_t *) &digest, sizeof(UInt256));
+    char *digestString = hexEncodeCreate(NULL, (uint8_t *) &digest, sizeof(UInt256));
     printf ("      Hex: %s\n", digestString);
     assert (0 == strcmp (digestString, signingHash));
 

--- a/ethereum/base/testBase.c
+++ b/ethereum/base/testBase.c
@@ -199,7 +199,7 @@ static void runSignatureTests1 (void) {
     BREthereumAddress addrRSV = signatureExtractAddress (sigRSV, signingBytes, signingBytesCount, &success);
     assert (1 == success);
 
-    assert (ETHEREUM_BOOLEAN_TRUE == addressEqual (addrVRS, addrRSV));
+    assert (ETHEREUM_BOOLEAN_TRUE == ethAddressEqual (addrVRS, addrRSV));
 
 }
 

--- a/ethereum/base/testBase.c
+++ b/ethereum/base/testBase.c
@@ -18,63 +18,63 @@ runEtherParseTests () {
     BRCoreParseStatus status;
     BREthereumEther e;
 
-    e = etherCreateString("1", WEI, &status);
+    e = ethEtherCreateString("1", WEI, &status);
     assert (CORE_PARSE_OK == status
-            && ETHEREUM_BOOLEAN_TRUE == etherIsEQ(e, etherCreateNumber(1, WEI)));
+            && ETHEREUM_BOOLEAN_TRUE == ethEtherIsEQ(e, ethEtherCreateNumber(1, WEI)));
 
-    e = etherCreateString("100", WEI, &status);
+    e = ethEtherCreateString("100", WEI, &status);
     assert (CORE_PARSE_OK == status
-            && ETHEREUM_BOOLEAN_TRUE == etherIsEQ(e, etherCreateNumber(100, WEI)));
+            && ETHEREUM_BOOLEAN_TRUE == ethEtherIsEQ(e, ethEtherCreateNumber(100, WEI)));
 
-    e = etherCreateString("100.0000", WEI, &status);
+    e = ethEtherCreateString("100.0000", WEI, &status);
     assert (CORE_PARSE_OK == status
-            && ETHEREUM_BOOLEAN_TRUE == etherIsEQ(e, etherCreateNumber(100, WEI)));
+            && ETHEREUM_BOOLEAN_TRUE == ethEtherIsEQ(e, ethEtherCreateNumber(100, WEI)));
 
-    e = etherCreateString("0.001", WEI+1, &status);
+    e = ethEtherCreateString("0.001", WEI+1, &status);
     assert (CORE_PARSE_OK == status
-            && ETHEREUM_BOOLEAN_TRUE == etherIsEQ(e, etherCreateNumber(1, WEI)));
+            && ETHEREUM_BOOLEAN_TRUE == ethEtherIsEQ(e, ethEtherCreateNumber(1, WEI)));
 
-    e = etherCreateString("0.00100", WEI+1, &status);
+    e = ethEtherCreateString("0.00100", WEI+1, &status);
     assert (CORE_PARSE_OK == status
-            && ETHEREUM_BOOLEAN_TRUE == etherIsEQ(e, etherCreateNumber(1, WEI)));
+            && ETHEREUM_BOOLEAN_TRUE == ethEtherIsEQ(e, ethEtherCreateNumber(1, WEI)));
 
-    e = etherCreateString("0.001002", ETHER, &status);
+    e = ethEtherCreateString("0.001002", ETHER, &status);
     assert (CORE_PARSE_OK == status
-            && ETHEREUM_BOOLEAN_TRUE == etherIsEQ(e, etherCreateNumber(1002, ETHER-2)));
+            && ETHEREUM_BOOLEAN_TRUE == ethEtherIsEQ(e, ethEtherCreateNumber(1002, ETHER-2)));
 
-    e = etherCreateString("12.03", ETHER, &status);
+    e = ethEtherCreateString("12.03", ETHER, &status);
     assert (CORE_PARSE_OK == status
-            && ETHEREUM_BOOLEAN_TRUE == etherIsEQ(e, etherCreateNumber(12030, ETHER-1)));
+            && ETHEREUM_BOOLEAN_TRUE == ethEtherIsEQ(e, ethEtherCreateNumber(12030, ETHER-1)));
 
-    e = etherCreateString("12.03", WEI, &status);
+    e = ethEtherCreateString("12.03", WEI, &status);
     //  assert (ETHEREUM_ETHER_PARSE_UNDERFLOW == status);
     assert (CORE_PARSE_OK != status);
 
-    e = etherCreateString("100000000000000000000000000000000000000000000000000000000000000000000000000000000", WEI, &status);
+    e = ethEtherCreateString("100000000000000000000000000000000000000000000000000000000000000000000000000000000", WEI, &status);
     //  assert (ETHEREUM_ETHER_PARSE_OVERFLOW == status);
     assert (CORE_PARSE_OK != status);
 
-    e = etherCreateString("1000000000000000000000", WEI, &status);
+    e = ethEtherCreateString("1000000000000000000000", WEI, &status);
     assert (CORE_PARSE_OK == status
-            && ETHEREUM_BOOLEAN_TRUE == etherIsEQ (e, etherCreateNumber(1, KETHER)));
+            && ETHEREUM_BOOLEAN_TRUE == ethEtherIsEQ (e, ethEtherCreateNumber(1, KETHER)));
 
-    e = etherCreateString("2000000000000000000000.000000", WEI, &status);
+    e = ethEtherCreateString("2000000000000000000000.000000", WEI, &status);
     assert (CORE_PARSE_OK == status
-            && ETHEREUM_BOOLEAN_TRUE == etherIsEQ (e, etherCreateNumber(2, KETHER)));
+            && ETHEREUM_BOOLEAN_TRUE == ethEtherIsEQ (e, ethEtherCreateNumber(2, KETHER)));
 
     char *s;
-    e = etherCreateString("123", WEI, &status);
-    s = etherGetValueString(e, WEI);
+    e = ethEtherCreateString("123", WEI, &status);
+    s = ethEtherGetValueString(e, WEI);
     assert (0 == strcmp (s, "123"));
     free (s);
 
-    e = etherCreateString("1234", WEI, &status);
-    s = etherGetValueString(e, WEI+1);
+    e = ethEtherCreateString("1234", WEI, &status);
+    s = ethEtherGetValueString(e, WEI+1);
     assert (0 == strcmp (s, "1.234"));
     free (s);
 
-    e = etherCreateString("123", WEI, &status);
-    s = etherGetValueString(e, WEI+2);
+    e = ethEtherCreateString("123", WEI, &status);
+    s = ethEtherGetValueString(e, WEI+2);
     assert (0 == strcmp (s, "0.000123"));
     free (s);
 }

--- a/ethereum/bcs/BREthereumBCS.c
+++ b/ethereum/bcs/BREthereumBCS.c
@@ -498,7 +498,7 @@ static int
 bcsLookupPendingTransaction (BREthereumBCS bcs,
                              BREthereumHash hash) {
     for (int i = 0; i < array_count(bcs->pendingTransactions); i++)
-        if (ETHEREUM_BOOLEAN_IS_TRUE (hashEqual(bcs->pendingTransactions[i], hash)))
+        if (ETHEREUM_BOOLEAN_IS_TRUE (ethHashEqual(bcs->pendingTransactions[i], hash)))
             return i;
     return -1;
 }
@@ -523,7 +523,7 @@ static int
 bcsLookupPendingLog (BREthereumBCS bcs,
                      BREthereumHash hash) {
     for (int i = 0; i < array_count(bcs->pendingLogs); i++)
-        if (ETHEREUM_BOOLEAN_IS_TRUE (hashEqual(bcs->pendingLogs[i], hash)))
+        if (ETHEREUM_BOOLEAN_IS_TRUE (ethHashEqual(bcs->pendingLogs[i], hash)))
             return i;
     return -1;
 }
@@ -564,7 +564,7 @@ bcsPendFindLogsByTransactionHash (BREthereumBCS bcs,
         if (NULL != log) {
             BREthereumHash txHash;
             if (ETHEREUM_BOOLEAN_IS_TRUE (logExtractIdentifier (log, &txHash, NULL)) &&
-                ETHEREUM_BOOLEAN_IS_TRUE (hashEqual(txHash, hash))) {
+                ETHEREUM_BOOLEAN_IS_TRUE (ethHashEqual(txHash, hash))) {
                 if (NULL == logs) array_new (logs, 1);
                 array_add (logs, log);
             }
@@ -887,7 +887,7 @@ bcsChainOrphans (BREthereumBCS bcs) {
         // Select the preferred block to chain by looking through all orphans for ...
         FOR_SET(BREthereumBlock, orphan, bcs->orphans) {
             // ... an orphan with a parent hash that matches `bcs->chain`.
-            if (ETHEREUM_BOOLEAN_IS_TRUE(hashEqual(blockGetHash (bcs->chain),
+            if (ETHEREUM_BOOLEAN_IS_TRUE(ethHashEqual(blockGetHash (bcs->chain),
                                                    blockHeaderGetParentHash(blockGetHeader(orphan)))))
                 block = bcsSelectPreferredBlock(bcs, block, orphan);
         }
@@ -997,8 +997,8 @@ bcsShowBlockForChain (BREthereumBCS bcs,
                       BREthereumBlock block,
                       const char *preface) {
     BREthereumHashString parent, hash;
-    hashFillString (blockGetHash(block), hash);
-    hashFillString (blockHeaderGetParentHash(blockGetHeader(block)), parent);
+    ethHashFillString (blockGetHash(block), hash);
+    ethHashFillString (blockHeaderGetParentHash(blockGetHeader(block)), parent);
     eth_log ("BCS", "%s: %" PRIu64 ", Hash: %s, Parent: %s",
              preface,
              blockGetNumber (block),
@@ -1932,7 +1932,7 @@ bcsHandleTransactionStatus (BREthereumBCS bcs,
 
     // Get the hash string - soley for eth_log() output.
     BREthereumHashString hashString;
-    hashFillString(transactionHash, hashString);
+    ethHashFillString(transactionHash, hashString);
 
     // Boolean to indicate if we need to update the transaction's status;
     int needStatus = 1;
@@ -1998,7 +1998,7 @@ bcsHandleTransactionStatus (BREthereumBCS bcs,
         if (NULL != logs) {
             for (size_t index = 0; index < array_count(logs); index++) {
                 logSetStatus (logs[index], status);
-                hashFillString (logGetHash(logs[index]), hashString);
+                ethHashFillString (logGetHash(logs[index]), hashString);
                 eth_log("BCS", "Log: \"%s\", Status: %d, Pending: %s%s%s",
                         hashString,
                         status.type,
@@ -2052,7 +2052,7 @@ bcsPeriodicDispatcher (BREventHandler handler,
         if (NULL != log) {
             BREthereumHash hash;
             if (ETHEREUM_BOOLEAN_IS_TRUE (logExtractIdentifier (log, &hash, NULL)) &&
-                -1 == hashesIndex(hashes, hash))
+                -1 == ethHashesIndex(hashes, hash))
                 array_add (hashes, hash);
         }
     }

--- a/ethereum/bcs/BREthereumBCS.c
+++ b/ethereum/bcs/BREthereumBCS.c
@@ -1770,7 +1770,7 @@ bcsHandleTransactionReceipts (BREthereumBCS bcs,
                                                                         blockGetNumber(block),
                                                                         ti,
                                                                         blockGetTimestamp(block),
-                                                                        gasCreate(0)));
+                                                                        ethGasCreate(0)));
                     
                     if (NULL == neededLogs) array_new(neededLogs, 3);
                     array_add(neededLogs, log);
@@ -1794,7 +1794,7 @@ bcsHandleTransactionReceipts (BREthereumBCS bcs,
     for (size_t ti = 0; ti < receiptsCount; ti++) {
         uint64_t gasUsed = (transactionReceiptGetGasUsed(receipts[ti]) -
                             (ti == 0 ? 0 : transactionReceiptGetGasUsed(receipts[ti-1])));
-        array_add (gasUsedByTransaction, gasCreate (gasUsed));
+        array_add (gasUsedByTransaction, ethGasCreate (gasUsed));
     }
 
     bcsReleaseReceiptsFully(bcs, receipts);

--- a/ethereum/bcs/BREthereumBCS.c
+++ b/ethereum/bcs/BREthereumBCS.c
@@ -859,9 +859,9 @@ bcsSelectPreferredBlock (BREthereumBCS bcs,
     BREthereumBlockHeader header1 = blockGetHeader(block1);
     BREthereumBlockHeader header2 = blockGetHeader(block2);
 
-    return (gtUInt256 (blockHeaderGetDifficulty(header1), blockHeaderGetDifficulty(header2))
+    return (uint256GT (blockHeaderGetDifficulty(header1), blockHeaderGetDifficulty(header2))
             ? block1
-            : (ltUInt256 (blockHeaderGetDifficulty(header1), blockHeaderGetDifficulty(header2))
+            : (uint256LT (blockHeaderGetDifficulty(header1), blockHeaderGetDifficulty(header2))
                ? block2
                : (blockHeaderGetTimestamp(header1) <= blockHeaderGetTimestamp(header2)
                   ? block1
@@ -1631,7 +1631,7 @@ bcsHandleBlockProof (BREthereumBCS bcs,
     // the point of CHT handling, maybe we won't
     //
     // We really, really need to find the block and mark the block.  Can be multiple blocks...
-    if (1 == eqUInt256 (proof.totalDifficulty, UINT256_ZERO)) {
+    if (1 == uint256EQL (proof.totalDifficulty, UINT256_ZERO)) {
         eth_log ("BCS", "Block %" PRIu64 " Proof Failed", number);
         return;
     }
@@ -1651,11 +1651,11 @@ bcsHandleBlockProof (BREthereumBCS bcs,
     // logs, etc) are complete and then process
 
     // If block has no totalDifficulty, assign it...
-    if (1 == eqUInt256 (blockGetTotalDifficulty (block), UINT256_ZERO))
+    if (1 == uint256EQL (blockGetTotalDifficulty (block), UINT256_ZERO))
         blockSetTotalDifficulty (block, proof.totalDifficulty);
 
     // ... otherwise, if the difficulties do not match
-    else if (0 == eqUInt256 (blockGetTotalDifficulty (block), proof.totalDifficulty)) {
+    else if (0 == uint256EQL (blockGetTotalDifficulty (block), proof.totalDifficulty)) {
         // TODO: This SHOULD indicate a problem...
         eth_log ("BCS", "Block %" PRIu64 " Overwrite Difficulty (Proof)", number);
         blockSetTotalDifficulty (block, proof.totalDifficulty);

--- a/ethereum/blockchain/BREthereumAccountState.c
+++ b/ethereum/blockchain/BREthereumAccountState.c
@@ -66,8 +66,8 @@ accountStateRlpEncode(BREthereumAccountState state, BRRlpCoder coder) {
 
     items[0] = rlpEncodeUInt64(coder, state.nonce, 0);
     items[1] = etherRlpEncode(state.balance, coder);
-    items[2] = hashRlpEncode(state.storageRoot, coder);
-    items[3] = hashRlpEncode(state.codeHash, coder);
+    items[2] = ethHashRlpEncode(state.storageRoot, coder);
+    items[3] = ethHashRlpEncode(state.codeHash, coder);
 
     return rlpEncodeListItems(coder, items, 4);
 }
@@ -82,8 +82,8 @@ accountStateRlpDecode (BRRlpItem item, BRRlpCoder coder) {
 
     state.nonce = rlpDecodeUInt64(coder, items[0], 0);
     state.balance = etherRlpDecode(items[1], coder);
-    state.storageRoot = hashRlpDecode(items[2], coder);
-    state.codeHash = hashRlpDecode(items[3], coder);
+    state.storageRoot = ethHashRlpDecode(items[2], coder);
+    state.codeHash = ethHashRlpDecode(items[3], coder);
 
     return state;
 }

--- a/ethereum/blockchain/BREthereumAccountState.c
+++ b/ethereum/blockchain/BREthereumAccountState.c
@@ -41,7 +41,7 @@ extern BREthereumBoolean
 accountStateEqual (BREthereumAccountState s1,
                    BREthereumAccountState s2) {
     return AS_ETHEREUM_BOOLEAN(s1.nonce == s2.nonce &&
-                               ETHEREUM_BOOLEAN_IS_TRUE(etherIsEQ(s1.balance, s2.balance)));
+                               ETHEREUM_BOOLEAN_IS_TRUE(ethEtherIsEQ(s1.balance, s2.balance)));
 }
 
 extern BREthereumAccountState
@@ -65,7 +65,7 @@ accountStateRlpEncode(BREthereumAccountState state, BRRlpCoder coder) {
     BRRlpItem items[4];
 
     items[0] = rlpEncodeUInt64(coder, state.nonce, 0);
-    items[1] = etherRlpEncode(state.balance, coder);
+    items[1] = ethEtherRlpEncode(state.balance, coder);
     items[2] = ethHashRlpEncode(state.storageRoot, coder);
     items[3] = ethHashRlpEncode(state.codeHash, coder);
 
@@ -81,7 +81,7 @@ accountStateRlpDecode (BRRlpItem item, BRRlpCoder coder) {
     assert (4 == itemsCount);
 
     state.nonce = rlpDecodeUInt64(coder, items[0], 0);
-    state.balance = etherRlpDecode(items[1], coder);
+    state.balance = ethEtherRlpDecode(items[1], coder);
     state.storageRoot = ethHashRlpDecode(items[2], coder);
     state.codeHash = ethHashRlpDecode(items[3], coder);
 

--- a/ethereum/blockchain/BREthereumBlock.c
+++ b/ethereum/blockchain/BREthereumBlock.c
@@ -1468,11 +1468,11 @@ networkGetGenesisBlockHeader (BREthereumNetwork network) {
     }
 
     BREthereumBlockHeader genesisHeader =
-    (network == ethereumMainnet
+    (network == ethNetworkMainnet
      ? ethereumMainnetBlockHeader
-     : (network == ethereumTestnet
+     : (network == ethNetworkTestnet
         ? ethereumTestnetBlockHeader
-        : (network == ethereumRinkeby
+        : (network == ethNetworkRinkeby
            ? ethereumRinkebyBlockHeader
            : NULL)));
 
@@ -1691,17 +1691,17 @@ blockCheckpointFindForNetwork (BREthereumNetwork network,
     blockCheckpointInitialize();
     assert (NULL != count);
 
-    if (network == ethereumMainnet) {
+    if (network == ethNetworkMainnet) {
         *count = CHECKPOINT_MAINNET_COUNT;
         return ethereumMainnetCheckpoints;
     }
 
-    if (network == ethereumTestnet) {
+    if (network == ethNetworkTestnet) {
         *count = CHECKPOINT_TESTNET_COUNT;
         return ethereumTestnetCheckpoints;
     }
 
-    if (network == ethereumRinkeby) {
+    if (network == ethNetworkRinkeby) {
         *count = CHECKPOINT_RINKEBY_COUNT;
         return ethereumRinkebyCheckpoints;
     }

--- a/ethereum/blockchain/BREthereumBlock.c
+++ b/ethereum/blockchain/BREthereumBlock.c
@@ -224,7 +224,7 @@ blockHeaderRelease (BREthereumBlockHeader header) {
 #if defined (BLOCK_HEADER_LOG_ALLOC_COUNT)
         eth_log ("MEM", "Block Header Release %d", --blockHeaderAllocCount);
 #endif
-        assert (ETHEREUM_BOOLEAN_IS_FALSE(hashEqual(header->hash, hashCreateEmpty())));
+        assert (ETHEREUM_BOOLEAN_IS_FALSE(ethHashEqual(header->hash, ethHashCreateEmpty())));
         memset (header, 0, sizeof(struct BREthereumBlockHeaderRecord));
         free (header);
     }
@@ -278,12 +278,12 @@ blockHeaderGetNonce (BREthereumBlockHeader header) {
 extern size_t
 blockHeaderHashValue (const void *h)
 {
-    return hashSetValue(&((BREthereumBlockHeader) h)->hash);
+    return ethHashSetValue(&((BREthereumBlockHeader) h)->hash);
 }
 
 extern int
 blockHeaderHashEqual (const void *h1, const void *h2) {
-    return h1 == h2 || hashSetEqual (&((BREthereumBlockHeader) h1)->hash,
+    return h1 == h2 || ethHashSetEqual (&((BREthereumBlockHeader) h1)->hash,
                                      &((BREthereumBlockHeader) h2)->hash);
 }
 
@@ -457,8 +457,8 @@ blockHeaderValidateDifficulty (BREthereumBlockHeader this,
 static int
 blockHeaderValidatePoWMixHash (BREthereumBlockHeader this,
                                BREthereumHash mixHash) {
-    return (ETHEREUM_BOOLEAN_IS_TRUE (hashEqual (mixHash, EMPTY_HASH_INIT)) || // no POW
-            ETHEREUM_BOOLEAN_IS_TRUE (hashEqual (mixHash, this->mixHash)));
+    return (ETHEREUM_BOOLEAN_IS_TRUE (ethHashEqual (mixHash, EMPTY_HASH_INIT)) || // no POW
+            ETHEREUM_BOOLEAN_IS_TRUE (ethHashEqual (mixHash, this->mixHash)));
 }
 
 static int
@@ -538,12 +538,12 @@ blockHeaderRlpEncode (BREthereumBlockHeader header,
     BRRlpItem items[15];
     size_t itemsCount = ETHEREUM_BOOLEAN_IS_TRUE(withNonce) ? 15 : 13;
 
-    items[ 0] = hashRlpEncode(header->parentHash, coder);
-    items[ 1] = hashRlpEncode(header->ommersHash, coder);
+    items[ 0] = ethHashRlpEncode(header->parentHash, coder);
+    items[ 1] = ethHashRlpEncode(header->ommersHash, coder);
     items[ 2] = addressRlpEncode(header->beneficiary, coder);
-    items[ 3] = hashRlpEncode(header->stateRoot, coder);
-    items[ 4] = hashRlpEncode(header->transactionsRoot, coder);
-    items[ 5] = hashRlpEncode(header->receiptsRoot, coder);
+    items[ 3] = ethHashRlpEncode(header->stateRoot, coder);
+    items[ 4] = ethHashRlpEncode(header->transactionsRoot, coder);
+    items[ 5] = ethHashRlpEncode(header->receiptsRoot, coder);
     items[ 6] = bloomFilterRlpEncode(header->logsBloom, coder);
     items[ 7] = rlpEncodeUInt256 (coder, header->difficulty, 0);
     items[ 8] = rlpEncodeUInt64(coder, header->number, 0);
@@ -553,7 +553,7 @@ blockHeaderRlpEncode (BREthereumBlockHeader header,
     items[12] = rlpEncodeBytes(coder, header->extraData, header->extraDataCount);
 
     if (ETHEREUM_BOOLEAN_IS_TRUE(withNonce)) {
-        items[13] = hashRlpEncode(header->mixHash, coder);
+        items[13] = ethHashRlpEncode(header->mixHash, coder);
         items[14] = rlpEncodeUInt64(coder, header->nonce, 0);
     }
 
@@ -570,14 +570,14 @@ blockHeaderRlpDecode (BRRlpItem item,
     const BRRlpItem *items = rlpDecodeList(coder, item, &itemsCount);
     assert (13 == itemsCount || 15 == itemsCount);
 
-    header->hash = hashCreateEmpty();
+    header->hash = ethHashCreateEmpty();
 
-    header->parentHash = hashRlpDecode(items[0], coder);
-    header->ommersHash = hashRlpDecode(items[1], coder);
+    header->parentHash = ethHashRlpDecode(items[0], coder);
+    header->ommersHash = ethHashRlpDecode(items[1], coder);
     header->beneficiary = addressRlpDecode(items[2], coder);
-    header->stateRoot = hashRlpDecode(items[3], coder);
-    header->transactionsRoot = hashRlpDecode(items[4], coder);
-    header->receiptsRoot = hashRlpDecode(items[5], coder);
+    header->stateRoot = ethHashRlpDecode(items[3], coder);
+    header->transactionsRoot = ethHashRlpDecode(items[4], coder);
+    header->receiptsRoot = ethHashRlpDecode(items[5], coder);
     header->logsBloom = bloomFilterRlpDecode(items[6], coder);
     header->difficulty = rlpDecodeUInt256(coder, items[7], 0);
     header->number = rlpDecodeUInt64(coder, items[8], 0);
@@ -592,7 +592,7 @@ blockHeaderRlpDecode (BRRlpItem item,
     rlpDataRelease(extraData);
 
     if (15 == itemsCount) {
-        header->mixHash = hashRlpDecode(items[13], coder);
+        header->mixHash = ethHashRlpDecode(items[13], coder);
         header->nonce = rlpDecodeUInt64(coder, items[14], 0);
     }
 
@@ -601,7 +601,7 @@ blockHeaderRlpDecode (BRRlpItem item,
 #endif
 
     BRRlpData data = rlpItemGetDataSharedDontRelease(coder, item);
-    header->hash = hashCreateFromData(data);
+    header->hash = ethHashCreateFromData(data);
     // Safe to ignore data release.
 
     return header;
@@ -800,7 +800,7 @@ blockGetTransactionTrieRoot (BREthereumBlock block) {
 
 extern BREthereumBoolean
 blockTransactionsAreValid (BREthereumBlock block) {
-    return (hashCompare(block->header->transactionsRoot, blockGetTransactionTrieRoot(block)));
+    return (ethHashCompare(block->header->transactionsRoot, blockGetTransactionTrieRoot(block)));
 }
 
 extern unsigned long
@@ -1063,12 +1063,12 @@ blockRlpDecode (BRRlpItem item,
 extern size_t
 blockHashValue (const void *b)
 {
-    return hashSetValue(& ((BREthereumBlock) b)->status.hash);
+    return ethHashSetValue(& ((BREthereumBlock) b)->status.hash);
 }
 
 extern int
 blockHashEqual (const void *b1, const void *b2) {
-    return b1 == b2 || hashSetEqual (& ((BREthereumBlock) b1)->status.hash,
+    return b1 == b2 || ethHashSetEqual (& ((BREthereumBlock) b1)->status.hash,
                                      & ((BREthereumBlock) b2)->status.hash);
 }
 
@@ -1318,7 +1318,7 @@ blockStatusRlpEncode (BREthereumBlockStatus status,
                       (status.accountStateRequest << 2) |
                       (status.headerProofRequest << 0));
 
-    items[0] = hashRlpEncode(status.hash, coder);
+    items[0] = ethHashRlpEncode(status.hash, coder);
     items[1] = rlpEncodeUInt64(coder, flags, 1);
 
     // TODO: Fill out
@@ -1342,7 +1342,7 @@ blockStatusRlpDecode (BRRlpItem item,
     const BRRlpItem *items = rlpDecodeList(coder, item, &itemsCount);
     assert (8 == itemsCount);
 
-    status.hash = hashRlpDecode(items[0], coder);
+    status.hash = ethHashRlpDecode(items[0], coder);
 
     uint64_t flags = rlpDecodeUInt64(coder, items[1], 1);
     status.transactionRequest  = 0x3 & (flags >> 6);
@@ -1521,13 +1521,13 @@ initializeGenesisBlocks (void) {
         }}
      */
     header = &genesisMainnetBlockHeaderRecord;
-    header->hash = hashCreate("0xd4e56740f876aef8c010b86a40d5f56745a118d0906a34e69aec8c0db1cb8fa3");
-    header->parentHash = hashCreate("0x0000000000000000000000000000000000000000000000000000000000000000");
-    header->ommersHash = hashCreate("0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347");
+    header->hash = ethHashCreate("0xd4e56740f876aef8c010b86a40d5f56745a118d0906a34e69aec8c0db1cb8fa3");
+    header->parentHash = ethHashCreate("0x0000000000000000000000000000000000000000000000000000000000000000");
+    header->ommersHash = ethHashCreate("0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347");
     header->beneficiary = addressCreate("0x0000000000000000000000000000000000000000");
-    header->stateRoot = hashCreate("0xd7f8974fb5ac78d9ac099b9ad5018bedc2ce0a72dad1827a1709da30580f0544");
-    header->transactionsRoot = hashCreate("0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421");
-    header->receiptsRoot = hashCreate("0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421");
+    header->stateRoot = ethHashCreate("0xd7f8974fb5ac78d9ac099b9ad5018bedc2ce0a72dad1827a1709da30580f0544");
+    header->transactionsRoot = ethHashCreate("0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421");
+    header->receiptsRoot = ethHashCreate("0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421");
     header->logsBloom = bloomFilterCreateString("00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000");
     header->difficulty = uint256Create (0x400000000);
     header->number = 0x0;
@@ -1536,7 +1536,7 @@ initializeGenesisBlocks (void) {
     header->timestamp = 0x0;
     hexDecode(header->extraData, 32, "11bbe8db4e347b4e8c937c1c8370e4b5ed33adb3db69cbdb7a38e1e50b1b82fa", 64);
     header->extraDataCount = 32;
-    header->mixHash = hashCreate("0x0000000000000000000000000000000000000000000000000000000000000000");
+    header->mixHash = ethHashCreate("0x0000000000000000000000000000000000000000000000000000000000000000");
     header->nonce = 0x0000000000000042;
 
     // Testnet
@@ -1564,13 +1564,13 @@ initializeGenesisBlocks (void) {
             "uncles":[]}}
      */
     header = &genesisTestnetBlockHeaderRecord;
-    header->hash = hashCreate("0x41941023680923e0fe4d74a34bdac8141f2540e3ae90623718e47d66d1ca4a2d");
-    header->parentHash = hashCreate("0x0000000000000000000000000000000000000000000000000000000000000000");
-    header->ommersHash = hashCreate("0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347");
+    header->hash = ethHashCreate("0x41941023680923e0fe4d74a34bdac8141f2540e3ae90623718e47d66d1ca4a2d");
+    header->parentHash = ethHashCreate("0x0000000000000000000000000000000000000000000000000000000000000000");
+    header->ommersHash = ethHashCreate("0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347");
     header->beneficiary = addressCreate("0x0000000000000000000000000000000000000000");
-    header->stateRoot = hashCreate("0x217b0bbcfb72e2d57e28f33cb361b9983513177755dc3f33ce3e7022ed62b77b");
-    header->transactionsRoot = hashCreate("0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421");
-    header->receiptsRoot = hashCreate("0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421");
+    header->stateRoot = ethHashCreate("0x217b0bbcfb72e2d57e28f33cb361b9983513177755dc3f33ce3e7022ed62b77b");
+    header->transactionsRoot = ethHashCreate("0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421");
+    header->receiptsRoot = ethHashCreate("0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421");
     header->logsBloom = bloomFilterCreateString("00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000");
     header->difficulty = uint256Create (0x100000);
     header->number = 0x0;
@@ -1579,7 +1579,7 @@ initializeGenesisBlocks (void) {
     header->timestamp = 0x0;
     hexDecode(header->extraData, 32, "3535353535353535353535353535353535353535353535353535353535353535", 64);
     header->extraDataCount = 32;
-    header->mixHash = hashCreate("0x0000000000000000000000000000000000000000000000000000000000000000");
+    header->mixHash = ethHashCreate("0x0000000000000000000000000000000000000000000000000000000000000000");
     header->nonce = 0x0000000000000042;
 
     // Rinkeby
@@ -1607,13 +1607,13 @@ initializeGenesisBlocks (void) {
             "uncles":[]}}
      */
     header = &genesisRinkebyBlockHeaderRecord;
-    header->hash = hashCreate("0x6341fd3daf94b748c72ced5a5b26028f2474f5f00d824504e4fa37a75767e177");
-    header->parentHash = hashCreate("0x0000000000000000000000000000000000000000000000000000000000000000");
-    header->ommersHash = hashCreate("0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347");
+    header->hash = ethHashCreate("0x6341fd3daf94b748c72ced5a5b26028f2474f5f00d824504e4fa37a75767e177");
+    header->parentHash = ethHashCreate("0x0000000000000000000000000000000000000000000000000000000000000000");
+    header->ommersHash = ethHashCreate("0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347");
     header->beneficiary = addressCreate("0x0000000000000000000000000000000000000000");
-    header->stateRoot = hashCreate("0x53580584816f617295ea26c0e17641e0120cab2f0a8ffb53a866fd53aa8e8c2d");
-    header->transactionsRoot = hashCreate("0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421");
-    header->receiptsRoot = hashCreate("0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421");
+    header->stateRoot = ethHashCreate("0x53580584816f617295ea26c0e17641e0120cab2f0a8ffb53a866fd53aa8e8c2d");
+    header->transactionsRoot = ethHashCreate("0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421");
+    header->receiptsRoot = ethHashCreate("0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421");
     header->logsBloom = bloomFilterCreateString("00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000");
     header->difficulty = uint256Create (0x1);
     header->number = 0x0;
@@ -1623,7 +1623,7 @@ initializeGenesisBlocks (void) {
     // TODO: Rinkeby ExtraData is oversized... ignore.
     hexDecode(header->extraData, 32, "3535353535353535353535353535353535353535353535353535353535353535", 64);
     header->extraDataCount = 32;
-    header->mixHash = hashCreate("0x0000000000000000000000000000000000000000000000000000000000000000");
+    header->mixHash = ethHashCreate("0x0000000000000000000000000000000000000000000000000000000000000000");
     header->nonce = 0x0000000000000000;
 }
 

--- a/ethereum/blockchain/BREthereumBlock.c
+++ b/ethereum/blockchain/BREthereumBlock.c
@@ -600,7 +600,7 @@ blockHeaderRlpDecode (BRRlpItem item,
     eth_log ("MEM", "Block Header Create RLP: %d", ++blockHeaderAllocCount);
 #endif
 
-    BRRlpData data = rlpGetDataSharedDontRelease(coder, item);
+    BRRlpData data = rlpItemGetDataSharedDontRelease(coder, item);
     header->hash = hashCreateFromData(data);
     // Safe to ignore data release.
 

--- a/ethereum/blockchain/BREthereumBlock.c
+++ b/ethereum/blockchain/BREthereumBlock.c
@@ -374,7 +374,7 @@ blockHeaderCanonicalDifficulty (BREthereumBlockHeader header,
     uint32_t rem; int overflow = 0;
 
     // z = P(H)_Hd / 2048
-    UInt256 x = divUInt256_Small(parent->difficulty, 2048, &rem);
+    UInt256 x = uint256Div_Small(parent->difficulty, 2048, &rem);
 
     int64_t sigma_2 = blockHeaderCanonicalDifficulty_GetSigma2 (header->number,
                                                                 header->timestamp,
@@ -392,22 +392,22 @@ blockHeaderCanonicalDifficulty (BREthereumBlockHeader header,
     // epsilon = floor (2 ^ epsilon_exponent)
      UInt256 epsilon = (epsilon_exponent < 0
                         ? UINT256_ZERO
-                        : createUInt256Power2 (epsilon_exponent));
+                        : uint256CreatePower2 (epsilon_exponent));
 
     // D(H) = P(H)d + x * sigma_2 + epsilon
 
-    UInt256 x_sigma = mulUInt256_Small(x, (uint32_t) xbs (sigma_2), &overflow);
+    UInt256 x_sigma = uint256Mul_Small(x, (uint32_t) xbs (sigma_2), &overflow);
     assert (0 == overflow);
 
     UInt256 r = (sigma_2 >= 0
-                 ? addUInt256_Overflow (parent->difficulty, x_sigma, &overflow)
-                 : subUInt256_Negative( parent->difficulty, x_sigma, &overflow));
+                 ? uint256Add_Overflow (parent->difficulty, x_sigma, &overflow)
+                 : uint256Sub_Negative( parent->difficulty, x_sigma, &overflow));
     assert (0 == overflow);
 
-    r = addUInt256_Overflow(r, epsilon, &overflow);
+    r = uint256Add_Overflow(r, epsilon, &overflow);
     assert (0 == overflow);
 
-    return gtUInt256 (r, Dzero) ? r : Dzero;
+    return uint256GT (r, Dzero) ? r : Dzero;
 }
 #endif
 
@@ -449,7 +449,7 @@ blockHeaderValidateDifficulty (BREthereumBlockHeader this,
                                BREthereumBlockHeader parent,
                                size_t parentOmmersCount,
                                BREthereumBlockHeader genesis) {
-    return eqUInt256 (this->difficulty,
+    return uint256EQL (this->difficulty,
                       blockHeaderCanonicalDifficulty (this, parent, parentOmmersCount, genesis));
 }
 #endif
@@ -476,7 +476,7 @@ blockHeaderValidatePoWNFactor (BREthereumBlockHeader this,
     // TODO: Does this account for '='?  What are the odds? (guaranteed to 'hit them')
 
     int overflow = 0;
-    mulUInt256_Overflow (powNFactor, this->difficulty, &overflow);
+    uint256Mul_Overflow (powNFactor, this->difficulty, &overflow);
     return 0 == overflow; /* || result == 2^256 */
 }
 
@@ -863,7 +863,7 @@ blockRecursivelyPropagateTotalDifficulty (BREthereumBlock block) {
 
         // Note: on overflow the return value is UINT256_ZERO
         block->totalDifficulty = (NULL != block->next
-                                  ? addUInt256_Overflow (blockGetDifficulty (block),
+                                  ? uint256Add_Overflow (blockGetDifficulty (block),
                                                          blockRecursivelyPropagateTotalDifficulty (block->next),
                                                          &overflow)
                                   : UINT256_ZERO);
@@ -1529,7 +1529,7 @@ initializeGenesisBlocks (void) {
     header->transactionsRoot = hashCreate("0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421");
     header->receiptsRoot = hashCreate("0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421");
     header->logsBloom = bloomFilterCreateString("00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000");
-    header->difficulty = createUInt256 (0x400000000);
+    header->difficulty = uint256Create (0x400000000);
     header->number = 0x0;
     header->gasLimit = 0x1388;
     header->gasUsed = 0x0;
@@ -1572,7 +1572,7 @@ initializeGenesisBlocks (void) {
     header->transactionsRoot = hashCreate("0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421");
     header->receiptsRoot = hashCreate("0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421");
     header->logsBloom = bloomFilterCreateString("00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000");
-    header->difficulty = createUInt256 (0x100000);
+    header->difficulty = uint256Create (0x100000);
     header->number = 0x0;
     header->gasLimit = 0x1000000;
     header->gasUsed = 0x0;
@@ -1615,7 +1615,7 @@ initializeGenesisBlocks (void) {
     header->transactionsRoot = hashCreate("0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421");
     header->receiptsRoot = hashCreate("0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421");
     header->logsBloom = bloomFilterCreateString("00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000");
-    header->difficulty = createUInt256 (0x1);
+    header->difficulty = uint256Create (0x1);
     header->number = 0x0;
     header->gasLimit = 0x47b760;
     header->gasUsed = 0x0;
@@ -1667,19 +1667,19 @@ static void blockCheckpointInitialize (void) {
 
         for (size_t index = 0; index < CHECKPOINT_MAINNET_COUNT; index++) {
             BREthereumBlockCheckpoint *cp = &ethereumMainnetCheckpoints[index];
-            cp->u.td = createUInt256Parse (cp->u.std, 0, &status);
+            cp->u.td = uint256CreateParse (cp->u.std, 0, &status);
             assert (CORE_PARSE_OK == status);
         }
 
         for (size_t index = 0; index < CHECKPOINT_TESTNET_COUNT; index++) {
             BREthereumBlockCheckpoint *cp = &ethereumTestnetCheckpoints[index];
-            cp->u.td = createUInt256Parse (cp->u.std, 0, &status);
+            cp->u.td = uint256CreateParse (cp->u.std, 0, &status);
             assert (CORE_PARSE_OK == status);
         }
 
         for (size_t index = 0; index < CHECKPOINT_RINKEBY_COUNT; index++) {
             BREthereumBlockCheckpoint *cp = &ethereumRinkebyCheckpoints[index];
-            cp->u.td = createUInt256Parse (cp->u.std, 0, &status);
+            cp->u.td = uint256CreateParse (cp->u.std, 0, &status);
             assert (CORE_PARSE_OK == status);
         }
     }

--- a/ethereum/blockchain/BREthereumBlock.c
+++ b/ethereum/blockchain/BREthereumBlock.c
@@ -540,7 +540,7 @@ blockHeaderRlpEncode (BREthereumBlockHeader header,
 
     items[ 0] = ethHashRlpEncode(header->parentHash, coder);
     items[ 1] = ethHashRlpEncode(header->ommersHash, coder);
-    items[ 2] = addressRlpEncode(header->beneficiary, coder);
+    items[ 2] = ethAddressRlpEncode(header->beneficiary, coder);
     items[ 3] = ethHashRlpEncode(header->stateRoot, coder);
     items[ 4] = ethHashRlpEncode(header->transactionsRoot, coder);
     items[ 5] = ethHashRlpEncode(header->receiptsRoot, coder);
@@ -574,7 +574,7 @@ blockHeaderRlpDecode (BRRlpItem item,
 
     header->parentHash = ethHashRlpDecode(items[0], coder);
     header->ommersHash = ethHashRlpDecode(items[1], coder);
-    header->beneficiary = addressRlpDecode(items[2], coder);
+    header->beneficiary = ethAddressRlpDecode(items[2], coder);
     header->stateRoot = ethHashRlpDecode(items[3], coder);
     header->transactionsRoot = ethHashRlpDecode(items[4], coder);
     header->receiptsRoot = ethHashRlpDecode(items[5], coder);
@@ -1524,7 +1524,7 @@ initializeGenesisBlocks (void) {
     header->hash = ethHashCreate("0xd4e56740f876aef8c010b86a40d5f56745a118d0906a34e69aec8c0db1cb8fa3");
     header->parentHash = ethHashCreate("0x0000000000000000000000000000000000000000000000000000000000000000");
     header->ommersHash = ethHashCreate("0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347");
-    header->beneficiary = addressCreate("0x0000000000000000000000000000000000000000");
+    header->beneficiary = ethAddressCreate("0x0000000000000000000000000000000000000000");
     header->stateRoot = ethHashCreate("0xd7f8974fb5ac78d9ac099b9ad5018bedc2ce0a72dad1827a1709da30580f0544");
     header->transactionsRoot = ethHashCreate("0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421");
     header->receiptsRoot = ethHashCreate("0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421");
@@ -1567,7 +1567,7 @@ initializeGenesisBlocks (void) {
     header->hash = ethHashCreate("0x41941023680923e0fe4d74a34bdac8141f2540e3ae90623718e47d66d1ca4a2d");
     header->parentHash = ethHashCreate("0x0000000000000000000000000000000000000000000000000000000000000000");
     header->ommersHash = ethHashCreate("0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347");
-    header->beneficiary = addressCreate("0x0000000000000000000000000000000000000000");
+    header->beneficiary = ethAddressCreate("0x0000000000000000000000000000000000000000");
     header->stateRoot = ethHashCreate("0x217b0bbcfb72e2d57e28f33cb361b9983513177755dc3f33ce3e7022ed62b77b");
     header->transactionsRoot = ethHashCreate("0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421");
     header->receiptsRoot = ethHashCreate("0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421");
@@ -1610,7 +1610,7 @@ initializeGenesisBlocks (void) {
     header->hash = ethHashCreate("0x6341fd3daf94b748c72ced5a5b26028f2474f5f00d824504e4fa37a75767e177");
     header->parentHash = ethHashCreate("0x0000000000000000000000000000000000000000000000000000000000000000");
     header->ommersHash = ethHashCreate("0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347");
-    header->beneficiary = addressCreate("0x0000000000000000000000000000000000000000");
+    header->beneficiary = ethAddressCreate("0x0000000000000000000000000000000000000000");
     header->stateRoot = ethHashCreate("0x53580584816f617295ea26c0e17641e0120cab2f0a8ffb53a866fd53aa8e8c2d");
     header->transactionsRoot = ethHashCreate("0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421");
     header->receiptsRoot = ethHashCreate("0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421");

--- a/ethereum/blockchain/BREthereumBlock.c
+++ b/ethereum/blockchain/BREthereumBlock.c
@@ -1534,7 +1534,7 @@ initializeGenesisBlocks (void) {
     header->gasLimit = 0x1388;
     header->gasUsed = 0x0;
     header->timestamp = 0x0;
-    decodeHex(header->extraData, 32, "11bbe8db4e347b4e8c937c1c8370e4b5ed33adb3db69cbdb7a38e1e50b1b82fa", 64);
+    hexDecode(header->extraData, 32, "11bbe8db4e347b4e8c937c1c8370e4b5ed33adb3db69cbdb7a38e1e50b1b82fa", 64);
     header->extraDataCount = 32;
     header->mixHash = hashCreate("0x0000000000000000000000000000000000000000000000000000000000000000");
     header->nonce = 0x0000000000000042;
@@ -1577,7 +1577,7 @@ initializeGenesisBlocks (void) {
     header->gasLimit = 0x1000000;
     header->gasUsed = 0x0;
     header->timestamp = 0x0;
-    decodeHex(header->extraData, 32, "3535353535353535353535353535353535353535353535353535353535353535", 64);
+    hexDecode(header->extraData, 32, "3535353535353535353535353535353535353535353535353535353535353535", 64);
     header->extraDataCount = 32;
     header->mixHash = hashCreate("0x0000000000000000000000000000000000000000000000000000000000000000");
     header->nonce = 0x0000000000000042;
@@ -1621,7 +1621,7 @@ initializeGenesisBlocks (void) {
     header->gasUsed = 0x0;
     header->timestamp = 0x58ee40ba;
     // TODO: Rinkeby ExtraData is oversized... ignore.
-    decodeHex(header->extraData, 32, "3535353535353535353535353535353535353535353535353535353535353535", 64);
+    hexDecode(header->extraData, 32, "3535353535353535353535353535353535353535353535353535353535353535", 64);
     header->extraDataCount = 32;
     header->mixHash = hashCreate("0x0000000000000000000000000000000000000000000000000000000000000000");
     header->nonce = 0x0000000000000000;

--- a/ethereum/blockchain/BREthereumBloomFilter.c
+++ b/ethereum/blockchain/BREthereumBloomFilter.c
@@ -49,7 +49,7 @@ bloomFilterCreateHash (const BREthereumHash hash) {
 
 extern BREthereumBloomFilter
 bloomFilterCreateData (const BRRlpData data) {
-    return bloomFilterCreateHash(hashCreateFromData(data));
+    return bloomFilterCreateHash(ethHashCreateFromData(data));
 }
 
 extern BREthereumBloomFilter
@@ -57,7 +57,7 @@ bloomFilterCreateAddress (const BREthereumAddress address) {
     BRRlpData data;
     data.bytes = (uint8_t *)  address.bytes;
     data.bytesCount = sizeof (address.bytes);
-    return bloomFilterCreateHash(hashCreateFromData(data));
+    return bloomFilterCreateHash(ethHashCreateFromData(data));
 }
 
 extern BREthereumBloomFilter

--- a/ethereum/blockchain/BREthereumBloomFilter.c
+++ b/ethereum/blockchain/BREthereumBloomFilter.c
@@ -64,7 +64,7 @@ extern BREthereumBloomFilter
 bloomFilterCreateString (const char *string) {
     BREthereumBloomFilter filter;
     if (0 == strncmp ("0x", string, 2)) string = &string[2];
-    decodeHex (filter.bytes, sizeof (filter.bytes), string, strlen(string));
+    hexDecode (filter.bytes, sizeof (filter.bytes), string, strlen(string));
     return filter;
 }
 
@@ -120,7 +120,7 @@ bloomFilterRlpDecode (BRRlpItem item, BRRlpCoder coder) {
 //
 extern char *
 bloomFilterAsString (BREthereumBloomFilter filter) {
-    return encodeHexCreate(NULL, filter.bytes, sizeof (filter.bytes));
+    return hexEncodeCreate(NULL, filter.bytes, sizeof (filter.bytes));
 }
 
 //

--- a/ethereum/blockchain/BREthereumLog.c
+++ b/ethereum/blockchain/BREthereumLog.c
@@ -458,7 +458,7 @@ logRlpDecode (BRRlpItem item,
     log->address = addressRlpDecode(items[0], coder);
     log->topics = logTopicsRlpDecode (items[1], coder);
 
-    log->data = rlpGetData (coder, items[2]); //  rlpDecodeBytes(coder, items[2]);
+    log->data = rlpItemGetData (coder, items[2]); //  rlpDecodeBytes(coder, items[2]);
 
     // 
     log->identifier.transactionReceiptIndex = LOG_TRANSACTION_RECEIPT_INDEX_UNKNOWN;
@@ -484,7 +484,7 @@ logRlpEncode(BREthereumLog log,
 
     items[0] = addressRlpEncode(log->address, coder);
     items[1] = logTopicsRlpEncode(log, coder);
-    items[2] = rlpGetItem(coder, log->data); //  rlpEncodeBytes(coder, log->data.bytes, log->data.bytesCount);
+    items[2] = rlpDataGetItem(coder, log->data); //  rlpEncodeBytes(coder, log->data.bytes, log->data.bytesCount);
 
     if (RLP_TYPE_ARCHIVE == type) {
         items[3] = hashRlpEncode(log->identifier.transactionHash, coder);

--- a/ethereum/blockchain/BREthereumLog.c
+++ b/ethereum/blockchain/BREthereumLog.c
@@ -195,7 +195,7 @@ logCreate (BREthereumAddress address,
            BRRlpData data) {
     BREthereumLog log = calloc (1, sizeof(struct BREthereumLogRecord));
 
-    log->hash = hashCreateEmpty();
+    log->hash = ethHashCreateEmpty();
     log->address = address;
 
     array_new(log->topics, topicsCount);
@@ -221,7 +221,7 @@ logInitializeIdentifier (BREthereumLog log,
     log->identifier.transactionReceiptIndex = transactionReceiptIndex;
 
     BRRlpData data = { sizeof (log->identifier), (uint8_t*) &log->identifier };
-    log->hash = hashCreateFromData(data);
+    log->hash = ethHashCreateFromData(data);
 }
 
 extern BREthereumBoolean
@@ -359,7 +359,7 @@ logIsErrored (BREthereumLog log) {
 extern size_t
 logHashValue (const void *l) {
     assert (LOG_TRANSACTION_RECEIPT_INDEX_UNKNOWN != ((BREthereumLog) l)->identifier.transactionReceiptIndex);
-    return hashSetValue(&((BREthereumLog) l)->hash);
+    return ethHashSetValue(&((BREthereumLog) l)->hash);
 }
 
 // Support BRSet
@@ -369,7 +369,7 @@ logHashEqual (const void *l1, const void *l2) {
 
     assert (LOG_TRANSACTION_RECEIPT_INDEX_UNKNOWN != ((BREthereumLog) l1)->identifier.transactionReceiptIndex);
     assert (LOG_TRANSACTION_RECEIPT_INDEX_UNKNOWN != ((BREthereumLog) l2)->identifier.transactionReceiptIndex);
-    return hashSetEqual (&((BREthereumLog) l1)->hash,
+    return ethHashSetEqual (&((BREthereumLog) l1)->hash,
                          &((BREthereumLog) l2)->hash);
 }
 
@@ -464,7 +464,7 @@ logRlpDecode (BRRlpItem item,
     log->identifier.transactionReceiptIndex = LOG_TRANSACTION_RECEIPT_INDEX_UNKNOWN;
 
     if (RLP_TYPE_ARCHIVE == type) {
-        BREthereumHash hash = hashRlpDecode(items[3], coder);
+        BREthereumHash hash = ethHashRlpDecode(items[3], coder);
 
         uint64_t transactionReceiptIndex = rlpDecodeUInt64(coder, items[4], 0);
         assert (transactionReceiptIndex <= (uint64_t) SIZE_MAX);
@@ -487,7 +487,7 @@ logRlpEncode(BREthereumLog log,
     items[2] = rlpDataGetItem(coder, log->data); //  rlpEncodeBytes(coder, log->data.bytes, log->data.bytesCount);
 
     if (RLP_TYPE_ARCHIVE == type) {
-        items[3] = hashRlpEncode(log->identifier.transactionHash, coder);
+        items[3] = ethHashRlpEncode(log->identifier.transactionHash, coder);
         items[4] = rlpEncodeUInt64(coder, log->identifier.transactionReceiptIndex, 0);
         items[5] = transactionStatusRLPEncode(log->status, coder);
     }

--- a/ethereum/blockchain/BREthereumLog.c
+++ b/ethereum/blockchain/BREthereumLog.c
@@ -47,7 +47,7 @@ logTopicCreateFromString (const char *string) {
     assert (0 == strncmp (string, "0x", 2) && (2 + 2 * LOG_TOPIC_BYTES_COUNT == stringLen));
 
     BREthereumLogTopic topic;
-    decodeHex(topic.bytes, sizeof(BREthereumLogTopic), &string[2], stringLen - 2);
+    hexDecode(topic.bytes, sizeof(BREthereumLogTopic), &string[2], stringLen - 2);
     return topic;
 }
 
@@ -93,7 +93,7 @@ logTopicAsString (BREthereumLogTopic topic) {
     BREthereumLogTopicString string;
     string.chars[0] = '0';
     string.chars[1] = 'x';
-    encodeHex(&string.chars[2], 65, topic.bytes, 32);
+    hexEncode(&string.chars[2], 65, topic.bytes, 32);
     return string;
 }
 

--- a/ethereum/blockchain/BREthereumLog.c
+++ b/ethereum/blockchain/BREthereumLog.c
@@ -305,7 +305,7 @@ logGetAddress (BREthereumLog log) {
 extern BREthereumBoolean
 logHasAddress (BREthereumLog log,
                BREthereumAddress address) {
-    return addressEqual(log->address, address);
+    return ethAddressEqual(log->address, address);
 }
 
 extern size_t
@@ -455,7 +455,7 @@ logRlpDecode (BRRlpItem item,
     assert ((3 == itemsCount && RLP_TYPE_NETWORK == type) ||
             (6 == itemsCount && RLP_TYPE_ARCHIVE == type));
 
-    log->address = addressRlpDecode(items[0], coder);
+    log->address = ethAddressRlpDecode(items[0], coder);
     log->topics = logTopicsRlpDecode (items[1], coder);
 
     log->data = rlpItemGetData (coder, items[2]); //  rlpDecodeBytes(coder, items[2]);
@@ -482,7 +482,7 @@ logRlpEncode(BREthereumLog log,
     
     BRRlpItem items[6]; // more than enough
 
-    items[0] = addressRlpEncode(log->address, coder);
+    items[0] = ethAddressRlpEncode(log->address, coder);
     items[1] = logTopicsRlpEncode(log, coder);
     items[2] = rlpDataGetItem(coder, log->data); //  rlpEncodeBytes(coder, log->data.bytes, log->data.bytesCount);
 

--- a/ethereum/blockchain/BREthereumNetwork.c
+++ b/ethereum/blockchain/BREthereumNetwork.c
@@ -287,26 +287,26 @@ networkInitilizeAllIfAppropriate (void) {
         // Mainnet
 
         ethereumMainnetRecord.genesisBlockHeaderHash =
-        hashCreate ("0xd4e56740f876aef8c010b86a40d5f56745a118d0906a34e69aec8c0db1cb8fa3");
+        ethHashCreate ("0xd4e56740f876aef8c010b86a40d5f56745a118d0906a34e69aec8c0db1cb8fa3");
 
         ethereumMainnetRecord.trustedCheckpointBlockHeaderHash =
-        hashCreate("0x04c2114a8cbe49ba5c37a03cc4b4b8d3adfc0bd2c78e0e726405dd84afca1d63");
+        ethHashCreate("0x04c2114a8cbe49ba5c37a03cc4b4b8d3adfc0bd2c78e0e726405dd84afca1d63");
 
         // Testnet / 'Ropsten'
 
         ethereumTestnetRecord.genesisBlockHeaderHash =
-        hashCreate("0x41941023680923e0fe4d74a34bdac8141f2540e3ae90623718e47d66d1ca4a2d");
+        ethHashCreate("0x41941023680923e0fe4d74a34bdac8141f2540e3ae90623718e47d66d1ca4a2d");
 
         ethereumTestnetRecord.trustedCheckpointBlockHeaderHash =
-        hashCreate("0x1b1ba890510e06411fdee9bb64ca7705c56a1a4ce3559ddb34b3680c526cb419");
+        ethHashCreate("0x1b1ba890510e06411fdee9bb64ca7705c56a1a4ce3559ddb34b3680c526cb419");
 
         // Rinkeby
 
         ethereumRinkebyRecord.genesisBlockHeaderHash =
-        hashCreate("0x6341fd3daf94b748c72ced5a5b26028f2474f5f00d824504e4fa37a75767e177");
+        ethHashCreate("0x6341fd3daf94b748c72ced5a5b26028f2474f5f00d824504e4fa37a75767e177");
         
         ethereumRinkebyRecord.trustedCheckpointBlockHeaderHash =
-        hashCreate("0x6341fd3daf94b748c72ced5a5b26028f2474f5f00d824504e4fa37a75767e177");
+        ethHashCreate("0x6341fd3daf94b748c72ced5a5b26028f2474f5f00d824504e4fa37a75767e177");
 
         // Notable RACE
         needsInitialization = 0;

--- a/ethereum/blockchain/BREthereumNetwork.c
+++ b/ethereum/blockchain/BREthereumNetwork.c
@@ -35,30 +35,30 @@ struct BREthereumNetworkRecord {
 };
 
 extern BREthereumChainId
-networkGetChainId (BREthereumNetwork network) {
+ethNetworkGetChainId (BREthereumNetwork network) {
     networkInitilizeAllIfAppropriate();
     return network->chainId;
 }
 
 extern BREthereumHash
-networkGetGenesisBlockHeaderHash (BREthereumNetwork network) {
+ethNetworkGetGenesisBlockHeaderHash (BREthereumNetwork network) {
     networkInitilizeAllIfAppropriate();
     return network->genesisBlockHeaderHash;
 }
 
 extern BREthereumHash
-networkGetTrustedCheckpointBlockHeaderHash (BREthereumNetwork network) {
+ethNetworkGetTrustedCheckpointBlockHeaderHash (BREthereumNetwork network) {
     networkInitilizeAllIfAppropriate();
     return network->trustedCheckpointBlockHeaderHash;
 }
 
 extern const char *
-networkGetName (BREthereumNetwork network) {
+ethNetworkGetName (BREthereumNetwork network) {
     return network->name;
 }
 
 extern char *
-networkCopyNameAsLowercase (BREthereumNetwork network) {
+ethNetworkCopyNameAsLowercase (BREthereumNetwork network) {
     char *networkName = strdup (network-> name);
     size_t networkNameLength = strlen (networkName);
 
@@ -69,29 +69,29 @@ networkCopyNameAsLowercase (BREthereumNetwork network) {
 }
 
 extern const char**
-networkGetSeeds (BREthereumNetwork network) {
+ethNetworkGetSeeds (BREthereumNetwork network) {
     return network->seeds;
 }
 
 extern size_t
-networkGetSeedsCount (BREthereumNetwork network) {
+ethNetworkGetSeedsCount (BREthereumNetwork network) {
     size_t i = 0;
     while (NULL != network->seeds[i]) i++;
     return i;
 }
 
 extern const char**
-networkGetEnodesBRD (BREthereumNetwork network) {
+ethNetworkGetEnodesBRD (BREthereumNetwork network) {
     return network->enodesBRD;
 }
 
 extern const char**
-networkGetEnodesCommunity (BREthereumNetwork network) {
+ethNetworkGetEnodesCommunity (BREthereumNetwork network) {
     return network->enodesCOM;
 }
 
 extern const char**
-networkGetEnodesLocal (BREthereumNetwork network, int parity) {
+ethNetworkGetEnodesLocal (BREthereumNetwork network, int parity) {
     return parity ?  network->enodesLCLParity : network->enodesLCLGeth;
 }
 
@@ -100,7 +100,7 @@ networkGetEnodesLocal (BREthereumNetwork network, int parity) {
 //
 // Mainnet
 //
-static struct BREthereumNetworkRecord ethereumMainnetRecord = {
+static struct BREthereumNetworkRecord ethNetworkMainnetRecord = {
     "mainnet",
     1,
     EMPTY_HASH_INIT,
@@ -141,7 +141,7 @@ static struct BREthereumNetworkRecord ethereumMainnetRecord = {
         "enode://654580048e9de8f7743ca38035c7ab7fbf2d59b6acd5b92cc031e4571b2c441fe9fc5bb261ada112fb39ca32c1ac7716d91a211b992693c9472ad6af42c5302a@127.0.0.1:30304",
         NULL }
 };
-const BREthereumNetwork ethereumMainnet = &ethereumMainnetRecord;
+const BREthereumNetwork ethNetworkMainnet = &ethNetworkMainnetRecord;
 
 /*
 // MainnetChainConfig is the chain parameters to run a node on the main network.
@@ -162,7 +162,7 @@ MainnetChainConfig = &ChainConfig{
 //
 // Testnet
 //
-static struct BREthereumNetworkRecord ethereumTestnetRecord = {
+static struct BREthereumNetworkRecord ethNetworkTestnetRecord = {
     "testnet", // aka "ropsten"
     3,
     EMPTY_HASH_INIT,
@@ -181,7 +181,7 @@ static struct BREthereumNetworkRecord ethereumTestnetRecord = {
     { NULL },
     { NULL }
 };
-const BREthereumNetwork ethereumTestnet = &ethereumTestnetRecord;
+const BREthereumNetwork ethNetworkTestnet = &ethNetworkTestnetRecord;
 
 /*
 // TestnetChainConfig contains the chain parameters to run a node on the Ropsten test network.
@@ -201,7 +201,7 @@ TestnetChainConfig = &ChainConfig{
 //
 // Rinkeby
 //
-static struct BREthereumNetworkRecord ethereumRinkebyRecord = {
+static struct BREthereumNetworkRecord ethNetworkRinkebyRecord = {
     "rinkeby",
     4,
     EMPTY_HASH_INIT,
@@ -216,7 +216,7 @@ static struct BREthereumNetworkRecord ethereumRinkebyRecord = {
     { NULL },
     { NULL }
 };
-const BREthereumNetwork ethereumRinkeby = &ethereumRinkebyRecord;
+const BREthereumNetwork ethNetworkRinkeby = &ethNetworkRinkebyRecord;
 
 /*
 // RinkebyChainConfig contains the chain parameters to run a node on the Rinkeby test network.
@@ -286,26 +286,26 @@ networkInitilizeAllIfAppropriate (void) {
 
         // Mainnet
 
-        ethereumMainnetRecord.genesisBlockHeaderHash =
+        ethNetworkMainnetRecord.genesisBlockHeaderHash =
         ethHashCreate ("0xd4e56740f876aef8c010b86a40d5f56745a118d0906a34e69aec8c0db1cb8fa3");
 
-        ethereumMainnetRecord.trustedCheckpointBlockHeaderHash =
+        ethNetworkMainnetRecord.trustedCheckpointBlockHeaderHash =
         ethHashCreate("0x04c2114a8cbe49ba5c37a03cc4b4b8d3adfc0bd2c78e0e726405dd84afca1d63");
 
         // Testnet / 'Ropsten'
 
-        ethereumTestnetRecord.genesisBlockHeaderHash =
+        ethNetworkTestnetRecord.genesisBlockHeaderHash =
         ethHashCreate("0x41941023680923e0fe4d74a34bdac8141f2540e3ae90623718e47d66d1ca4a2d");
 
-        ethereumTestnetRecord.trustedCheckpointBlockHeaderHash =
+        ethNetworkTestnetRecord.trustedCheckpointBlockHeaderHash =
         ethHashCreate("0x1b1ba890510e06411fdee9bb64ca7705c56a1a4ce3559ddb34b3680c526cb419");
 
         // Rinkeby
 
-        ethereumRinkebyRecord.genesisBlockHeaderHash =
+        ethNetworkRinkebyRecord.genesisBlockHeaderHash =
         ethHashCreate("0x6341fd3daf94b748c72ced5a5b26028f2474f5f00d824504e4fa37a75767e177");
         
-        ethereumRinkebyRecord.trustedCheckpointBlockHeaderHash =
+        ethNetworkRinkebyRecord.trustedCheckpointBlockHeaderHash =
         ethHashCreate("0x6341fd3daf94b748c72ced5a5b26028f2474f5f00d824504e4fa37a75767e177");
 
         // Notable RACE

--- a/ethereum/blockchain/BREthereumNetwork.h
+++ b/ethereum/blockchain/BREthereumNetwork.h
@@ -34,19 +34,19 @@ typedef struct BREthereumNetworkRecord *BREthereumNetwork;
 typedef int BREthereumChainId;  // 'Officially' UInt256
 
 extern const char *
-networkGetName (BREthereumNetwork network);
+ethNetworkGetName (BREthereumNetwork network);
 
 extern char *
-networkCopyNameAsLowercase (BREthereumNetwork network);
+ethNetworkCopyNameAsLowercase (BREthereumNetwork network);
 
 extern BREthereumChainId
-networkGetChainId (BREthereumNetwork network);
+ethNetworkGetChainId (BREthereumNetwork network);
 
 extern BREthereumHash
-networkGetGenesisBlockHeaderHash (BREthereumNetwork network);
+ethNetworkGetGenesisBlockHeaderHash (BREthereumNetwork network);
 
 extern BREthereumHash
-networkGetTrustedCheckpointBlockHeaderHash (BREthereumNetwork network);
+ethNetworkGetTrustedCheckpointBlockHeaderHash (BREthereumNetwork network);
 
 
 /**
@@ -56,34 +56,34 @@ networkGetTrustedCheckpointBlockHeaderHash (BREthereumNetwork network);
  * @return A NULL terminated array of strings
  */
 extern const char**
-networkGetSeeds (BREthereumNetwork network);
+ethNetworkGetSeeds (BREthereumNetwork network);
 
 extern size_t
-networkGetSeedsCount (BREthereumNetwork network);
+ethNetworkGetSeedsCount (BREthereumNetwork network);
 
 /**
  * BRD Enodes - backup to a failed 'seeds' query
  */
 extern const char**
-networkGetEnodesBRD (BREthereumNetwork network);
+ethNetworkGetEnodesBRD (BREthereumNetwork network);
 
 /**
  * Community Enocdes - backup to a failed 'seeds' query
  */
 extern const char**
-networkGetEnodesCommunity (BREthereumNetwork network);
+ethNetworkGetEnodesCommunity (BREthereumNetwork network);
 
 /**
  * Local Enodes
  */
 extern const char**
-networkGetEnodesLocal (BREthereumNetwork network, int parity);
+ethNetworkGetEnodesLocal (BREthereumNetwork network, int parity);
 
 /// MARK: - Networks
 
-extern const BREthereumNetwork ethereumMainnet;
-extern const BREthereumNetwork ethereumTestnet;
-extern const BREthereumNetwork ethereumRinkeby;
+extern const BREthereumNetwork ethNetworkMainnet;
+extern const BREthereumNetwork ethNetworkTestnet;
+extern const BREthereumNetwork ethNetworkRinkeby;
 
 #ifdef __cplusplus
 }

--- a/ethereum/blockchain/BREthereumTransaction.c
+++ b/ethereum/blockchain/BREthereumTransaction.c
@@ -644,11 +644,11 @@ transactionShow (BREthereumTransaction transaction, const char *topic) {
     eth_log (topic, "    Total : %s WEI", totalWEI);
     eth_log (topic, "    Data  : %s", transaction->data);
 
-    BREthereumContractFunction function = contractLookupFunctionForEncoding (contractERC20, transaction->data);
-    if (NULL != function && functionERC20Transfer == function) {
+    BREthereumContractFunction function = ethContractLookupFunctionForEncoding (ethContractERC20, transaction->data);
+    if (NULL != function && ethFunctionERC20Transfer == function) {
         BRCoreParseStatus status;
-        UInt256 funcAmount = functionERC20TransferDecodeAmount(function, transaction->data, &status);
-        char *funcAddr   = functionERC20TransferDecodeAddress (function, transaction->data);
+        UInt256 funcAmount = ethFunctionERC20TransferDecodeAmount(function, transaction->data, &status);
+        char *funcAddr   = ethFunctionERC20TransferDecodeAddress (function, transaction->data);
         char *funcAmt    = uint256CoerceString(funcAmount, 10);
 
         // BREthereumToken token = tokenLookup(target);

--- a/ethereum/blockchain/BREthereumTransaction.c
+++ b/ethereum/blockchain/BREthereumTransaction.c
@@ -110,7 +110,7 @@ transactionCreate(BREthereumAddress sourceAddress,
     transaction->data = (NULL == data ? NULL : strdup (data));
     transaction->nonce = nonce;
     transaction->chainId = 0;
-    transaction->hash = hashCreateEmpty();
+    transaction->hash = ethHashCreateEmpty();
     transaction->gasEstimate = gasLimit;
 
     // Ensure that `transactionIsSigned()` returns FALSE.
@@ -253,12 +253,12 @@ transactionSetNonce (BREthereumTransaction transaction,
 extern size_t
 transactionHashValue (const void *t)
 {
-    return hashSetValue(&((BREthereumTransaction) t)->hash);
+    return ethHashSetValue(&((BREthereumTransaction) t)->hash);
 }
 
 extern int
 transactionHashEqual (const void *t1, const void *t2) {
-    return t1 == t2 || hashSetEqual (&((BREthereumTransaction) t1)->hash,
+    return t1 == t2 || ethHashSetEqual (&((BREthereumTransaction) t1)->hash,
                                      &((BREthereumTransaction) t2)->hash);
 }
 
@@ -392,7 +392,7 @@ transactionRlpEncode(BREthereumTransaction transaction,
             // For ARCHIVE add in a few things beyond 'SIGNED / NETWORK'
             if (RLP_TYPE_ARCHIVE == type) {
                 items[ 9] = addressRlpEncode(transaction->sourceAddress, coder);
-                items[10] = hashRlpEncode(transaction->hash, coder);
+                items[10] = ethHashRlpEncode(transaction->hash, coder);
                 items[11] = transactionStatusRLPEncode(transaction->status, coder);
                 itemsCount += 3;
             }
@@ -403,7 +403,7 @@ transactionRlpEncode(BREthereumTransaction transaction,
 
     if (RLP_TYPE_TRANSACTION_SIGNED == type) {
         BRRlpData data = rlpItemGetDataSharedDontRelease(coder, result);
-        transaction->hash = hashCreateFromData(data);
+        transaction->hash = ethHashCreateFromData(data);
     }
 
     return result;
@@ -475,14 +475,14 @@ transactionRlpDecode (BRRlpItem item,
         case RLP_TYPE_ARCHIVE:
             // Extract the archive-specific data
             transaction->sourceAddress = addressRlpDecode(items[9], coder);
-            transaction->hash = hashRlpDecode(items[10], coder);
+            transaction->hash = ethHashRlpDecode(items[10], coder);
             transaction->status = transactionStatusRLPDecode(items[11], NULL, coder);
             break;
 
         case RLP_TYPE_TRANSACTION_SIGNED: {
             // With a SIGNED RLP encoding, we can extract the source address and compute the hash.
             BRRlpData result = rlpItemGetDataSharedDontRelease(coder, item);
-            transaction->hash = hashCreateFromData(result);
+            transaction->hash = ethHashCreateFromData(result);
 
             // :fingers-crossed:
             transaction->sourceAddress = transactionExtractAddress (transaction, network, coder);
@@ -620,7 +620,7 @@ extern void
 transactionShow (BREthereumTransaction transaction, const char *topic) {
     int overflow;
 
-    char *hash = hashAsString (transaction->hash);
+    char *hash = ethHashAsString (transaction->hash);
     char *source = addressGetEncodedString(transaction->sourceAddress, 1);
     char *target = addressGetEncodedString(transactionGetTargetAddress(transaction), 1);
     char *amount = etherGetValueString (transactionGetAmount(transaction), ETHER);

--- a/ethereum/blockchain/BREthereumTransaction.c
+++ b/ethereum/blockchain/BREthereumTransaction.c
@@ -189,7 +189,7 @@ transactionGetFeeBasis (BREthereumTransaction transaction) {
 
 extern BREthereumEther
 transactionGetFee (BREthereumTransaction transaction, int *overflow) {
-    return feeBasisGetFee (transactionGetFeeBasis(transaction), overflow);
+    return ethFeeBasisGetFee (transactionGetFeeBasis(transaction), overflow);
 }
 
 extern BREthereumFeeBasis
@@ -202,7 +202,7 @@ transactionGetFeeBasisLimit (BREthereumTransaction transaction) {
 
 extern BREthereumEther
 transactionGetFeeLimit (BREthereumTransaction transaction, int *overflow) {
-    return feeBasisGetFee (transactionGetFeeBasisLimit(transaction), overflow);
+    return ethFeeBasisGetFee (transactionGetFeeBasisLimit(transaction), overflow);
 }
 
 extern BREthereumGasPrice

--- a/ethereum/blockchain/BREthereumTransaction.c
+++ b/ethereum/blockchain/BREthereumTransaction.c
@@ -627,7 +627,7 @@ transactionShow (BREthereumTransaction transaction, const char *topic) {
     char *gasP   = etherGetValueString (transactionGetGasPrice(transaction).etherPerGas, GWEI);
     char *fee    = etherGetValueString (transactionGetFee(transaction, &overflow), ETHER);
 
-    BREthereumEther totalEth = etherCreate(addUInt256_Overflow(transaction->amount.valueInWEI, transactionGetFee(transaction, &overflow).valueInWEI, &overflow));
+    BREthereumEther totalEth = etherCreate(uint256Add_Overflow(transaction->amount.valueInWEI, transactionGetFee(transaction, &overflow).valueInWEI, &overflow));
     char *total  = etherGetValueString (totalEth, ETHER);
     char *totalWEI = etherGetValueString (totalEth, WEI);
 
@@ -649,7 +649,7 @@ transactionShow (BREthereumTransaction transaction, const char *topic) {
         BRCoreParseStatus status;
         UInt256 funcAmount = functionERC20TransferDecodeAmount(function, transaction->data, &status);
         char *funcAddr   = functionERC20TransferDecodeAddress (function, transaction->data);
-        char *funcAmt    = coerceString(funcAmount, 10);
+        char *funcAmt    = uint256CoerceString(funcAmount, 10);
 
         // BREthereumToken token = tokenLookup(target);
 

--- a/ethereum/blockchain/BREthereumTransaction.c
+++ b/ethereum/blockchain/BREthereumTransaction.c
@@ -351,7 +351,7 @@ transactionRlpEncode(BREthereumTransaction transaction,
     items[1] = ethGasPriceRlpEncode(transaction->gasPrice, coder);
     items[2] = ethGasRlpEncode(transaction->gasLimit, coder);
     items[3] = ethAddressRlpEncode(transaction->targetAddress, coder);
-    items[4] = etherRlpEncode(transaction->amount, coder);
+    items[4] = ethEtherRlpEncode(transaction->amount, coder);
     items[5] = rlpEncodeHexString(coder, transaction->data);
     itemsCount = 6;
 
@@ -438,7 +438,7 @@ transactionRlpDecode (BRRlpItem item,
     transaction->gasLimit = ethGasRlpDecode(items[2], coder);
     
     transaction->targetAddress = ethAddressRlpDecode(items[3], coder);
-    transaction->amount = etherRlpDecode(items[4], coder);
+    transaction->amount = ethEtherRlpDecode(items[4], coder);
     transaction->data = rlpDecodeHexString (coder, items[5], "0x");
     
     transaction->chainId = ethNetworkGetChainId(network);
@@ -623,13 +623,13 @@ transactionShow (BREthereumTransaction transaction, const char *topic) {
     char *hash = ethHashAsString (transaction->hash);
     char *source = ethAddressGetEncodedString(transaction->sourceAddress, 1);
     char *target = ethAddressGetEncodedString(transactionGetTargetAddress(transaction), 1);
-    char *amount = etherGetValueString (transactionGetAmount(transaction), ETHER);
-    char *gasP   = etherGetValueString (transactionGetGasPrice(transaction).etherPerGas, GWEI);
-    char *fee    = etherGetValueString (transactionGetFee(transaction, &overflow), ETHER);
+    char *amount = ethEtherGetValueString (transactionGetAmount(transaction), ETHER);
+    char *gasP   = ethEtherGetValueString (transactionGetGasPrice(transaction).etherPerGas, GWEI);
+    char *fee    = ethEtherGetValueString (transactionGetFee(transaction, &overflow), ETHER);
 
-    BREthereumEther totalEth = etherCreate(uint256Add_Overflow(transaction->amount.valueInWEI, transactionGetFee(transaction, &overflow).valueInWEI, &overflow));
-    char *total  = etherGetValueString (totalEth, ETHER);
-    char *totalWEI = etherGetValueString (totalEth, WEI);
+    BREthereumEther totalEth = ethEtherCreate(uint256Add_Overflow(transaction->amount.valueInWEI, transactionGetFee(transaction, &overflow).valueInWEI, &overflow));
+    char *total  = ethEtherGetValueString (totalEth, ETHER);
+    char *totalWEI = ethEtherGetValueString (totalEth, WEI);
 
     eth_log (topic, "=== Transaction%s", "");
     eth_log (topic, "    Hash  : %s", hash);

--- a/ethereum/blockchain/BREthereumTransaction.c
+++ b/ethereum/blockchain/BREthereumTransaction.c
@@ -114,7 +114,7 @@ transactionCreate(BREthereumAddress sourceAddress,
     transaction->gasEstimate = gasLimit;
 
     // Ensure that `transactionIsSigned()` returns FALSE.
-    signatureClear (&transaction->signature, SIGNATURE_TYPE_RECOVERABLE_VRS_EIP);
+    ethSignatureClear (&transaction->signature, SIGNATURE_TYPE_RECOVERABLE_VRS_EIP);
 
 #if defined (TRANSACTION_LOG_ALLOC_COUNT)
     eth_log ("MEM", "TX Create - Count: %d", ++transactionAllocCount);
@@ -326,7 +326,7 @@ transactionExtractAddress(BREthereumTransaction transaction,
     BRRlpItem item = transactionRlpEncode (transaction, network, RLP_TYPE_TRANSACTION_UNSIGNED, coder);
     BRRlpData data = rlpItemGetData(coder, item);
 
-    BREthereumAddress address = signatureExtractAddress(transaction->signature,
+    BREthereumAddress address = ethSignatureExtractAddress(transaction->signature,
                                    data.bytes,
                                    data.bytesCount,
                                    &success);
@@ -446,7 +446,7 @@ transactionRlpDecode (BRRlpItem item,
     uint64_t eipChainId = rlpDecodeUInt64(coder, items[6], 1);
     
     // By default, ensure `transacdtionIsSigned()` returns FALSE.
-    signatureClear (&transaction->signature, SIGNATURE_TYPE_RECOVERABLE_VRS_EIP);
+    ethSignatureClear (&transaction->signature, SIGNATURE_TYPE_RECOVERABLE_VRS_EIP);
     
     // We have a signature - is this the proper logic?
     if (eipChainId != transaction->chainId) {

--- a/ethereum/blockchain/BREthereumTransaction.c
+++ b/ethereum/blockchain/BREthereumTransaction.c
@@ -531,7 +531,7 @@ transactionGetRlpHexEncoded (BREthereumTransaction transaction,
         size_t resultLen = strlen(prefix) + 2 * data.bytesCount + 1;
         result = malloc (resultLen);
         strcpy (result, prefix);
-        encodeHex(&result[strlen(prefix)], 2 * data.bytesCount + 1, data.bytes, data.bytesCount);
+        hexEncode(&result[strlen(prefix)], 2 * data.bytesCount + 1, data.bytes, data.bytesCount);
     }
 
     rlpReleaseItem(coder, item);

--- a/ethereum/blockchain/BREthereumTransaction.c
+++ b/ethereum/blockchain/BREthereumTransaction.c
@@ -164,8 +164,8 @@ transactionGetTargetAddress(BREthereumTransaction transaction) {
 extern BREthereumBoolean
 transactionHasAddress (BREthereumTransaction transaction,
                        BREthereumAddress address) {
-    return (ETHEREUM_BOOLEAN_IS_TRUE(addressEqual(address, transaction->sourceAddress))
-            || ETHEREUM_BOOLEAN_IS_TRUE(addressEqual(address, transaction->targetAddress))
+    return (ETHEREUM_BOOLEAN_IS_TRUE(ethAddressEqual(address, transaction->sourceAddress))
+            || ETHEREUM_BOOLEAN_IS_TRUE(ethAddressEqual(address, transaction->targetAddress))
             ? ETHEREUM_BOOLEAN_TRUE
             : ETHEREUM_BOOLEAN_FALSE);
 }
@@ -350,7 +350,7 @@ transactionRlpEncode(BREthereumTransaction transaction,
     items[0] = rlpEncodeUInt64(coder, transaction->nonce, 1);
     items[1] = ethGasPriceRlpEncode(transaction->gasPrice, coder);
     items[2] = ethGasRlpEncode(transaction->gasLimit, coder);
-    items[3] = addressRlpEncode(transaction->targetAddress, coder);
+    items[3] = ethAddressRlpEncode(transaction->targetAddress, coder);
     items[4] = etherRlpEncode(transaction->amount, coder);
     items[5] = rlpEncodeHexString(coder, transaction->data);
     itemsCount = 6;
@@ -391,7 +391,7 @@ transactionRlpEncode(BREthereumTransaction transaction,
 
             // For ARCHIVE add in a few things beyond 'SIGNED / NETWORK'
             if (RLP_TYPE_ARCHIVE == type) {
-                items[ 9] = addressRlpEncode(transaction->sourceAddress, coder);
+                items[ 9] = ethAddressRlpEncode(transaction->sourceAddress, coder);
                 items[10] = ethHashRlpEncode(transaction->hash, coder);
                 items[11] = transactionStatusRLPEncode(transaction->status, coder);
                 itemsCount += 3;
@@ -437,7 +437,7 @@ transactionRlpDecode (BRRlpItem item,
     transaction->gasPrice = ethGasPriceRlpDecode(items[1], coder);
     transaction->gasLimit = ethGasRlpDecode(items[2], coder);
     
-    transaction->targetAddress = addressRlpDecode(items[3], coder);
+    transaction->targetAddress = ethAddressRlpDecode(items[3], coder);
     transaction->amount = etherRlpDecode(items[4], coder);
     transaction->data = rlpDecodeHexString (coder, items[5], "0x");
     
@@ -474,7 +474,7 @@ transactionRlpDecode (BRRlpItem item,
     switch (type) {
         case RLP_TYPE_ARCHIVE:
             // Extract the archive-specific data
-            transaction->sourceAddress = addressRlpDecode(items[9], coder);
+            transaction->sourceAddress = ethAddressRlpDecode(items[9], coder);
             transaction->hash = ethHashRlpDecode(items[10], coder);
             transaction->status = transactionStatusRLPDecode(items[11], NULL, coder);
             break;
@@ -621,8 +621,8 @@ transactionShow (BREthereumTransaction transaction, const char *topic) {
     int overflow;
 
     char *hash = ethHashAsString (transaction->hash);
-    char *source = addressGetEncodedString(transaction->sourceAddress, 1);
-    char *target = addressGetEncodedString(transactionGetTargetAddress(transaction), 1);
+    char *source = ethAddressGetEncodedString(transaction->sourceAddress, 1);
+    char *target = ethAddressGetEncodedString(transactionGetTargetAddress(transaction), 1);
     char *amount = etherGetValueString (transactionGetAmount(transaction), ETHER);
     char *gasP   = etherGetValueString (transactionGetGasPrice(transaction).etherPerGas, GWEI);
     char *fee    = etherGetValueString (transactionGetFee(transaction, &overflow), ETHER);

--- a/ethereum/blockchain/BREthereumTransaction.c
+++ b/ethereum/blockchain/BREthereumTransaction.c
@@ -217,7 +217,7 @@ transactionGetGasLimit (BREthereumTransaction transaction) {
 
 static BREthereumGas
 gasLimitApplyMargin (BREthereumGas gas) {
-    return gasCreate(((100 + GAS_LIMIT_MARGIN_PERCENT) * gas.amountOfGas) / 100);
+    return ethGasCreate(((100 + GAS_LIMIT_MARGIN_PERCENT) * gas.amountOfGas) / 100);
 }
 
 extern BREthereumGas
@@ -234,7 +234,7 @@ transactionSetGasEstimate (BREthereumTransaction transaction,
     // unless the gasEstimate is 21000 (special case for ETH transfers).
     BREthereumGas gasLimitWithMargin = (21000 != gasEstimate.amountOfGas
                                         ? gasLimitApplyMargin (gasEstimate)
-                                        : gasCreate(21000));
+                                        : ethGasCreate(21000));
     if (gasLimitWithMargin.amountOfGas > transaction->gasLimit.amountOfGas)
         transaction->gasLimit = gasLimitWithMargin;
 }
@@ -348,8 +348,8 @@ transactionRlpEncode(BREthereumTransaction transaction,
     size_t itemsCount = 0;
 
     items[0] = rlpEncodeUInt64(coder, transaction->nonce, 1);
-    items[1] = gasPriceRlpEncode(transaction->gasPrice, coder);
-    items[2] = gasRlpEncode(transaction->gasLimit, coder);
+    items[1] = ethGasPriceRlpEncode(transaction->gasPrice, coder);
+    items[2] = ethGasRlpEncode(transaction->gasLimit, coder);
     items[3] = addressRlpEncode(transaction->targetAddress, coder);
     items[4] = etherRlpEncode(transaction->amount, coder);
     items[5] = rlpEncodeHexString(coder, transaction->data);
@@ -434,8 +434,8 @@ transactionRlpDecode (BRRlpItem item,
     //    items[5] = transactionEncodeDataForHolding(transaction, transaction->amount, coder);
     
     transaction->nonce = rlpDecodeUInt64(coder, items[0], 1);
-    transaction->gasPrice = gasPriceRlpDecode(items[1], coder);
-    transaction->gasLimit = gasRlpDecode(items[2], coder);
+    transaction->gasPrice = ethGasPriceRlpDecode(items[1], coder);
+    transaction->gasLimit = ethGasRlpDecode(items[2], coder);
     
     transaction->targetAddress = addressRlpDecode(items[3], coder);
     transaction->amount = etherRlpDecode(items[4], coder);

--- a/ethereum/blockchain/BREthereumTransaction.c
+++ b/ethereum/blockchain/BREthereumTransaction.c
@@ -363,7 +363,7 @@ transactionRlpEncode(BREthereumTransaction transaction,
     // scheme using v = 27 and v = 28 remains valid and continues to operate under the same rules
     // as it does now.
 
-    transaction->chainId = networkGetChainId(network);
+    transaction->chainId = ethNetworkGetChainId(network);
 
     switch (type) {
         case RLP_TYPE_TRANSACTION_UNSIGNED:
@@ -441,7 +441,7 @@ transactionRlpDecode (BRRlpItem item,
     transaction->amount = etherRlpDecode(items[4], coder);
     transaction->data = rlpDecodeHexString (coder, items[5], "0x");
     
-    transaction->chainId = networkGetChainId(network);
+    transaction->chainId = ethNetworkGetChainId(network);
     
     uint64_t eipChainId = rlpDecodeUInt64(coder, items[6], 1);
     

--- a/ethereum/blockchain/BREthereumTransaction.c
+++ b/ethereum/blockchain/BREthereumTransaction.c
@@ -324,7 +324,7 @@ transactionExtractAddress(BREthereumTransaction transaction,
     int success = 1;
 
     BRRlpItem item = transactionRlpEncode (transaction, network, RLP_TYPE_TRANSACTION_UNSIGNED, coder);
-    BRRlpData data = rlpGetData(coder, item);
+    BRRlpData data = rlpItemGetData(coder, item);
 
     BREthereumAddress address = signatureExtractAddress(transaction->signature,
                                    data.bytes,
@@ -332,7 +332,7 @@ transactionExtractAddress(BREthereumTransaction transaction,
                                    &success);
     
     rlpDataRelease(data);
-    rlpReleaseItem(coder, item);
+    rlpItemRelease(coder, item);
     return address;
 }
 
@@ -402,7 +402,7 @@ transactionRlpEncode(BREthereumTransaction transaction,
     BRRlpItem result = rlpEncodeListItems(coder, items, itemsCount);
 
     if (RLP_TYPE_TRANSACTION_SIGNED == type) {
-        BRRlpData data = rlpGetDataSharedDontRelease(coder, result);
+        BRRlpData data = rlpItemGetDataSharedDontRelease(coder, result);
         transaction->hash = hashCreateFromData(data);
     }
 
@@ -481,7 +481,7 @@ transactionRlpDecode (BRRlpItem item,
 
         case RLP_TYPE_TRANSACTION_SIGNED: {
             // With a SIGNED RLP encoding, we can extract the source address and compute the hash.
-            BRRlpData result = rlpGetDataSharedDontRelease(coder, item);
+            BRRlpData result = rlpItemGetDataSharedDontRelease(coder, item);
             transaction->hash = hashCreateFromData(result);
 
             // :fingers-crossed:
@@ -504,9 +504,9 @@ transactionGetRlpData (BREthereumTransaction transaction,
                        BREthereumRlpType type) {
     BRRlpCoder coder = rlpCoderCreate();
     BRRlpItem item   = transactionRlpEncode (transaction, network, type, coder);
-    BRRlpData data   = rlpGetData (coder, item);
+    BRRlpData data   = rlpItemGetData (coder, item);
 
-    rlpReleaseItem  (coder, item);
+    rlpItemRelease  (coder, item);
     rlpCoderRelease (coder);
 
     return data;
@@ -521,7 +521,7 @@ transactionGetRlpHexEncoded (BREthereumTransaction transaction,
 
     BRRlpCoder coder = rlpCoderCreate();
     BRRlpItem item = transactionRlpEncode (transaction, network, type, coder);
-    BRRlpData data = rlpGetDataSharedDontRelease(coder, item);
+    BRRlpData data = rlpItemGetDataSharedDontRelease(coder, item);
 
     char *result;
 
@@ -534,7 +534,7 @@ transactionGetRlpHexEncoded (BREthereumTransaction transaction,
         hexEncode(&result[strlen(prefix)], 2 * data.bytesCount + 1, data.bytes, data.bytesCount);
     }
 
-    rlpReleaseItem(coder, item);
+    rlpItemRelease(coder, item);
     rlpCoderRelease(coder);
     return result;
 }

--- a/ethereum/blockchain/BREthereumTransaction.h
+++ b/ethereum/blockchain/BREthereumTransaction.h
@@ -25,7 +25,7 @@ extern "C" {
 
 static inline BREthereumGas
 gasApplyLmitMargin (BREthereumGas gas) {
-    return gasCreate(((100 + GAS_LIMIT_MARGIN_PERCENT) * gas.amountOfGas) / 100);
+    return ethGasCreate(((100 + GAS_LIMIT_MARGIN_PERCENT) * gas.amountOfGas) / 100);
 }
 
 /**

--- a/ethereum/blockchain/BREthereumTransactionStatus.c
+++ b/ethereum/blockchain/BREthereumTransactionStatus.c
@@ -90,7 +90,7 @@ transactionStatusEqual (BREthereumTransactionStatus ts1,
                                ((TRANSACTION_STATUS_INCLUDED != ts1.type && TRANSACTION_STATUS_ERRORED != ts1.type) ||
                                 (TRANSACTION_STATUS_INCLUDED == ts1.type &&
                                  ETHEREUM_COMPARISON_EQ == ethGasCompare(ts1.u.included.gasUsed, ts2.u.included.gasUsed) &&
-                                 ETHEREUM_BOOLEAN_IS_TRUE(hashEqual(ts1.u.included.blockHash, ts2.u.included.blockHash)) &&
+                                 ETHEREUM_BOOLEAN_IS_TRUE(ethHashEqual(ts1.u.included.blockHash, ts2.u.included.blockHash)) &&
                                  ts1.u.included.blockNumber == ts2.u.included.blockNumber &&
                                  ts1.u.included.transactionIndex == ts2.u.included.transactionIndex) ||
                                 (TRANSACTION_STATUS_ERRORED == ts1.type &&
@@ -148,7 +148,7 @@ transactionStatusRLPDecode (BRRlpItem item,
             // code with an existing archival value, we keep '3' around.
             assert (5 == othersCount || 3 == othersCount);
 
-            return transactionStatusCreateIncluded (hashRlpDecode(others[0], coder),
+            return transactionStatusCreateIncluded (ethHashRlpDecode(others[0], coder),
                                                     rlpDecodeUInt64(coder, others[1], 0),
                                                     rlpDecodeUInt64(coder, others[2], 0),
                                                     (3 == othersCount
@@ -186,7 +186,7 @@ transactionStatusRLPEncode (BREthereumTransactionStatus status,
 
         case TRANSACTION_STATUS_INCLUDED:
             items[1] = rlpEncodeList (coder, 5,
-                                      hashRlpEncode(status.u.included.blockHash, coder),
+                                      ethHashRlpEncode(status.u.included.blockHash, coder),
                                       rlpEncodeUInt64(coder, status.u.included.blockNumber, 0),
                                       rlpEncodeUInt64(coder, status.u.included.transactionIndex, 0),
                                       rlpEncodeUInt64(coder, status.u.included.blockTimestamp, 0),

--- a/ethereum/blockchain/BREthereumTransactionStatus.c
+++ b/ethereum/blockchain/BREthereumTransactionStatus.c
@@ -89,7 +89,7 @@ transactionStatusEqual (BREthereumTransactionStatus ts1,
     return AS_ETHEREUM_BOOLEAN(ts1.type == ts2.type &&
                                ((TRANSACTION_STATUS_INCLUDED != ts1.type && TRANSACTION_STATUS_ERRORED != ts1.type) ||
                                 (TRANSACTION_STATUS_INCLUDED == ts1.type &&
-                                 ETHEREUM_COMPARISON_EQ == gasCompare(ts1.u.included.gasUsed, ts2.u.included.gasUsed) &&
+                                 ETHEREUM_COMPARISON_EQ == ethGasCompare(ts1.u.included.gasUsed, ts2.u.included.gasUsed) &&
                                  ETHEREUM_BOOLEAN_IS_TRUE(hashEqual(ts1.u.included.blockHash, ts2.u.included.blockHash)) &&
                                  ts1.u.included.blockNumber == ts2.u.included.blockNumber &&
                                  ts1.u.included.transactionIndex == ts2.u.included.transactionIndex) ||
@@ -155,8 +155,8 @@ transactionStatusRLPDecode (BRRlpItem item,
                                                      ? TRANSACTION_STATUS_BLOCK_TIMESTAMP_UNKNOWN
                                                      : rlpDecodeUInt64(coder, others[3], 0)),
                                                     (3 == othersCount
-                                                     ? gasCreate(0)
-                                                     : gasRlpDecode(others[4], coder)));
+                                                     ? ethGasCreate(0)
+                                                     : ethGasRlpDecode(others[4], coder)));
         }
         
         case TRANSACTION_STATUS_ERRORED: {
@@ -190,7 +190,7 @@ transactionStatusRLPEncode (BREthereumTransactionStatus status,
                                       rlpEncodeUInt64(coder, status.u.included.blockNumber, 0),
                                       rlpEncodeUInt64(coder, status.u.included.transactionIndex, 0),
                                       rlpEncodeUInt64(coder, status.u.included.blockTimestamp, 0),
-                                      gasRlpEncode(status.u.included.gasUsed, coder));
+                                      ethGasRlpEncode(status.u.included.gasUsed, coder));
             items[2] = rlpEncodeString(coder, "");
 
             break;

--- a/ethereum/blockchain/testBc.c
+++ b/ethereum/blockchain/testBc.c
@@ -358,7 +358,7 @@ runLogTests (void) {
 
     logSetStatus(log, transactionStatusCreateIncluded(someBlockHash, someBlockNumber, 0,
                                                       TRANSACTION_STATUS_BLOCK_TIMESTAMP_UNKNOWN,
-                                                      gasCreate(0)));
+                                                      ethGasCreate(0)));
     BREthereumTransactionStatus status = logGetStatus(log);
 
     BRRlpItem item = logRlpEncode(log, RLP_TYPE_ARCHIVE, coder);

--- a/ethereum/blockchain/testBc.c
+++ b/ethereum/blockchain/testBc.c
@@ -23,8 +23,8 @@ extern void
 runBloomTests (void) {
     printf ("==== Bloom\n");
 
-    BREthereumBloomFilter filter1 = bloomFilterCreateAddress(addressCreate(BLOOM_ADDR_1));
-    BREthereumBloomFilter filter2 = logTopicGetBloomFilterAddress(addressCreate(BLOOM_ADDR_2));
+    BREthereumBloomFilter filter1 = bloomFilterCreateAddress(ethAddressCreate(BLOOM_ADDR_1));
+    BREthereumBloomFilter filter2 = logTopicGetBloomFilterAddress(ethAddressCreate(BLOOM_ADDR_2));
 
     BREthereumBloomFilter filter = bloomFilterOr(filter1, filter2);
     char *filterAsString = bloomFilterAsString(filter);
@@ -35,7 +35,7 @@ runBloomTests (void) {
 
     assert (ETHEREUM_BOOLEAN_IS_TRUE(bloomFilterMatch(filter, filter1)));
     assert (ETHEREUM_BOOLEAN_IS_TRUE(bloomFilterMatch(filter, filter2)));
-    assert (ETHEREUM_BOOLEAN_IS_FALSE(bloomFilterMatch(filter, bloomFilterCreateAddress(addressCreate("195e7baea6a6c7c4c2dfeb977efac326af552d87")))));
+    assert (ETHEREUM_BOOLEAN_IS_FALSE(bloomFilterMatch(filter, bloomFilterCreateAddress(ethAddressCreate("195e7baea6a6c7c4c2dfeb977efac326af552d87")))));
 
 }
 
@@ -237,9 +237,9 @@ runBlockTest1 () {
     {
         BREthereumBloomFilter filter = bloomFilterCreateString(BLOCK_1_BLOOM);
 
-        BREthereumAddress addressSource = addressCreate(BLOCK_1_TX_132_SOURCE);
-        BREthereumAddress addressTarget = addressCreate(BLOCK_1_TX_132_TARGET);
-        BREthereumAddress addressTokenC = addressCreate(BLOCK_1_TX_132_TOKENC);
+        BREthereumAddress addressSource = ethAddressCreate(BLOCK_1_TX_132_SOURCE);
+        BREthereumAddress addressTarget = ethAddressCreate(BLOCK_1_TX_132_TARGET);
+        BREthereumAddress addressTokenC = ethAddressCreate(BLOCK_1_TX_132_TOKENC);
 
         // 'LogsBloom' holds contact and topic info ...
         assert (ETHEREUM_BOOLEAN_IS_TRUE (bloomFilterMatch(filter, bloomFilterCreateAddress(addressTokenC))));
@@ -255,9 +255,9 @@ runBlockTest1 () {
     {
         BREthereumBloomFilter filter = bloomFilterCreateString(BLOCK_2_BLOOM);
 
-        BREthereumAddress addressSource = addressCreate(BLOCK_2_TX_53_SOURCE);
-        BREthereumAddress addressTarget = addressCreate(BLOCK_2_TX_53_TARGET);
-        BREthereumAddress addressTokenC = addressCreate(BLOCK_2_TX_53_TOKENC);
+        BREthereumAddress addressSource = ethAddressCreate(BLOCK_2_TX_53_SOURCE);
+        BREthereumAddress addressTarget = ethAddressCreate(BLOCK_2_TX_53_TARGET);
+        BREthereumAddress addressTokenC = ethAddressCreate(BLOCK_2_TX_53_TOKENC);
 
         // 'LogsBloom' holds contact and topic info ...
         assert (ETHEREUM_BOOLEAN_IS_TRUE (bloomFilterMatch(filter, bloomFilterCreateAddress(addressTokenC))));

--- a/ethereum/blockchain/testBc.c
+++ b/ethereum/blockchain/testBc.c
@@ -56,7 +56,7 @@ runBloomTests (void) {
 static BREthereumBlockHeader
 testGetBlockHeader (const char *rlp) {
     BRRlpData data;
-    data.bytes = decodeHexCreate(&data.bytesCount, rlp, strlen (rlp));
+    data.bytes = hexDecodeCreate(&data.bytesCount, rlp, strlen (rlp));
 
     BRRlpCoder coder = rlpCoderCreate();
     BRRlpItem blockItem = rlpGetItem(coder, data);
@@ -73,7 +73,7 @@ testGetBlockHeader (const char *rlp) {
 static BREthereumBlock
 testGetBlock (const char *rlp) {
     BRRlpData data;
-    data.bytes = decodeHexCreate(&data.bytesCount, rlp, strlen (rlp));
+    data.bytes = hexDecodeCreate(&data.bytesCount, rlp, strlen (rlp));
 
     BRRlpCoder coder = rlpCoderCreate();
     BRRlpItem blockItem = rlpGetItem(coder, data);
@@ -170,7 +170,7 @@ runBlockTest0 (void) {
     //
     // Block
     //
-    data.bytes = decodeHexCreate(&data.bytesCount, GENESIS_RLP, strlen (GENESIS_RLP));
+    data.bytes = hexDecodeCreate(&data.bytesCount, GENESIS_RLP, strlen (GENESIS_RLP));
 
     BRRlpCoder coder = rlpCoderCreate();
     BRRlpItem blockItem = rlpGetItem(coder, data);
@@ -320,7 +320,7 @@ runLogTests (void) {
     BRRlpData data;
 
     // Log
-    data.bytes = decodeHexCreate(&data.bytesCount, LOG_1_RLP, strlen (LOG_1_RLP));
+    data.bytes = hexDecodeCreate(&data.bytesCount, LOG_1_RLP, strlen (LOG_1_RLP));
 
     BRRlpCoder coder  = rlpCoderCreate();
     BRRlpItem logItem = rlpGetItem(coder, data);
@@ -329,7 +329,7 @@ runLogTests (void) {
 
     BREthereumAddress address = logGetAddress(log);
     size_t addressBytesCount;
-    uint8_t *addressBytes = decodeHexCreate(&addressBytesCount, LOG_1_ADDRESS, strlen(LOG_1_ADDRESS));
+    uint8_t *addressBytes = hexDecodeCreate(&addressBytesCount, LOG_1_ADDRESS, strlen(LOG_1_ADDRESS));
     assert (addressBytesCount == sizeof (address.bytes));
     assert (0 == memcmp (address.bytes, addressBytes, addressBytesCount));
     free (addressBytes);
@@ -454,7 +454,7 @@ runTransactionReceiptTests (void) {
 
     /*
      // Log
-     data.bytes = decodeHexCreate(&data.bytesCount, RECEIPT_1_RLP, strlen (RECEIPT_1_RLP));
+     data.bytes = hexDecodeCreate(&data.bytesCount, RECEIPT_1_RLP, strlen (RECEIPT_1_RLP));
 
      BREthereumTransactionReceipt receipt = transactionReceiptDecodeRLP(data);
      // assert

--- a/ethereum/blockchain/testBc.c
+++ b/ethereum/blockchain/testBc.c
@@ -78,7 +78,7 @@ testGetBlock (const char *rlp) {
     BRRlpCoder coder = rlpCoderCreate();
     BRRlpItem blockItem = rlpDataGetItem(coder, data);
 
-    BREthereumBlock block = blockRlpDecode(blockItem, ethereumMainnet, RLP_TYPE_NETWORK, coder);
+    BREthereumBlock block = blockRlpDecode(blockItem, ethNetworkMainnet, RLP_TYPE_NETWORK, coder);
 
     rlpDataRelease(data);
     rlpItemRelease (coder, blockItem);
@@ -175,10 +175,10 @@ runBlockTest0 (void) {
     BRRlpCoder coder = rlpCoderCreate();
     BRRlpItem blockItem = rlpDataGetItem(coder, data);
 
-    BREthereumBlock block = blockRlpDecode(blockItem, ethereumMainnet, RLP_TYPE_NETWORK, coder);
+    BREthereumBlock block = blockRlpDecode(blockItem, ethNetworkMainnet, RLP_TYPE_NETWORK, coder);
 
     BREthereumBlockHeader header = blockGetHeader(block);
-    BREthereumBlockHeader genesis = networkGetGenesisBlockHeader (ethereumMainnet);
+    BREthereumBlockHeader genesis = networkGetGenesisBlockHeader (ethNetworkMainnet);
 
     assert (ETHEREUM_BOOLEAN_IS_TRUE(ethHashEqual(blockHeaderGetParentHash(header), blockHeaderGetParentHash(genesis))));
     assert(blockHeaderGetTimestamp(header) == blockHeaderGetTimestamp(genesis));
@@ -202,7 +202,7 @@ runBlockTest0 (void) {
     assert (0 == blockGetTransactionsCount(block));
     rlpItemRelease(coder, blockItem);
 
-    blockItem = blockRlpEncode(block, ethereumMainnet, RLP_TYPE_NETWORK, coder);
+    blockItem = blockRlpEncode(block, ethNetworkMainnet, RLP_TYPE_NETWORK, coder);
     rlpItemShow(coder, blockItem, "BlockTest");
     rlpItemRelease(coder, blockItem);
     rlpDataRelease(data);
@@ -275,7 +275,7 @@ runBlockCheckpointTest (void) {
     const BREthereumBlockCheckpoint *cp1;
     BREthereumBlockHeader hd1;
 
-    cp1 = blockCheckpointLookupLatest(ethereumMainnet);
+    cp1 = blockCheckpointLookupLatest(ethNetworkMainnet);
     //    assert (5750000 == cp1->number);
 
     hd1 = blockCheckpointCreatePartialBlockHeader(cp1);

--- a/ethereum/blockchain/testBc.c
+++ b/ethereum/blockchain/testBc.c
@@ -59,12 +59,12 @@ testGetBlockHeader (const char *rlp) {
     data.bytes = hexDecodeCreate(&data.bytesCount, rlp, strlen (rlp));
 
     BRRlpCoder coder = rlpCoderCreate();
-    BRRlpItem blockItem = rlpGetItem(coder, data);
+    BRRlpItem blockItem = rlpDataGetItem(coder, data);
 
     BREthereumBlockHeader header = blockHeaderRlpDecode(blockItem, RLP_TYPE_NETWORK, coder);
 
     rlpDataRelease(data);
-    rlpReleaseItem (coder, blockItem);
+    rlpItemRelease (coder, blockItem);
     rlpCoderRelease(coder);
 
     return header;
@@ -76,12 +76,12 @@ testGetBlock (const char *rlp) {
     data.bytes = hexDecodeCreate(&data.bytesCount, rlp, strlen (rlp));
 
     BRRlpCoder coder = rlpCoderCreate();
-    BRRlpItem blockItem = rlpGetItem(coder, data);
+    BRRlpItem blockItem = rlpDataGetItem(coder, data);
 
     BREthereumBlock block = blockRlpDecode(blockItem, ethereumMainnet, RLP_TYPE_NETWORK, coder);
 
     rlpDataRelease(data);
-    rlpReleaseItem (coder, blockItem);
+    rlpItemRelease (coder, blockItem);
     rlpCoderRelease(coder);
 
     return block;
@@ -173,7 +173,7 @@ runBlockTest0 (void) {
     data.bytes = hexDecodeCreate(&data.bytesCount, GENESIS_RLP, strlen (GENESIS_RLP));
 
     BRRlpCoder coder = rlpCoderCreate();
-    BRRlpItem blockItem = rlpGetItem(coder, data);
+    BRRlpItem blockItem = rlpDataGetItem(coder, data);
 
     BREthereumBlock block = blockRlpDecode(blockItem, ethereumMainnet, RLP_TYPE_NETWORK, coder);
 
@@ -200,11 +200,11 @@ runBlockTest0 (void) {
      */
     assert (0 == blockGetOmmersCount(block));
     assert (0 == blockGetTransactionsCount(block));
-    rlpReleaseItem(coder, blockItem);
+    rlpItemRelease(coder, blockItem);
 
     blockItem = blockRlpEncode(block, ethereumMainnet, RLP_TYPE_NETWORK, coder);
-    rlpShowItem(coder, blockItem, "BlockTest");
-    rlpReleaseItem(coder, blockItem);
+    rlpItemShow(coder, blockItem, "BlockTest");
+    rlpItemRelease(coder, blockItem);
     rlpDataRelease(data);
     blockRelease(block);
     blockHeaderRelease (genesis);
@@ -323,9 +323,9 @@ runLogTests (void) {
     data.bytes = hexDecodeCreate(&data.bytesCount, LOG_1_RLP, strlen (LOG_1_RLP));
 
     BRRlpCoder coder  = rlpCoderCreate();
-    BRRlpItem logItem = rlpGetItem(coder, data);
+    BRRlpItem logItem = rlpDataGetItem(coder, data);
     BREthereumLog log = logRlpDecode(logItem, RLP_TYPE_NETWORK, coder);
-    rlpReleaseItem(coder, logItem);
+    rlpItemRelease(coder, logItem);
 
     BREthereumAddress address = logGetAddress(log);
     size_t addressBytesCount;
@@ -339,13 +339,13 @@ runLogTests (void) {
 
 
     logItem = logRlpEncode(log, RLP_TYPE_NETWORK, coder);
-    BRRlpData encodeData = rlpGetData(coder, logItem);
-    rlpReleaseItem(coder, logItem);
+    BRRlpData encodeData = rlpItemGetData(coder, logItem);
+    rlpItemRelease(coder, logItem);
 
     assert (data.bytesCount == encodeData.bytesCount
             && 0 == memcmp (data.bytes, encodeData.bytes, encodeData.bytesCount));
 
-    rlpShow(data, "LogTest");
+    rlpDataShow(data, "LogTest");
 
     // Archive
     BREthereumHash someBlockHash = HASH_INIT("fc45a8c5ebb5f920931e3d5f48992f3a89b544b4e21dc2c11c5bf8165a7245d6");
@@ -364,7 +364,7 @@ runLogTests (void) {
     BRRlpItem item = logRlpEncode(log, RLP_TYPE_ARCHIVE, coder);
     BREthereumLog logArchived = logRlpDecode(item, RLP_TYPE_ARCHIVE, coder);
     BREthereumTransactionStatus statusArchived = logGetStatus(logArchived);
-    rlpReleaseItem(coder, item);
+    rlpItemRelease(coder, item);
 
     assert (status.type == statusArchived.type);
 
@@ -423,7 +423,7 @@ runAccountStateTests (void) {
     assert (ETHEREUM_BOOLEAN_IS_TRUE(hashEqual(accountStateGetCodeHash(state),
                                                accountStateGetCodeHash(decodedState))));
 
-    rlpReleaseItem(coder, encoding);
+    rlpItemRelease(coder, encoding);
     rlpCoderRelease(coder);
 }
 

--- a/ethereum/blockchain/testBc.c
+++ b/ethereum/blockchain/testBc.c
@@ -406,7 +406,7 @@ runAccountStateTests (void) {
     printf ("==== Account State\n");
 
     BREthereumAccountState state = accountStateCreate(ACCOUNT_STATE_NONCE,
-                                                      etherCreateNumber(ACCOUNT_STATE_BALANCE, WEI),
+                                                      ethEtherCreateNumber(ACCOUNT_STATE_BALANCE, WEI),
                                                       emptyHash,
                                                       emptyHash);
     BRRlpCoder coder = rlpCoderCreate();
@@ -415,7 +415,7 @@ runAccountStateTests (void) {
     BREthereumAccountState decodedState = accountStateRlpDecode(encoding, coder);
 
     assert (accountStateGetNonce(state) == accountStateGetNonce(decodedState));
-    assert (ETHEREUM_BOOLEAN_IS_TRUE(etherIsEQ(accountStateGetBalance(state),
+    assert (ETHEREUM_BOOLEAN_IS_TRUE(ethEtherIsEQ(accountStateGetBalance(state),
                                                accountStateGetBalance(decodedState))));
     assert (ETHEREUM_BOOLEAN_IS_TRUE(ethHashEqual(accountStateGetStorageRoot(state),
                                                accountStateGetStorageRoot(decodedState))));

--- a/ethereum/blockchain/testBc.c
+++ b/ethereum/blockchain/testBc.c
@@ -180,7 +180,7 @@ runBlockTest0 (void) {
     BREthereumBlockHeader header = blockGetHeader(block);
     BREthereumBlockHeader genesis = networkGetGenesisBlockHeader (ethereumMainnet);
 
-    assert (ETHEREUM_BOOLEAN_IS_TRUE(hashEqual(blockHeaderGetParentHash(header), blockHeaderGetParentHash(genesis))));
+    assert (ETHEREUM_BOOLEAN_IS_TRUE(ethHashEqual(blockHeaderGetParentHash(header), blockHeaderGetParentHash(genesis))));
     assert(blockHeaderGetTimestamp(header) == blockHeaderGetTimestamp(genesis));
     assert(blockHeaderGetNumber(header) == blockHeaderGetNumber(genesis));
     //    assert(blockHeaderGetGasUsed(header) == blockHeaderGetGasUsed(genesis));
@@ -281,7 +281,7 @@ runBlockCheckpointTest (void) {
     hd1 = blockCheckpointCreatePartialBlockHeader(cp1);
     assert (cp1->number == blockHeaderGetNumber(hd1));
     assert (cp1->timestamp == blockHeaderGetTimestamp(hd1));
-    assert (ETHEREUM_BOOLEAN_IS_TRUE(hashEqual(cp1->hash, blockHeaderGetHash(hd1))));
+    assert (ETHEREUM_BOOLEAN_IS_TRUE(ethHashEqual(cp1->hash, blockHeaderGetHash(hd1))));
     blockHeaderRelease(hd1);
 }
 
@@ -372,13 +372,13 @@ runLogTests (void) {
     size_t statusArchiveIndex;
     assert (ETHEREUM_BOOLEAN_IS_TRUE (logExtractIdentifier(logArchived, &statusArchiveTxHash, &statusArchiveIndex)));
 //    assert (ETHEREUM_BOOLEAN_IS_TRUE(hashEqual(status.identifier.transactionHash, statusArchiveTxHash)));
-    assert (ETHEREUM_BOOLEAN_IS_TRUE(hashEqual (someTxHash, statusArchiveTxHash)));
+    assert (ETHEREUM_BOOLEAN_IS_TRUE(ethHashEqual (someTxHash, statusArchiveTxHash)));
 
 //    assert (status.identifier.transactionReceiptIndex == statusArchiveIndex);
     assert (someTxIndex == statusArchiveIndex);
 
-    assert (ETHEREUM_BOOLEAN_IS_TRUE(hashEqual(status.u.included.blockHash, statusArchived.u.included.blockHash)));
-    assert (ETHEREUM_BOOLEAN_IS_TRUE(hashEqual(someBlockHash, statusArchived.u.included.blockHash)));
+    assert (ETHEREUM_BOOLEAN_IS_TRUE(ethHashEqual(status.u.included.blockHash, statusArchived.u.included.blockHash)));
+    assert (ETHEREUM_BOOLEAN_IS_TRUE(ethHashEqual(someBlockHash, statusArchived.u.included.blockHash)));
 
     assert (status.u.included.blockNumber == statusArchived.u.included.blockNumber);
     assert (someBlockNumber = statusArchived.u.included.blockNumber);
@@ -417,10 +417,10 @@ runAccountStateTests (void) {
     assert (accountStateGetNonce(state) == accountStateGetNonce(decodedState));
     assert (ETHEREUM_BOOLEAN_IS_TRUE(etherIsEQ(accountStateGetBalance(state),
                                                accountStateGetBalance(decodedState))));
-    assert (ETHEREUM_BOOLEAN_IS_TRUE(hashEqual(accountStateGetStorageRoot(state),
+    assert (ETHEREUM_BOOLEAN_IS_TRUE(ethHashEqual(accountStateGetStorageRoot(state),
                                                accountStateGetStorageRoot(decodedState))));
 
-    assert (ETHEREUM_BOOLEAN_IS_TRUE(hashEqual(accountStateGetCodeHash(state),
+    assert (ETHEREUM_BOOLEAN_IS_TRUE(ethHashEqual(accountStateGetCodeHash(state),
                                                accountStateGetCodeHash(decodedState))));
 
     rlpItemRelease(coder, encoding);

--- a/ethereum/contract/BREthereumContract.c
+++ b/ethereum/contract/BREthereumContract.c
@@ -136,9 +136,9 @@ static void
 topicDecodeUInt256 (void) {}
 
 private_extern char *
-eventERC20TransferDecodeAddress (BREthereumContractEvent event,
-                                 const char *topic) {
-    assert (event == eventERC20Transfer);
+ethEventERC20TransferDecodeAddress (BREthereumContractEvent event,
+                                    const char *topic) {
+    assert (event == ethEventERC20Transfer);
     // Second argument - skip selector + 1st argument
     char result[2 + 40 + 1];
     result[0] = '0';
@@ -149,9 +149,9 @@ eventERC20TransferDecodeAddress (BREthereumContractEvent event,
 }
 
 private_extern char *
-eventERC20TransferEncodeAddress (BREthereumContractEvent event,
-                                 const char *address) {
-    assert (event == eventERC20Transfer);
+ethEventERC20TransferEncodeAddress (BREthereumContractEvent event,
+                                    const char *address) {
+    assert (event == ethEventERC20Transfer);
     assert ('0' == address[0] && 'x' == address[1] && 42 == strlen (address));
 
     address = &address[2];
@@ -169,14 +169,14 @@ eventERC20TransferEncodeAddress (BREthereumContractEvent event,
 }
 
 private_extern UInt256
-eventERC20TransferDecodeUInt256 (BREthereumContractEvent event,
-                                 const char *number,
-                                 BRCoreParseStatus *status) {
+ethEventERC20TransferDecodeUInt256 (BREthereumContractEvent event,
+                                    const char *number,
+                                    BRCoreParseStatus *status) {
     return uint256CreateParse(number, 16, status);
 }
 
 extern const char *
-eventGetSelector (BREthereumContractEvent event) {
+ethEventGetSelector (BREthereumContractEvent event) {
     return event->selector;
 }
 
@@ -312,12 +312,12 @@ static struct BREthereumContractRecord contractRecordERC20 = {
     }
 };
 
-BREthereumContract contractERC20 = &contractRecordERC20;
-BREthereumContractFunction functionERC20Transfer = &contractRecordERC20.functions[2];
-BREthereumContractEvent eventERC20Transfer = &contractRecordERC20.events[0];
+BREthereumContract ethContractERC20 = &contractRecordERC20;
+BREthereumContractFunction ethFunctionERC20Transfer = &contractRecordERC20.functions[2];
+BREthereumContractEvent ethEventERC20Transfer = &contractRecordERC20.events[0];
 
 extern BREthereumContractFunction
-contractLookupFunctionForEncoding (BREthereumContract contract, const char *encoding) {
+ethContractLookupFunctionForEncoding (BREthereumContract contract, const char *encoding) {
     for (int i = 0; i < contract->functionsCount; i++)
         if (functionIsEncodedInData(&contract->functions[i], encoding))
             return &contract->functions[i];
@@ -325,7 +325,7 @@ contractLookupFunctionForEncoding (BREthereumContract contract, const char *enco
 }
 
 extern BREthereumContractEvent
-contractLookupEventForTopic (BREthereumContract contract, const char *topic) {
+ethContractLookupEventForTopic (BREthereumContract contract, const char *topic) {
     for (int i = 0; i < contract->eventsCount; i++)
         if (0 == strcmp (topic, contract->events[i].selector))
             return &contract->events[i];
@@ -333,19 +333,19 @@ contractLookupEventForTopic (BREthereumContract contract, const char *topic) {
 }
 
 private_extern UInt256
-functionERC20TransferDecodeAmount (BREthereumContractFunction function,
-                                   const char *data,
-                                   BRCoreParseStatus *status) {
-    assert (function == functionERC20Transfer);
+ethFunctionERC20TransferDecodeAmount (BREthereumContractFunction function,
+                                      const char *data,
+                                      BRCoreParseStatus *status) {
+    assert (function == ethFunctionERC20Transfer);
     // Second argument - skip selector + 1st argument
     data = &data [strlen(function->selector) + 1 * 64];
     return uint256CreateParse(data, 16, status);
 }
 
 private_extern char *
-functionERC20TransferDecodeAddress (BREthereumContractFunction function,
-                                    const char *data) {
-    assert (function == functionERC20Transfer);
+ethFunctionERC20TransferDecodeAddress (BREthereumContractFunction function,
+                                       const char *data) {
+    assert (function == ethFunctionERC20Transfer);
     // Second argument - skip selector + 1st argument
     char result[2 + 40 + 1];
     result[0] = '0';
@@ -358,7 +358,7 @@ functionERC20TransferDecodeAddress (BREthereumContractFunction function,
 /**
  */
 extern const char *
-contractEncode (BREthereumContract contract, BREthereumContractFunction function, ...) {
+ethContractEncode (BREthereumContract contract, BREthereumContractFunction function, ...) {
     // We'll require VAR ARGS
     unsigned int argsCount = function->argumentCount;
     

--- a/ethereum/contract/BREthereumContract.c
+++ b/ethereum/contract/BREthereumContract.c
@@ -70,7 +70,7 @@ static void argumentEncodeAddress (uint8_t *bytes, size_t bytesCount, uint8_t *t
     memset (target, 0, targetCount);
 
     uint8_t decodedBytes[bytesCount/2];
-    decodeHex(decodedBytes, bytesCount/2, (char *) bytes, bytesCount);
+    hexDecode(decodedBytes, bytesCount/2, (char *) bytes, bytesCount);
 
     memcpy (&target[targetCount - bytesCount/2], decodedBytes, bytesCount/2);
 }
@@ -382,7 +382,7 @@ contractEncode (BREthereumContract contract, BREthereumContractFunction function
         size_t  bytesCount = va_arg (args, size_t);
         (*function->argumentEncoders[i]) (bytes, bytesCount, targetBytes, 32);
         
-        encodeHex(&encoding[encodingIndex], 65, targetBytes, 32);
+        hexEncode(&encoding[encodingIndex], 65, targetBytes, 32);
         encodingIndex += 64;
     }
     encoding[encodingIndex] = '\0';

--- a/ethereum/contract/BREthereumContract.c
+++ b/ethereum/contract/BREthereumContract.c
@@ -172,7 +172,7 @@ private_extern UInt256
 eventERC20TransferDecodeUInt256 (BREthereumContractEvent event,
                                  const char *number,
                                  BRCoreParseStatus *status) {
-    return createUInt256Parse(number, 16, status);
+    return uint256CreateParse(number, 16, status);
 }
 
 extern const char *
@@ -339,7 +339,7 @@ functionERC20TransferDecodeAmount (BREthereumContractFunction function,
     assert (function == functionERC20Transfer);
     // Second argument - skip selector + 1st argument
     data = &data [strlen(function->selector) + 1 * 64];
-    return createUInt256Parse(data, 16, status);
+    return uint256CreateParse(data, 16, status);
 }
 
 private_extern char *

--- a/ethereum/contract/BREthereumContract.h
+++ b/ethereum/contract/BREthereumContract.h
@@ -19,16 +19,15 @@ typedef struct BREthereumFunctionRecord *BREthereumContractFunction;
 typedef struct BREthereumEventRecord *BREthereumContractEvent;
 typedef struct BREthereumContractRecord *BREthereumContract;
 
-
-extern BREthereumContract contractERC20;
-extern BREthereumContractFunction functionERC20Transfer; // "transfer(address,uint256)"
-extern BREthereumContractEvent eventERC20Transfer;       // "Transfer(address indexed _from, address indexed _to, uint256 _value)"
+extern BREthereumContract ethContractERC20;
+extern BREthereumContractFunction ethFunctionERC20Transfer; // "transfer(address,uint256)"
+extern BREthereumContractEvent ethEventERC20Transfer;       // "Transfer(address indexed _from, address indexed _to, uint256 _value)"
 
 /**
  *
  */
 extern const char *
-eventGetSelector (BREthereumContractEvent event);
+ethEventGetSelector (BREthereumContractEvent event);
 
 /**
  * Encode an Ehtereum function with arguments.  The specific arguments and their types are
@@ -49,7 +48,7 @@ eventGetSelector (BREthereumContractEvent event);
  * free (encoding);
  */
 extern const char *
-contractEncode (BREthereumContract contract, BREthereumContractFunction function, ...);
+ethContractEncode (BREthereumContract contract, BREthereumContractFunction function, ...);
 
 /**
  * Return the function for `encodeing` or NULL.
@@ -59,10 +58,10 @@ contractEncode (BREthereumContract contract, BREthereumContractFunction function
  * @return
  */
 extern BREthereumContractFunction
-contractLookupFunctionForEncoding (BREthereumContract contract, const char *encoding);
+ethContractLookupFunctionForEncoding (BREthereumContract contract, const char *encoding);
 
 extern BREthereumContractEvent
-contractLookupEventForTopic (BREthereumContract contract, const char *topic);
+ethContractLookupEventForTopic (BREthereumContract contract, const char *topic);
 
 
 //
@@ -72,26 +71,26 @@ contractLookupEventForTopic (BREthereumContract contract, const char *topic);
 #include "../util/BRUtil.h"
 
 private_extern UInt256
-functionERC20TransferDecodeAmount (BREthereumContractFunction function,
-                                   const char *data,
-                                   BRCoreParseStatus *status);
+ethFunctionERC20TransferDecodeAmount (BREthereumContractFunction function,
+                                      const char *data,
+                                      BRCoreParseStatus *status);
 
 private_extern char *
-functionERC20TransferDecodeAddress (BREthereumContractFunction function,
-                                    const char *data);
+ethFunctionERC20TransferDecodeAddress (BREthereumContractFunction function,
+                                       const char *data);
 
 private_extern char *
-eventERC20TransferDecodeAddress (BREthereumContractEvent event,
-                                 const char *topic);
+ethEventERC20TransferDecodeAddress (BREthereumContractEvent event,
+                                    const char *topic);
 
 private_extern char *
-eventERC20TransferEncodeAddress (BREthereumContractEvent event,
-                                 const char *address);
+ethEventERC20TransferEncodeAddress (BREthereumContractEvent event,
+                                    const char *address);
 
 private_extern UInt256
-eventERC20TransferDecodeUInt256 (BREthereumContractEvent event,
-                                 const char *number,
-                                 BRCoreParseStatus *status);
+ethEventERC20TransferDecodeUInt256 (BREthereumContractEvent event,
+                                    const char *number,
+                                    BRCoreParseStatus *status);
 
 #ifdef __cplusplus
 }

--- a/ethereum/contract/BREthereumToken.c
+++ b/ethereum/contract/BREthereumToken.c
@@ -196,8 +196,8 @@ tokenEncode (BREthereumToken token,
                           rlpEncodeString (coder, token->name),
                           rlpEncodeString (coder, token->description),
                           rlpEncodeUInt64 (coder, token->decimals, 0),
-                          gasRlpEncode (token->gasLimit, coder),
-                          gasPriceRlpEncode (token->gasPrice, coder));
+                          ethGasRlpEncode (token->gasLimit, coder),
+                          ethGasPriceRlpEncode (token->gasPrice, coder));
 }
 
 extern BREthereumToken
@@ -215,8 +215,8 @@ tokenDecode (BRRlpItem item,
     token->name    = rlpDecodeString (coder, items[2]);
     token->description = rlpDecodeString(coder, items[3]);
     token->decimals    = (unsigned int) rlpDecodeUInt64 (coder, items[4], 0);
-    token->gasLimit    = gasRlpDecode (items[5], coder);
-    token->gasPrice    = gasPriceRlpDecode (items[6], coder);
+    token->gasLimit    = ethGasRlpDecode (items[5], coder);
+    token->gasPrice    = ethGasPriceRlpDecode (items[6], coder);
 
     return token;
 }

--- a/ethereum/contract/BREthereumToken.c
+++ b/ethereum/contract/BREthereumToken.c
@@ -66,70 +66,70 @@ struct BREthereumTokenRecord {
 };
 
 extern BREthereumAddress
-tokenGetAddressRaw (BREthereumToken token) {
+ethTokenGetAddressRaw (BREthereumToken token) {
     return token->raw;
 }
 
 extern const char *
-tokenGetAddress(BREthereumToken token) {
+ethTokenGetAddress(BREthereumToken token) {
     return token->address;
 }
 
 extern BREthereumBoolean
-tokenHasAddress (BREthereumToken token,
-                 const char *address) {
+ethTokenHasAddress (BREthereumToken token,
+                    const char *address) {
     return ethAddressEqual (token->raw, ethAddressCreate (address));
 }
 
 extern const char *
-tokenGetSymbol(BREthereumToken token) {
+ethTokenGetSymbol(BREthereumToken token) {
     return token->symbol;
 }
 
 extern const char *
-tokenGetName(BREthereumToken token) {
+ethTokenGetName(BREthereumToken token) {
     return token->name;
 }
 
 extern const char *
-tokenGetDescription(BREthereumToken token) {
+ethTokenGetDescription(BREthereumToken token) {
     return token->description;
 }
 
 extern int
-tokenGetDecimals(BREthereumToken token) {
+ethTokenGetDecimals(BREthereumToken token) {
     return token->decimals;
 }
 
 extern BREthereumGas
-tokenGetGasLimit(BREthereumToken token) {
+ethTokenGetGasLimit(BREthereumToken token) {
     return token->gasLimit;
 }
 
 
 extern BREthereumGasPrice
-tokenGetGasPrice(BREthereumToken token) {
+ethTokenGetGasPrice(BREthereumToken token) {
     return token->gasPrice;
 }
 
 extern BREthereumContract
-tokenGetContract(BREthereumToken token) {
-    return contractERC20;
+ethTokenGetContract(BREthereumToken token) {
+    return ethContractERC20;
 }
 
 extern BREthereumHash
-tokenGetHash (BREthereumToken token) {
+ethTokenGetHash (BREthereumToken token) {
     return ethAddressGetHash(token->raw);
 }
 
 extern BREthereumToken
-tokenCreate (const char *address,
-             const char *symbol,
-             const char *name,
-             const char *description,
-             int decimals,
-             BREthereumGas defaultGasLimit,
-             BREthereumGasPrice defaultGasPrice) {
+ethTokenCreate (const char *address,
+                const char *symbol,
+                const char *name,
+                const char *description,
+                int decimals,
+                BREthereumGas defaultGasLimit,
+                BREthereumGasPrice defaultGasPrice) {
     BREthereumToken token = malloc (sizeof(struct BREthereumTokenRecord));
 
     token->address     = strdup (address);
@@ -145,7 +145,7 @@ tokenCreate (const char *address,
 }
 
 extern void
-tokenRelease (BREthereumToken token) {
+ethTokenRelease (BREthereumToken token) {
     free (token->address);
     free (token->symbol);
     free (token->name);
@@ -154,13 +154,13 @@ tokenRelease (BREthereumToken token) {
 }
 
 extern void
-tokenUpdate (BREthereumToken token,
-             const char *symbol,
-             const char *name,
-             const char *description,
-             int decimals,
-             BREthereumGas defaultGasLimit,
-             BREthereumGasPrice defaultGasPrice) {
+ethTokenUpdate (BREthereumToken token,
+                const char *symbol,
+                const char *name,
+                const char *description,
+                int decimals,
+                BREthereumGas defaultGasLimit,
+                BREthereumGasPrice defaultGasPrice) {
 
     if (0 != strcasecmp (symbol     , token->symbol     )) { free (token->symbol     ); token->symbol      = strdup (symbol     ); }
     if (0 != strcasecmp (name       , token->name       )) { free (token->name       ); token->name        = strdup (name       ); }
@@ -179,17 +179,17 @@ tokenHashValue (const void *t)
 static inline int
 tokenHashEqual (const void *t1, const void *t2) {
     return t1 == t2 || ethAddressHashEqual (((BREthereumToken) t1)->raw,
-                                         ((BREthereumToken) t2)->raw);
+                                            ((BREthereumToken) t2)->raw);
 }
 
 extern BRSetOf(BREthereumToken)
-tokenSetCreate (size_t capacity) {
+ethTokenSetCreate (size_t capacity) {
     return BRSetNew (tokenHashValue, tokenHashEqual, capacity);
 }
 
 extern BRRlpItem
-tokenEncode (BREthereumToken token,
-             BRRlpCoder coder) {
+ethTokenRlpEncode (BREthereumToken token,
+                   BRRlpCoder coder) {
     return rlpEncodeList (coder, 7,
                           ethAddressRlpEncode (token->raw, coder),
                           rlpEncodeString (coder, token->symbol),
@@ -201,8 +201,8 @@ tokenEncode (BREthereumToken token,
 }
 
 extern BREthereumToken
-tokenDecode (BRRlpItem item,
-             BRRlpCoder coder) {
+ethTokenRlpDecode (BRRlpItem item,
+                   BRRlpCoder coder) {
     BREthereumToken token = malloc (sizeof(struct BREthereumTokenRecord));
 
     size_t itemsCount = 0;
@@ -226,8 +226,8 @@ tokenDecode (BRRlpItem item,
 // Token Quantity
 //
 extern BREthereumTokenQuantity
-createTokenQuantity(BREthereumToken token,
-                    UInt256 valueAsInteger) {
+ethTokenQuantityCreate(BREthereumToken token,
+                       UInt256 valueAsInteger) {
     assert (NULL != token);
 
     BREthereumTokenQuantity quantity;
@@ -237,10 +237,10 @@ createTokenQuantity(BREthereumToken token,
 }
 
 extern BREthereumTokenQuantity
-createTokenQuantityString(BREthereumToken token,
-                          const char *number,
-                          BREthereumTokenQuantityUnit unit,
-                          BRCoreParseStatus *status) {
+ethTokenQuantityCreateString(BREthereumToken token,
+                             const char *number,
+                             BREthereumTokenQuantityUnit unit,
+                             BRCoreParseStatus *status) {
     UInt256 valueAsInteger;
 
     if ((TOKEN_QUANTITY_TYPE_DECIMAL == unit && CORE_PARSE_OK != stringParseIsDecimal(number))
@@ -253,24 +253,24 @@ createTokenQuantityString(BREthereumToken token,
                           : uint256CreateParse(number, 10, status));
     }
 
-    return createTokenQuantity(token, (CORE_PARSE_OK != *status ? UINT256_ZERO : valueAsInteger));
+    return ethTokenQuantityCreate(token, (CORE_PARSE_OK != *status ? UINT256_ZERO : valueAsInteger));
 }
 
 extern const BREthereumToken
-tokenQuantityGetToken(BREthereumTokenQuantity quantity) {
+ethTokenQuantityGetToken(BREthereumTokenQuantity quantity) {
     return quantity.token;
 }
 
 extern char *
-tokenQuantityGetValueString(const BREthereumTokenQuantity quantity,
-                            BREthereumTokenQuantityUnit unit) {
+ethTokenQuantityGetValueString(const BREthereumTokenQuantity quantity,
+                               BREthereumTokenQuantityUnit unit) {
     return TOKEN_QUANTITY_TYPE_INTEGER == unit
-           ? uint256CoerceString(quantity.valueAsInteger, 10)
-           : uint256CoerceStringDecimal(quantity.valueAsInteger, quantity.token->decimals);
+    ? uint256CoerceString(quantity.valueAsInteger, 10)
+    : uint256CoerceStringDecimal(quantity.valueAsInteger, quantity.token->decimals);
 }
 
 extern BREthereumComparison
-tokenQuantityCompare(BREthereumTokenQuantity q1, BREthereumTokenQuantity q2, int *typeMismatch) {
+ethTokenQuantityCompare(BREthereumTokenQuantity q1, BREthereumTokenQuantity q2, int *typeMismatch) {
     *typeMismatch = (q1.token != q2.token);
     if (*typeMismatch) return ETHEREUM_COMPARISON_GT;
     switch (uint256Compare(q1.valueAsInteger, q2.valueAsInteger)) {

--- a/ethereum/contract/BREthereumToken.c
+++ b/ethereum/contract/BREthereumToken.c
@@ -78,7 +78,7 @@ tokenGetAddress(BREthereumToken token) {
 extern BREthereumBoolean
 tokenHasAddress (BREthereumToken token,
                  const char *address) {
-    return addressEqual (token->raw, addressCreate (address));
+    return ethAddressEqual (token->raw, ethAddressCreate (address));
 }
 
 extern const char *
@@ -119,7 +119,7 @@ tokenGetContract(BREthereumToken token) {
 
 extern BREthereumHash
 tokenGetHash (BREthereumToken token) {
-    return addressGetHash(token->raw);
+    return ethAddressGetHash(token->raw);
 }
 
 extern BREthereumToken
@@ -139,7 +139,7 @@ tokenCreate (const char *address,
     token->decimals    = decimals;
     token->gasLimit    = defaultGasLimit;
     token->gasPrice    = defaultGasPrice;
-    token->raw         = addressCreate (address);
+    token->raw         = ethAddressCreate (address);
 
     return token;
 }
@@ -173,12 +173,12 @@ tokenUpdate (BREthereumToken token,
 static inline size_t
 tokenHashValue (const void *t)
 {
-    return addressHashValue(((BREthereumToken) t)->raw);
+    return ethAddressHashValue(((BREthereumToken) t)->raw);
 }
 
 static inline int
 tokenHashEqual (const void *t1, const void *t2) {
-    return t1 == t2 || addressHashEqual (((BREthereumToken) t1)->raw,
+    return t1 == t2 || ethAddressHashEqual (((BREthereumToken) t1)->raw,
                                          ((BREthereumToken) t2)->raw);
 }
 
@@ -191,7 +191,7 @@ extern BRRlpItem
 tokenEncode (BREthereumToken token,
              BRRlpCoder coder) {
     return rlpEncodeList (coder, 7,
-                          addressRlpEncode (token->raw, coder),
+                          ethAddressRlpEncode (token->raw, coder),
                           rlpEncodeString (coder, token->symbol),
                           rlpEncodeString (coder, token->name),
                           rlpEncodeString (coder, token->description),
@@ -209,8 +209,8 @@ tokenDecode (BRRlpItem item,
     const BRRlpItem *items = rlpDecodeList (coder, item, &itemsCount);
     assert (7 == itemsCount);
 
-    token->raw     = addressRlpDecode (items[0], coder);
-    token->address = addressGetEncodedString(token->raw, 1);
+    token->raw     = ethAddressRlpDecode (items[0], coder);
+    token->address = ethAddressGetEncodedString(token->raw, 1);
     token->symbol  = rlpDecodeString (coder, items[1]);
     token->name    = rlpDecodeString (coder, items[2]);
     token->description = rlpDecodeString(coder, items[3]);

--- a/ethereum/contract/BREthereumToken.c
+++ b/ethereum/contract/BREthereumToken.c
@@ -243,14 +243,14 @@ createTokenQuantityString(BREthereumToken token,
                           BRCoreParseStatus *status) {
     UInt256 valueAsInteger;
 
-    if ((TOKEN_QUANTITY_TYPE_DECIMAL == unit && CORE_PARSE_OK != parseIsDecimal(number))
-        || (TOKEN_QUANTITY_TYPE_INTEGER == unit && CORE_PARSE_OK != parseIsInteger(number))) {
+    if ((TOKEN_QUANTITY_TYPE_DECIMAL == unit && CORE_PARSE_OK != stringParseIsDecimal(number))
+        || (TOKEN_QUANTITY_TYPE_INTEGER == unit && CORE_PARSE_OK != stringParseIsInteger(number))) {
         *status = CORE_PARSE_STRANGE_DIGITS;
         valueAsInteger = UINT256_ZERO;
     } else {
         valueAsInteger = (TOKEN_QUANTITY_TYPE_DECIMAL == unit
-                          ? createUInt256ParseDecimal(number, token->decimals, status)
-                          : createUInt256Parse(number, 10, status));
+                          ? uint256CreateParseDecimal(number, token->decimals, status)
+                          : uint256CreateParse(number, 10, status));
     }
 
     return createTokenQuantity(token, (CORE_PARSE_OK != *status ? UINT256_ZERO : valueAsInteger));
@@ -265,15 +265,15 @@ extern char *
 tokenQuantityGetValueString(const BREthereumTokenQuantity quantity,
                             BREthereumTokenQuantityUnit unit) {
     return TOKEN_QUANTITY_TYPE_INTEGER == unit
-           ? coerceString(quantity.valueAsInteger, 10)
-           : coerceStringDecimal(quantity.valueAsInteger, quantity.token->decimals);
+           ? uint256CoerceString(quantity.valueAsInteger, 10)
+           : uint256CoerceStringDecimal(quantity.valueAsInteger, quantity.token->decimals);
 }
 
 extern BREthereumComparison
 tokenQuantityCompare(BREthereumTokenQuantity q1, BREthereumTokenQuantity q2, int *typeMismatch) {
     *typeMismatch = (q1.token != q2.token);
     if (*typeMismatch) return ETHEREUM_COMPARISON_GT;
-    switch (compareUInt256(q1.valueAsInteger, q2.valueAsInteger)) {
+    switch (uint256Compare(q1.valueAsInteger, q2.valueAsInteger)) {
         case -1:
             return ETHEREUM_COMPARISON_LT;
         case 0:

--- a/ethereum/contract/BREthereumToken.h
+++ b/ethereum/contract/BREthereumToken.h
@@ -29,76 +29,76 @@ extern "C" {
 typedef struct BREthereumTokenRecord *BREthereumToken;
 
 extern BREthereumAddress
-tokenGetAddressRaw (BREthereumToken token);
-    
+ethTokenGetAddressRaw (BREthereumToken token);
+
 /**
  * Return the token address as a '0x'-prefixed string.  DO NOT FREE THIS.
  */
 extern const char *
-tokenGetAddress (BREthereumToken token);
+ethTokenGetAddress (BREthereumToken token);
 
 /**
  * Check if `token` has `address` which must be a '0x'-prefixed hex string.
  */
 extern BREthereumBoolean
-tokenHasAddress (BREthereumToken token,
-                 const char *address);
+ethTokenHasAddress (BREthereumToken token,
+                    const char *address);
 
 extern const char *
-tokenGetSymbol (BREthereumToken token);
+ethTokenGetSymbol (BREthereumToken token);
 
 extern const char *
-tokenGetName (BREthereumToken token);
+ethTokenGetName (BREthereumToken token);
 
 extern const char *
-tokenGetDescription(BREthereumToken token);
+ethTokenGetDescription(BREthereumToken token);
 
 extern int
-tokenGetDecimals (BREthereumToken token);
+ethTokenGetDecimals (BREthereumToken token);
 
 extern BREthereumGas
-tokenGetGasLimit (BREthereumToken token);
+ethTokenGetGasLimit (BREthereumToken token);
 
 extern BREthereumGasPrice
-tokenGetGasPrice (BREthereumToken token);
+ethTokenGetGasPrice (BREthereumToken token);
 
 extern BREthereumContract
-tokenGetContract (BREthereumToken token);
+ethTokenGetContract (BREthereumToken token);
 
 extern BREthereumHash
-tokenGetHash (BREthereumToken token);
+ethTokenGetHash (BREthereumToken token);
 
 extern BREthereumToken
-tokenCreate (const char *address,
-             const char *symbol,
-             const char *name,
-             const char *description,
-             int decimals,
-             BREthereumGas defaultGasLimit,
-             BREthereumGasPrice defaultGasPrice);
+ethTokenCreate (const char *address,
+                const char *symbol,
+                const char *name,
+                const char *description,
+                int decimals,
+                BREthereumGas defaultGasLimit,
+                BREthereumGasPrice defaultGasPrice);
 
 extern void
-tokenRelease (BREthereumToken token);
+ethTokenRelease (BREthereumToken token);
 
 extern void
-tokenUpdate (BREthereumToken token,
-             const char *symbol,
-             const char *name,
-             const char *description,
-             int decimals,
-             BREthereumGas defaultGasLimit,
-             BREthereumGasPrice defaultGasPrice);
+ethTokenUpdate (BREthereumToken token,
+                const char *symbol,
+                const char *name,
+                const char *description,
+                int decimals,
+                BREthereumGas defaultGasLimit,
+                BREthereumGasPrice defaultGasPrice);
 
 extern BRRlpItem
-tokenEncode (BREthereumToken token,
-             BRRlpCoder coder);
+ethTokenRlpEncode (BREthereumToken token,
+                   BRRlpCoder coder);
 
 extern BREthereumToken
-tokenDecode (BRRlpItem item,
-             BRRlpCoder coder);
+ethTokenRlpDecode (BRRlpItem item,
+                   BRRlpCoder coder);
 
 extern BRSetOf(BREthereumToken)
-tokenSetCreate (size_t capacity);
+ethTokenSetCreate (size_t capacity);
 
 //
 // Token Quantity
@@ -108,8 +108,8 @@ tokenSetCreate (size_t capacity);
  * A BREthereumTokenQuantityUnit defines the (external) representation of a token quantity
  */
 typedef enum {
-  TOKEN_QUANTITY_TYPE_DECIMAL,
-  TOKEN_QUANTITY_TYPE_INTEGER
+    TOKEN_QUANTITY_TYPE_DECIMAL,
+    TOKEN_QUANTITY_TYPE_INTEGER
 } BREthereumTokenQuantityUnit;
 
 /**
@@ -117,22 +117,22 @@ typedef enum {
  *
  */
 typedef struct {
-  BREthereumToken token;
-  UInt256 valueAsInteger;
+    BREthereumToken token;
+    UInt256 valueAsInteger;
 } BREthereumTokenQuantity;
 
 extern BREthereumTokenQuantity
-createTokenQuantity (BREthereumToken token,
-                     UInt256 valueAsInteger);
+ethTokenQuantityCreate (BREthereumToken token,
+                        UInt256 valueAsInteger);
 
 extern BREthereumTokenQuantity
-createTokenQuantityString (BREthereumToken token,
-                           const char *number,
-                           BREthereumTokenQuantityUnit unit,
-                           BRCoreParseStatus *status);
+ethTokenQuantityCreateString (BREthereumToken token,
+                              const char *number,
+                              BREthereumTokenQuantityUnit unit,
+                              BRCoreParseStatus *status);
 
 extern const BREthereumToken
-tokenQuantityGetToken (BREthereumTokenQuantity quantity);
+ethTokenQuantityGetToken (BREthereumTokenQuantity quantity);
 
 /**
  * A newly allocated string; you own it.
@@ -142,11 +142,11 @@ tokenQuantityGetToken (BREthereumTokenQuantity quantity);
  * @return
  */
 extern char *
-tokenQuantityGetValueString(const BREthereumTokenQuantity quantity,
-                            BREthereumTokenQuantityUnit unit);
+ethTokenQuantityGetValueString(const BREthereumTokenQuantity quantity,
+                               BREthereumTokenQuantityUnit unit);
 
 extern BREthereumComparison
-tokenQuantityCompare (BREthereumTokenQuantity q1, BREthereumTokenQuantity q2, int *typeMismatch);
+ethTokenQuantityCompare (BREthereumTokenQuantity q1, BREthereumTokenQuantity q2, int *typeMismatch);
 
 #ifdef __cplusplus
 }

--- a/ethereum/contract/testContract.c
+++ b/ethereum/contract/testContract.c
@@ -45,8 +45,8 @@ installTokensForTest (void) {
     if (!needInstall) return;
     needInstall = 0;
     
-    BREthereumGas defaultGasLimit = gasCreate(TOKEN_BRD_DEFAULT_GAS_LIMIT);
-    BREthereumGasPrice defaultGasPrice = gasPriceCreate(etherCreateNumber(TOKEN_BRD_DEFAULT_GAS_PRICE_IN_WEI_UINT64, WEI));
+    BREthereumGas defaultGasLimit = ethGasCreate(TOKEN_BRD_DEFAULT_GAS_LIMIT);
+    BREthereumGasPrice defaultGasPrice = ethGasPriceCreate(etherCreateNumber(TOKEN_BRD_DEFAULT_GAS_PRICE_IN_WEI_UINT64, WEI));
 
     tokens = tokenSetCreate(10);
 

--- a/ethereum/contract/testContract.c
+++ b/ethereum/contract/testContract.c
@@ -94,7 +94,7 @@ installTokensForTest (void) {
 static void
 runTokenParseTests () {
     BRCoreParseStatus status = CORE_PARSE_OK;
-    UInt256 value = createUInt256Parse ("5968770000000000000000", 10, &status);
+    UInt256 value = uint256CreateParse ("5968770000000000000000", 10, &status);
 
     //  UInt256 valueParseInt = parseTokenQuantity("5968770000000000000000", TOKEN_QUANTITY_TYPE_INTEGER, 18, &error);
     //  UInt256 valueParseDec = parseTokenQuantity("5968770000000000000000", TOKEN_QUANTITY_TYPE_INTEGER, 18, &error);
@@ -104,10 +104,10 @@ runTokenParseTests () {
     address = addressCreate (tokenBRDAddress);
     BREthereumToken token = BRSetGet (tokens, &address);
     BREthereumTokenQuantity valueInt = createTokenQuantityString(token, "5968770000000000000000", TOKEN_QUANTITY_TYPE_INTEGER, &status);
-    assert (CORE_PARSE_OK == status && eqUInt256(value, valueInt.valueAsInteger));
+    assert (CORE_PARSE_OK == status && uint256EQL(value, valueInt.valueAsInteger));
 
     BREthereumTokenQuantity valueDec = createTokenQuantityString(token, "5968.77", TOKEN_QUANTITY_TYPE_DECIMAL, &status);
-    assert (CORE_PARSE_OK == status && eqUInt256(valueInt.valueAsInteger, valueDec.valueAsInteger));
+    assert (CORE_PARSE_OK == status && uint256EQL(valueInt.valueAsInteger, valueDec.valueAsInteger));
 }
 
 void runTokenLookupTests () {

--- a/ethereum/contract/testContract.c
+++ b/ethereum/contract/testContract.c
@@ -35,7 +35,7 @@ static BRSetOf(BREthereumToken) tokens;
 
 extern BREthereumToken
 tokenLookupTest (const char *address) {
-    BREthereumAddress addr = addressCreate(address);
+    BREthereumAddress addr = ethAddressCreate(address);
     return BRSetGet (tokens, &addr);
 }
 
@@ -101,7 +101,7 @@ runTokenParseTests () {
 
     BREthereumAddress address;
 
-    address = addressCreate (tokenBRDAddress);
+    address = ethAddressCreate (tokenBRDAddress);
     BREthereumToken token = BRSetGet (tokens, &address);
     BREthereumTokenQuantity valueInt = createTokenQuantityString(token, "5968770000000000000000", TOKEN_QUANTITY_TYPE_INTEGER, &status);
     assert (CORE_PARSE_OK == status && uint256EQL(value, valueInt.valueAsInteger));
@@ -116,19 +116,19 @@ void runTokenLookupTests () {
     BREthereumToken token;
     BREthereumAddress address;
 
-    address = addressCreate (tokenBRDAddress);
+    address = ethAddressCreate (tokenBRDAddress);
 
     token = BRSetGet (tokens, &address); // BRD
     assert (NULL != token);
 
 #if defined (BITCOIN_DEBUG)
-    address = addressCreate (tokenTSTAddress);
+    address = ethAddressCreate (tokenTSTAddress);
     token = BRSetGet (tokens, &address); // TST
     assert (NULL != token);
 #endif
 
 #if !defined(BITCOIN_TESTNET)
-    address = addressCreate ("0x86fa049857e0209aa7d9e616f7eb3b3b78ecfdb0");
+    address = ethAddressCreate ("0x86fa049857e0209aa7d9e616f7eb3b3b78ecfdb0");
     token = BRSetGet (tokens, &address); // EOI
     assert (NULL != token);
 #endif

--- a/ethereum/contract/testContract.c
+++ b/ethereum/contract/testContract.c
@@ -46,7 +46,7 @@ installTokensForTest (void) {
     needInstall = 0;
     
     BREthereumGas defaultGasLimit = ethGasCreate(TOKEN_BRD_DEFAULT_GAS_LIMIT);
-    BREthereumGasPrice defaultGasPrice = ethGasPriceCreate(etherCreateNumber(TOKEN_BRD_DEFAULT_GAS_PRICE_IN_WEI_UINT64, WEI));
+    BREthereumGasPrice defaultGasPrice = ethGasPriceCreate(ethEtherCreateNumber(TOKEN_BRD_DEFAULT_GAS_PRICE_IN_WEI_UINT64, WEI));
 
     tokens = ethTokenSetCreate(10);
 

--- a/ethereum/contract/testContract.c
+++ b/ethereum/contract/testContract.c
@@ -48,11 +48,11 @@ installTokensForTest (void) {
     BREthereumGas defaultGasLimit = ethGasCreate(TOKEN_BRD_DEFAULT_GAS_LIMIT);
     BREthereumGasPrice defaultGasPrice = ethGasPriceCreate(etherCreateNumber(TOKEN_BRD_DEFAULT_GAS_PRICE_IN_WEI_UINT64, WEI));
 
-    tokens = tokenSetCreate(10);
+    tokens = ethTokenSetCreate(10);
 
     BREthereumToken token;
 
-    token = tokenCreate (tokenBRDAddress,
+    token = ethTokenCreate (tokenBRDAddress,
                          "BRD",
                          "BRD Token",
                          "",
@@ -62,7 +62,7 @@ installTokensForTest (void) {
     BRSetAdd (tokens, token);
 
 #if defined (BITCOIN_DEBUG)
-    token = tokenCreate (tokenTSTAddress,
+    token = ethTokenCreate (tokenTSTAddress,
                          "TST",
                          "Test Standard Token",
                          "TeST Standard Token (TST) for TeSTing (TST)",
@@ -72,7 +72,7 @@ installTokensForTest (void) {
     BRSetAdd (tokens, token);
 
 #endif
-    token = tokenCreate (tokenEOSAddress,
+    token = ethTokenCreate (tokenEOSAddress,
                          "EOS",
                          "EOS Token",
                          "",
@@ -81,7 +81,7 @@ installTokensForTest (void) {
                          defaultGasPrice);
     BRSetAdd (tokens, token);
 
-    token = tokenCreate (tokenKNCAddress,
+    token = ethTokenCreate (tokenKNCAddress,
                          "KNC",
                          "KNC token",
                          "",
@@ -103,10 +103,10 @@ runTokenParseTests () {
 
     address = ethAddressCreate (tokenBRDAddress);
     BREthereumToken token = BRSetGet (tokens, &address);
-    BREthereumTokenQuantity valueInt = createTokenQuantityString(token, "5968770000000000000000", TOKEN_QUANTITY_TYPE_INTEGER, &status);
+    BREthereumTokenQuantity valueInt = ethTokenQuantityCreateString(token, "5968770000000000000000", TOKEN_QUANTITY_TYPE_INTEGER, &status);
     assert (CORE_PARSE_OK == status && uint256EQL(value, valueInt.valueAsInteger));
 
-    BREthereumTokenQuantity valueDec = createTokenQuantityString(token, "5968.77", TOKEN_QUANTITY_TYPE_DECIMAL, &status);
+    BREthereumTokenQuantity valueDec = ethTokenQuantityCreateString(token, "5968.77", TOKEN_QUANTITY_TYPE_DECIMAL, &status);
     assert (CORE_PARSE_OK == status && uint256EQL(valueInt.valueAsInteger, valueDec.valueAsInteger));
 }
 

--- a/ethereum/ewm/BREthereumAccount.c
+++ b/ethereum/ewm/BREthereumAccount.c
@@ -121,8 +121,8 @@ addressDetailFillKey(BREthereumAddressDetail *address, const BRKey *key, uint32_
     memcpy(address->publicKey, &key->pubKey[1], sizeof (address->publicKey));
     
     
-    address->raw = addressCreateKey(key);
-    char *string = addressGetEncodedString(address->raw, 1);
+    address->raw = ethAddressCreateKey(key);
+    char *string = ethAddressGetEncodedString(address->raw, 1);
     memcpy (address->string, string, 42);
     address->string[42] = '\0';
     free (string);
@@ -155,7 +155,7 @@ addressDetailFillRaw (BREthereumAddressDetail *address, const char *string) {
     address->index = 0;
     address->nonce = 0;
     strlcpy (&address->string[0], string, 43);
-    address->raw = addressCreate(string);
+    address->raw = ethAddressCreate(string);
 }
 #endif
 
@@ -291,7 +291,7 @@ accountGetPrimaryAddressPublicKeyString (BREthereumAccount account, int compress
 extern BREthereumBoolean
 accountHasAddress(BREthereumAccount account,
                   BREthereumAddress address) {
-    return addressEqual(account->primaryAddress.raw, address);
+    return ethAddressEqual(account->primaryAddress.raw, address);
 }
 
 extern BREthereumSignature

--- a/ethereum/ewm/BREthereumAccount.c
+++ b/ethereum/ewm/BREthereumAccount.c
@@ -301,7 +301,7 @@ accountSignBytesWithPrivateKey(BREthereumAccount account,
                                uint8_t *bytes,
                                size_t bytesCount,
                                BRKey privateKey) {
-    return signatureCreate(type, bytes, bytesCount, privateKey);
+    return ethSignatureCreate(type, bytes, bytesCount, privateKey);
 }
 
 extern BREthereumSignature

--- a/ethereum/ewm/BREthereumAccount.c
+++ b/ethereum/ewm/BREthereumAccount.c
@@ -67,7 +67,7 @@ typedef struct BREthereumAddressDetailRecord {
      * The 'official' ethereum address string for (the external representation of) this
      * BREthereum address.
      *
-     * THIS IS NOT A SIMPLE STRING; this is a hex encoded (with encodeHex) string prefixed with
+     * THIS IS NOT A SIMPLE STRING; this is a hex encoded (with hexEncode) string prefixed with
      * "0x".  Generally, when using this string, for example when RLP encoding, one needs to
      * convert back to the byte array (use rlpEncodeItemHexString())
      */
@@ -282,7 +282,7 @@ accountGetPrimaryAddressPublicKeyString (BREthereumAccount account, int compress
     
     char *result = malloc (4 + 2 * sourceLen + 1);
     strcpy (result, prefix);  // encode properly...
-    encodeHex(&result[4], 2 * sourceLen + 1, account->primaryAddress.publicKey, sourceLen);
+    hexEncode(&result[4], 2 * sourceLen + 1, account->primaryAddress.publicKey, sourceLen);
     
     return result;
 }

--- a/ethereum/ewm/BREthereumAccount.c
+++ b/ethereum/ewm/BREthereumAccount.c
@@ -179,7 +179,7 @@ struct BREthereumAccountRecord {
 };
 
 extern BREthereumAccount
-createAccountWithBIP32Seed (UInt512 seed) {
+ethAccountCreateWithBIP32Seed (UInt512 seed) {
     BREthereumAccount account = (BREthereumAccount) calloc (1, sizeof (struct BREthereumAccountRecord));
     
     // Assign the key; create the primary address.
@@ -191,7 +191,7 @@ createAccountWithBIP32Seed (UInt512 seed) {
 }
 
 extern BREthereumAccount
-createAccountWithPublicKey (const BRKey key) { // 65 bytes, 0x04-prefixed, uncompressed public key
+ethAccountCreateWithPublicKey (const BRKey key) { // 65 bytes, 0x04-prefixed, uncompressed public key
     BREthereumAccount account = (BREthereumAccount) calloc (1, sizeof (struct BREthereumAccountRecord));
     
     // Assign the key; create the primary address.
@@ -202,7 +202,7 @@ createAccountWithPublicKey (const BRKey key) { // 65 bytes, 0x04-prefixed, uncom
 }
 
 extern BREthereumAccount
-createAccountDetailed(const char *paperKey, const char *wordList[], const int wordListLength) {
+ethAccountCreateDetailed(const char *paperKey, const char *wordList[], const int wordListLength) {
     
     // Validate arguments
     if (NULL == paperKey || NULL == wordList || BIP39_WORDLIST_COUNT != wordListLength)
@@ -219,54 +219,54 @@ createAccountDetailed(const char *paperKey, const char *wordList[], const int wo
 
         // Use a well-known public paper key, but overwrite the address.  This won't work for
         // signing, but will work for viewing.
-        BREthereumAccount account = createAccountWithBIP32Seed(deriveSeedFromPaperKey(DEBUG_PAPER_KEY));
+        BREthereumAccount account = ethAccountCreateWithBIP32Seed(deriveSeedFromPaperKey(DEBUG_PAPER_KEY));
         addressDetailFillRaw (&account->primaryAddress, paperKey);
         return account;
     }
 #endif
     // Generate the 512bit private key using a BIP39 paperKey
-    return createAccountWithBIP32Seed(deriveSeedFromPaperKey(paperKey));
+    return ethAccountCreateWithBIP32Seed(deriveSeedFromPaperKey(paperKey));
 }
 
 extern BREthereumAccount
-createAccount(const char *paperKey) {
+ethAccountCreate (const char *paperKey) {
     if (NULL == sharedWordList)
         installSharedWordList(BRBIP39WordsEn, BIP39_WORDLIST_COUNT);
     
-    return createAccountDetailed(paperKey, sharedWordList, BIP39_WORDLIST_COUNT);
+    return ethAccountCreateDetailed(paperKey, sharedWordList, BIP39_WORDLIST_COUNT);
 }
 
 extern void
-accountFree (BREthereumAccount account) {
+ethAccountRelease (BREthereumAccount account) {
     free (account);
 }
 
 extern BREthereumAddress
-accountGetPrimaryAddress(BREthereumAccount account) {
+ethAccountGetPrimaryAddress(BREthereumAccount account) {
     return account->primaryAddress.raw;
 }
 
 extern char *
-accountGetPrimaryAddressString (BREthereumAccount account) {
+ethAccountGetPrimaryAddressString (BREthereumAccount account) {
     return strdup(account->primaryAddress.string);
     
 }
 
 extern BRKey
-accountGetPrimaryAddressPublicKey (BREthereumAccount account) {
+ethAccountGetPrimaryAddressPublicKey (BREthereumAccount account) {
     return addressDetailGetPublicKey(&account->primaryAddress);
 }
 
 extern BRKey
-accountGetPrimaryAddressPrivateKey (BREthereumAccount account,
-                                    const char *paperKey) {
+ethAccountGetPrimaryAddressPrivateKey (BREthereumAccount account,
+                                       const char *paperKey) {
     return derivePrivateKeyFromSeed(deriveSeedFromPaperKey(paperKey),
                                     account->primaryAddress.index);
 }
 
 #if defined (DEBUG)
 extern const char *
-accountGetPrimaryAddressPublicKeyString (BREthereumAccount account, int compressed) {
+ethAccountGetPrimaryAddressPublicKeyString (BREthereumAccount account, int compressed) {
     // The byte array at address->publicKey has the '04' 'uncompressed' prefix removed.  Thus
     // the value in publicKey is uncompressed and 64 bytes.  As a string, this result will have
     // an 0x0<n> prefix where 'n' is in { 4: uncompressed, 2: compressed even, 3: compressed odd }.
@@ -289,36 +289,36 @@ accountGetPrimaryAddressPublicKeyString (BREthereumAccount account, int compress
 #endif
 
 extern BREthereumBoolean
-accountHasAddress(BREthereumAccount account,
-                  BREthereumAddress address) {
+ethAccountHasAddress(BREthereumAccount account,
+                     BREthereumAddress address) {
     return ethAddressEqual(account->primaryAddress.raw, address);
 }
 
 extern BREthereumSignature
-accountSignBytesWithPrivateKey(BREthereumAccount account,
-                               BREthereumAddress address,
-                               BREthereumSignatureType type,
-                               uint8_t *bytes,
-                               size_t bytesCount,
-                               BRKey privateKey) {
+ethAccountSignBytesWithPrivateKey(BREthereumAccount account,
+                                  BREthereumAddress address,
+                                  BREthereumSignatureType type,
+                                  uint8_t *bytes,
+                                  size_t bytesCount,
+                                  BRKey privateKey) {
     return ethSignatureCreate(type, bytes, bytesCount, privateKey);
 }
 
 extern BREthereumSignature
-accountSignBytes(BREthereumAccount account,
-                 BREthereumAddress address,
-                 BREthereumSignatureType type,
-                 uint8_t *bytes,
-                 size_t bytesCount,
-                 const char *paperKey) {
+ethAccountSignBytes(BREthereumAccount account,
+                    BREthereumAddress address,
+                    BREthereumSignatureType type,
+                    uint8_t *bytes,
+                    size_t bytesCount,
+                    const char *paperKey) {
     UInt512 seed = deriveSeedFromPaperKey(paperKey);
     // TODO: Account has Address
-    return accountSignBytesWithPrivateKey(account,
-                                          address,
-                                          type,
-                                          bytes,
-                                          bytesCount,
-                                          derivePrivateKeyFromSeed(seed, account->primaryAddress.index));
+    return ethAccountSignBytesWithPrivateKey(account,
+                                             address,
+                                             type,
+                                             bytes,
+                                             bytesCount,
+                                             derivePrivateKeyFromSeed(seed, account->primaryAddress.index));
 }
 
 //
@@ -354,33 +354,33 @@ derivePrivateKeyFromSeed (UInt512 seed, uint32_t index) {
 // New
 //
 extern uint32_t
-accountGetAddressIndex (BREthereumAccount account,
-                        BREthereumAddress address) {
+ethAccountGetAddressIndex (BREthereumAccount account,
+                           BREthereumAddress address) {
     // TODO: Lookup address, assert address
     return account->primaryAddress.index;
 }
 
 extern uint64_t
-accountGetAddressNonce (BREthereumAccount account,
-                        BREthereumAddress address) {
+ethAccountGetAddressNonce (BREthereumAccount account,
+                           BREthereumAddress address) {
     // TODO: Lookup address, assert address
     return account->primaryAddress.nonce;
     
 }
 
 private_extern void
-accountSetAddressNonce(BREthereumAccount account,
-                       BREthereumAddress address,
-                       uint64_t nonce,
-                       BREthereumBoolean force) {
+ethAccountSetAddressNonce(BREthereumAccount account,
+                          BREthereumAddress address,
+                          uint64_t nonce,
+                          BREthereumBoolean force) {
     // TODO: Lookup address, assert address
     if (ETHEREUM_BOOLEAN_IS_TRUE(force) || nonce > account->primaryAddress.nonce)
         account->primaryAddress.nonce = nonce;
 }
 
 private_extern uint64_t
-accountGetThenIncrementAddressNonce(BREthereumAccount account,
-                                    BREthereumAddress address) {
+ethAccountGetThenIncrementAddressNonce(BREthereumAccount account,
+                                       BREthereumAddress address) {
     // TODO: Lookup address, assert address
     return account->primaryAddress.nonce++;
 }

--- a/ethereum/ewm/BREthereumAccount.h
+++ b/ethereum/ewm/BREthereumAccount.h
@@ -26,17 +26,17 @@ extern "C" {
  * @return
  */
 extern BREthereumAccount
-createAccount(const char *paperKey);
+ethAccountCreate (const char *paperKey);
 
 /**
  * Create a new account using the 65 bytes, 0x04-prefixed, uncompressed public key (as returned
  * by addressGetPublicKey())
  */
 extern BREthereumAccount
-createAccountWithPublicKey (const BRKey publicKey);
+ethAccountCreateWithPublicKey (const BRKey publicKey);
 
 extern BREthereumAccount
-createAccountWithBIP32Seed (UInt512 seed);
+ethAccountCreateWithBIP32Seed (UInt512 seed);
 
 /**
  * Create a new account using paperKey and the provided wordList
@@ -47,10 +47,10 @@ createAccountWithBIP32Seed (UInt512 seed);
  * @return
  */
 extern BREthereumAccount
-createAccountDetailed(const char *paperKey, const char *wordList[], const int wordListLength);
+ethAccountCreateDetailed(const char *paperKey, const char *wordList[], const int wordListLength);
 
 extern void
-accountFree (BREthereumAccount account);
+ethAccountRelease (BREthereumAccount account);
 
 /**
  * The account's primary address (aka 'address[0]').
@@ -59,32 +59,32 @@ accountFree (BREthereumAccount account);
  * @return
  */
 extern BREthereumAddress
-accountGetPrimaryAddress(BREthereumAccount account);
+ethAccountGetPrimaryAddress(BREthereumAccount account);
 
 extern char *
-accountGetPrimaryAddressString (BREthereumAccount account);
+ethAccountGetPrimaryAddressString (BREthereumAccount account);
 
 /**
  * the public key for the account's primary address
  */
 extern BRKey
-accountGetPrimaryAddressPublicKey (BREthereumAccount account);
+ethAccountGetPrimaryAddressPublicKey (BREthereumAccount account);
 
 /**
  * the privateKey for the account's primary address
  */
 extern BRKey
-accountGetPrimaryAddressPrivateKey (BREthereumAccount account,
-                                    const char *paperKey);
+ethAccountGetPrimaryAddressPrivateKey (BREthereumAccount account,
+                                       const char *paperKey);
 
 #if defined (DEBUG)
 extern const char *
-accountGetPrimaryAddressPublicKeyString (BREthereumAccount account, int compressed);
+ethAccountGetPrimaryAddressPublicKeyString (BREthereumAccount account, int compressed);
 #endif
 
 extern BREthereumBoolean
-accountHasAddress(BREthereumAccount account,
-                  BREthereumAddress address);
+ethAccountHasAddress(BREthereumAccount account,
+                     BREthereumAddress address);
 
 /**
  * Sign an arbitrary array of bytes with the account's private key using the signature algorithm
@@ -97,20 +97,20 @@ accountHasAddress(BREthereumAccount account,
  * @return
  */
 extern BREthereumSignature
-accountSignBytesWithPrivateKey(BREthereumAccount account,
-                               BREthereumAddress address,
-                               BREthereumSignatureType type,
-                               uint8_t *bytes,
-                               size_t bytesCount,
-                               BRKey privateKey);
+ethAccountSignBytesWithPrivateKey(BREthereumAccount account,
+                                  BREthereumAddress address,
+                                  BREthereumSignatureType type,
+                                  uint8_t *bytes,
+                                  size_t bytesCount,
+                                  BRKey privateKey);
 
 extern BREthereumSignature
-accountSignBytes(BREthereumAccount account,
-                 BREthereumAddress address,
-                 BREthereumSignatureType type,
-                 uint8_t *bytes,
-                 size_t bytesCount,
-                 const char *paperKey);
+ethAccountSignBytes(BREthereumAccount account,
+                    BREthereumAddress address,
+                    BREthereumSignatureType type,
+                    uint8_t *bytes,
+                    size_t bytesCount,
+                    const char *paperKey);
 
 //
 // Support (quasi-private)
@@ -126,25 +126,25 @@ derivePrivateKeyFromSeed (UInt512 seed, uint32_t index);
 // New
 //
 extern uint32_t
-accountGetAddressIndex (BREthereumAccount account,
-                        BREthereumAddress address);
+ethAccountGetAddressIndex (BREthereumAccount account,
+                           BREthereumAddress address);
 
 extern uint64_t
-accountGetAddressNonce (BREthereumAccount account,
-                        BREthereumAddress address);
+ethAccountGetAddressNonce (BREthereumAccount account,
+                           BREthereumAddress address);
 
 //
 // Private
 //
 private_extern void
-accountSetAddressNonce(BREthereumAccount account,
-                       BREthereumAddress address,
-                       uint64_t nonce,
-                       BREthereumBoolean force);
+ethAccountSetAddressNonce(BREthereumAccount account,
+                          BREthereumAddress address,
+                          uint64_t nonce,
+                          BREthereumBoolean force);
 
 private_extern uint64_t
-accountGetThenIncrementAddressNonce(BREthereumAccount account,
-                                    BREthereumAddress address);
+ethAccountGetThenIncrementAddressNonce(BREthereumAccount account,
+                                       BREthereumAddress address);
 
 #ifdef __cplusplus
 }

--- a/ethereum/ewm/BREthereumAmount.c
+++ b/ethereum/ewm/BREthereumAmount.c
@@ -65,7 +65,7 @@ amountCompare (BREthereumAmount a1, BREthereumAmount a2, int *typeMismatch) {
         case AMOUNT_ETHER:
             return etherCompare(a1.u.ether, a2.u.ether);
         case AMOUNT_TOKEN:
-            return tokenQuantityCompare(a1.u.tokenQuantity, a2.u.tokenQuantity, typeMismatch);
+            return ethTokenQuantityCompare(a1.u.tokenQuantity, a2.u.tokenQuantity, typeMismatch);
     }
 }
 
@@ -75,7 +75,7 @@ amountGetGasEstimate (BREthereumAmount amount) {
         case AMOUNT_ETHER:
             return ethGasCreate (DEFAULT_ETHER_GAS_LIMIT);
         case AMOUNT_TOKEN:
-            return tokenGetGasLimit (amount.u.tokenQuantity.token);
+            return ethTokenGetGasLimit (amount.u.tokenQuantity.token);
     }
 }
 
@@ -98,7 +98,7 @@ amountRlpDecodeAsEther (BRRlpItem item, BRRlpCoder coder) {
 
 extern BREthereumAmount
 amountRlpDecodeAsToken (BRRlpItem item, BRRlpCoder coder, BREthereumToken token) {
-    return amountCreateToken(createTokenQuantity(token, rlpDecodeUInt256(coder, item, 1)));
+    return amountCreateToken(ethTokenQuantityCreate(token, rlpDecodeUInt256(coder, item, 1)));
 }
  
 //
@@ -116,7 +116,7 @@ extern BREthereumAmount
 amountCreateTokenQuantityString (BREthereumToken token, const char *number, BREthereumTokenQuantityUnit unit, BRCoreParseStatus *status) {
     BREthereumAmount amount;
     amount.type = AMOUNT_TOKEN;
-    amount.u.tokenQuantity = createTokenQuantityString(token, number, unit, status);
+    amount.u.tokenQuantity = ethTokenQuantityCreateString(token, number, unit, status);
     return amount;
 }
 

--- a/ethereum/ewm/BREthereumAmount.c
+++ b/ethereum/ewm/BREthereumAmount.c
@@ -63,7 +63,7 @@ ethAmountCompare (BREthereumAmount a1, BREthereumAmount a2, int *typeMismatch) {
     if (*typeMismatch) return ETHEREUM_COMPARISON_GT;
     switch (a1.type) {
         case AMOUNT_ETHER:
-            return etherCompare(a1.u.ether, a2.u.ether);
+            return ethEtherCompare(a1.u.ether, a2.u.ether);
         case AMOUNT_TOKEN:
             return ethTokenQuantityCompare(a1.u.tokenQuantity, a2.u.tokenQuantity, typeMismatch);
     }
@@ -83,7 +83,7 @@ extern BRRlpItem
 ethAmountRlpEncode(BREthereumAmount amount, BRRlpCoder coder) {
     switch (amount.type) {
         case AMOUNT_ETHER:
-            return etherRlpEncode(amount.u.ether, coder);
+            return ethEtherRlpEncode(amount.u.ether, coder);
             
         case AMOUNT_TOKEN:
             // We do not encode a 'number 0', we encode an empty string - it seems from ethereumio
@@ -93,7 +93,7 @@ ethAmountRlpEncode(BREthereumAmount amount, BRRlpCoder coder) {
 
 extern BREthereumAmount
 ethAmountRlpDecodeAsEther (BRRlpItem item, BRRlpCoder coder) {
-    return ethAmountCreateEther(etherRlpDecode(item, coder));
+    return ethAmountCreateEther(ethEtherRlpDecode(item, coder));
 }
 
 extern BREthereumAmount
@@ -108,7 +108,7 @@ extern BREthereumAmount
 ethAmountCreateEtherString (const char *number, BREthereumEtherUnit unit, BRCoreParseStatus *status) {
     BREthereumAmount amount;
     amount.type = AMOUNT_ETHER;
-    amount.u.ether = etherCreateString(number, unit, status);
+    amount.u.ether = ethEtherCreateString(number, unit, status);
     return amount;
 }
 

--- a/ethereum/ewm/BREthereumAmount.c
+++ b/ethereum/ewm/BREthereumAmount.c
@@ -18,7 +18,7 @@
 // amount
 //
 extern BREthereumAmount
-amountCreateEther (BREthereumEther ether) {
+ethAmountCreateEther (BREthereumEther ether) {
     BREthereumAmount amount;
     amount.type = AMOUNT_ETHER;
     amount.u.ether = ether;
@@ -26,7 +26,7 @@ amountCreateEther (BREthereumEther ether) {
 }
 
 extern BREthereumAmount
-amountCreateToken (BREthereumTokenQuantity tokenQuantity) {
+ethAmountCreateToken (BREthereumTokenQuantity tokenQuantity) {
     BREthereumAmount amount;
     amount.type = AMOUNT_TOKEN;
     amount.u.tokenQuantity = tokenQuantity;
@@ -34,30 +34,30 @@ amountCreateToken (BREthereumTokenQuantity tokenQuantity) {
 }
 
 extern BREthereumAmountType
-amountGetType (BREthereumAmount amount) {
+ethAmountGetType (BREthereumAmount amount) {
     return amount.type;
 }
 
 extern BREthereumEther
-amountGetEther (BREthereumAmount amount) {
+ethAmountGetEther (BREthereumAmount amount) {
     assert (amount.type == AMOUNT_ETHER);
     return amount.u.ether;
 }
 
 extern BREthereumTokenQuantity
-amountGetTokenQuantity (BREthereumAmount amount) {
+ethAmountGetTokenQuantity (BREthereumAmount amount) {
     assert (amount.type == AMOUNT_TOKEN);
     return amount.u.tokenQuantity;
 }
 
 extern BREthereumToken
-amountGetToken (BREthereumAmount amount) {
+ethAmountGetToken (BREthereumAmount amount) {
     assert (amount.type == AMOUNT_TOKEN);
     return amount.u.tokenQuantity.token;
 }
 
 extern BREthereumComparison
-amountCompare (BREthereumAmount a1, BREthereumAmount a2, int *typeMismatch) {
+ethAmountCompare (BREthereumAmount a1, BREthereumAmount a2, int *typeMismatch) {
     assert (NULL != typeMismatch);
     *typeMismatch = (a1.type != a2.type);
     if (*typeMismatch) return ETHEREUM_COMPARISON_GT;
@@ -70,7 +70,7 @@ amountCompare (BREthereumAmount a1, BREthereumAmount a2, int *typeMismatch) {
 }
 
 extern BREthereumGas
-amountGetGasEstimate (BREthereumAmount amount) {
+ethAmountGetGasEstimate (BREthereumAmount amount) {
     switch (amount.type) {
         case AMOUNT_ETHER:
             return ethGasCreate (DEFAULT_ETHER_GAS_LIMIT);
@@ -80,7 +80,7 @@ amountGetGasEstimate (BREthereumAmount amount) {
 }
 
 extern BRRlpItem
-amountRlpEncode(BREthereumAmount amount, BRRlpCoder coder) {
+ethAmountRlpEncode(BREthereumAmount amount, BRRlpCoder coder) {
     switch (amount.type) {
         case AMOUNT_ETHER:
             return etherRlpEncode(amount.u.ether, coder);
@@ -92,20 +92,20 @@ amountRlpEncode(BREthereumAmount amount, BRRlpCoder coder) {
 }
 
 extern BREthereumAmount
-amountRlpDecodeAsEther (BRRlpItem item, BRRlpCoder coder) {
-    return amountCreateEther(etherRlpDecode(item, coder));
+ethAmountRlpDecodeAsEther (BRRlpItem item, BRRlpCoder coder) {
+    return ethAmountCreateEther(etherRlpDecode(item, coder));
 }
 
 extern BREthereumAmount
-amountRlpDecodeAsToken (BRRlpItem item, BRRlpCoder coder, BREthereumToken token) {
-    return amountCreateToken(ethTokenQuantityCreate(token, rlpDecodeUInt256(coder, item, 1)));
+ethAmountRlpDecodeAsToken (BRRlpItem item, BRRlpCoder coder, BREthereumToken token) {
+    return ethAmountCreateToken(ethTokenQuantityCreate(token, rlpDecodeUInt256(coder, item, 1)));
 }
- 
+
 //
 // Parse
 //
 extern BREthereumAmount
-amountCreateEtherString (const char *number, BREthereumEtherUnit unit, BRCoreParseStatus *status) {
+ethAmountCreateEtherString (const char *number, BREthereumEtherUnit unit, BRCoreParseStatus *status) {
     BREthereumAmount amount;
     amount.type = AMOUNT_ETHER;
     amount.u.ether = etherCreateString(number, unit, status);
@@ -113,7 +113,7 @@ amountCreateEtherString (const char *number, BREthereumEtherUnit unit, BRCorePar
 }
 
 extern BREthereumAmount
-amountCreateTokenQuantityString (BREthereumToken token, const char *number, BREthereumTokenQuantityUnit unit, BRCoreParseStatus *status) {
+ethAmountCreateTokenQuantityString (BREthereumToken token, const char *number, BREthereumTokenQuantityUnit unit, BRCoreParseStatus *status) {
     BREthereumAmount amount;
     amount.type = AMOUNT_TOKEN;
     amount.u.tokenQuantity = ethTokenQuantityCreateString(token, number, unit, status);

--- a/ethereum/ewm/BREthereumAmount.c
+++ b/ethereum/ewm/BREthereumAmount.c
@@ -73,7 +73,7 @@ extern BREthereumGas
 amountGetGasEstimate (BREthereumAmount amount) {
     switch (amount.type) {
         case AMOUNT_ETHER:
-            return gasCreate (DEFAULT_ETHER_GAS_LIMIT);
+            return ethGasCreate (DEFAULT_ETHER_GAS_LIMIT);
         case AMOUNT_TOKEN:
             return tokenGetGasLimit (amount.u.tokenQuantity.token);
     }

--- a/ethereum/ewm/BREthereumAmount.h
+++ b/ethereum/ewm/BREthereumAmount.h
@@ -30,56 +30,55 @@ typedef enum {
  * An Ethereum Wallet holds a specific amount of ETHER or TOKENs
  */
 typedef struct BREthereumAmountRecord {
-  BREthereumAmountType type;
-  union {
-    BREthereumEther ether;
-    BREthereumTokenQuantity tokenQuantity;
-  } u;
+    BREthereumAmountType type;
+    union {
+        BREthereumEther ether;
+        BREthereumTokenQuantity tokenQuantity;
+    } u;
 } BREthereumAmount;
 
 extern BREthereumAmount
-amountCreateEther (BREthereumEther ether);
+ethAmountCreateEther (BREthereumEther ether);
 
-// TODO: what is 'scale' - replace with 'decimals'?
 extern BREthereumAmount
-amountCreateToken (BREthereumTokenQuantity tokenQuantity);
+ethAmountCreateToken (BREthereumTokenQuantity tokenQuantity);
 
 extern BREthereumAmountType
-amountGetType (BREthereumAmount amount);
+ethAmountGetType (BREthereumAmount amount);
 
 /**
  * The amount's ether if holding ETHER; otherwise fatal.
  */
 extern BREthereumEther
-amountGetEther (BREthereumAmount amount);
+ethAmountGetEther (BREthereumAmount amount);
 
 /**
  * The amount's tokenQuantity if holding TOKEN; otherwise fatal.
  */
 extern BREthereumTokenQuantity
-amountGetTokenQuantity (BREthereumAmount amount);
+ethAmountGetTokenQuantity (BREthereumAmount amount);
 
 extern BREthereumToken
-amountGetToken (BREthereumAmount amount);
-    
+ethAmountGetToken (BREthereumAmount amount);
+
 extern BREthereumComparison
-amountCompare (BREthereumAmount a1, BREthereumAmount a2, int *typeMismatch);
+ethAmountCompare (BREthereumAmount a1, BREthereumAmount a2, int *typeMismatch);
 
 /**
  * An estimate of the Gas required to transfer amount.  For ETHER this is 'fixed' as 22000; for
  * TOKEN this is derived from the token's properties.
  */
 extern BREthereumGas
-amountGetGasEstimate (BREthereumAmount amount);
+ethAmountGetGasEstimate (BREthereumAmount amount);
 
 extern BRRlpItem
-amountRlpEncode(BREthereumAmount amount, BRRlpCoder coder);
+ethAmountRlpEncode(BREthereumAmount amount, BRRlpCoder coder);
 
 extern BREthereumAmount
-amountRlpDecodeAsEther (BRRlpItem item, BRRlpCoder coder);
+ethAmountRlpDecodeAsEther (BRRlpItem item, BRRlpCoder coder);
 
 extern BREthereumAmount
-amountRlpDecodeAsToken (BRRlpItem item, BRRlpCoder coder, BREthereumToken token);
+ethAmountRlpDecodeAsToken (BRRlpItem item, BRRlpCoder coder, BREthereumToken token);
 
 //
 // Parsing
@@ -104,9 +103,9 @@ amountRlpDecodeAsToken (BRRlpItem item, BRRlpCoder coder, BREthereumToken token)
  *
  */
 extern BREthereumAmount
-amountCreateEtherString (const char *number,
-                          BREthereumEtherUnit unit,
-                          BRCoreParseStatus *status);
+ethAmountCreateEtherString (const char *number,
+                            BREthereumEtherUnit unit,
+                            BRCoreParseStatus *status);
 
 /**
  *
@@ -127,10 +126,10 @@ amountCreateEtherString (const char *number,
  *
  */
 extern BREthereumAmount
-amountCreateTokenQuantityString (BREthereumToken token,
-                                const char *number,
-                                 BREthereumTokenQuantityUnit unit,
-                                 BRCoreParseStatus *status);
+ethAmountCreateTokenQuantityString (BREthereumToken token,
+                                    const char *number,
+                                    BREthereumTokenQuantityUnit unit,
+                                    BRCoreParseStatus *status);
 
 #ifdef __cplusplus
 }

--- a/ethereum/ewm/BREthereumClient.h
+++ b/ethereum/ewm/BREthereumClient.h
@@ -308,9 +308,9 @@ extern "C" {
 #define WALLET_NUMBER_OF_EVENT_TYPES  (1 + WALLET_EVENT_DELETED)
 
     extern BREthereumWalletEvent
-    walletEventCreateError (BREthereumWalletEventType type,
-                            BREthereumStatus status,
-                            const char *errorDescription);
+    ethWalletEventCreateError (BREthereumWalletEventType type,
+                               BREthereumStatus status,
+                               const char *errorDescription);
     
     typedef void (*BREthereumClientHandlerWalletEvent) (BREthereumClientContext context,
                                                         BREthereumEWM ewm,
@@ -366,9 +366,9 @@ extern "C" {
     } BREthereumTransferEvent;
 
     extern BREthereumTransferEvent
-    transferEventCreateError (BREthereumTransferEventType type,
-                              BREthereumStatus status,
-                              const char *errorDescription);
+    ethTransferEventCreateError (BREthereumTransferEventType type,
+                                 BREthereumStatus status,
+                                 const char *errorDescription);
 
     typedef void (*BREthereumClientHandlerTransferEvent) (BREthereumClientContext context,
                                                           BREthereumEWM ewm,

--- a/ethereum/ewm/BREthereumEWM.c
+++ b/ethereum/ewm/BREthereumEWM.c
@@ -290,7 +290,7 @@ ewmCreate (BREthereumNetwork network,
 
     // The file service.  Initialize {nodes, blocks, transactions and logs} from the FileService
 
-    ewm->fs = fileServiceCreateFromTypeSpecfications (storagePath, "eth", networkGetName(network),
+    ewm->fs = fileServiceCreateFromTypeSpecfications (storagePath, "eth", ethNetworkGetName (network),
                                                       ewm,
                                                       ewmFileServiceErrorHandler,
                                                       ewmFileServiceSpecificationsCount,
@@ -1097,7 +1097,7 @@ ewmUpdateMode (BREthereumEWM ewm,
 extern void
 ewmWipe (BREthereumNetwork network,
          const char *storagePath) {
-    fileServiceWipe (storagePath, "eth", networkGetName(network));
+    fileServiceWipe (storagePath, "eth", ethNetworkGetName (network));
 }
 
 /// MARK: - Blocks

--- a/ethereum/ewm/BREthereumEWM.c
+++ b/ethereum/ewm/BREthereumEWM.c
@@ -1782,7 +1782,7 @@ ewmHandleTransactionOriginatingLog (BREthereumEWM ewm,
             // If this transaction is the transfer's originatingTransaction, then update the
             // originatingTransaction's status.
             BREthereumTransaction original = transferGetOriginatingTransaction (transfer);
-            if (NULL != original && ETHEREUM_BOOLEAN_IS_TRUE(hashEqual (transactionGetHash(original),
+            if (NULL != original && ETHEREUM_BOOLEAN_IS_TRUE(ethHashEqual (transactionGetHash(original),
                                                                         transactionGetHash(transaction))))
             transactionSetStatus (original, transactionGetStatus(transaction));
 
@@ -1832,7 +1832,7 @@ ewmHandleLogFeeBasis (BREthereumEWM ewm,
                 if (NULL != log) {
                     BREthereumHash transactionHash;
                     if (ETHEREUM_BOOLEAN_TRUE == logExtractIdentifier (log, &transactionHash, NULL) &&
-                        ETHEREUM_BOOLEAN_TRUE == hashEqual (transactionHash, hash))
+                        ETHEREUM_BOOLEAN_TRUE == ethHashEqual (transactionHash, hash))
                         ewmHandleLogFeeBasis (ewm, hash, transferTransaction, transferLog);
                 }
             }
@@ -1897,7 +1897,7 @@ ewmHandleTransaction (BREthereumEWM ewm,
         // If this transaction is the transfer's originatingTransaction, then update the
         // originatingTransaction's status.
         BREthereumTransaction original = transferGetOriginatingTransaction (transfer);
-        if (NULL != original && ETHEREUM_BOOLEAN_IS_TRUE(hashEqual (transactionGetHash(original),
+        if (NULL != original && ETHEREUM_BOOLEAN_IS_TRUE(ethHashEqual (transactionGetHash(original),
                                                                     transactionGetHash(transaction))))
             transactionSetStatus (original, transactionGetStatus(transaction));
 
@@ -1906,7 +1906,7 @@ ewmHandleTransaction (BREthereumEWM ewm,
 
     if (needStatusEvent) {
         BREthereumHashString hashString;
-        hashFillString(hash, hashString);
+        ethHashFillString(hash, hashString);
         eth_log ("EWM", "Transaction: \"%s\", Change: %s, Status: %d", hashString,
                  BCS_CALLBACK_TRANSACTION_TYPE_NAME(type),
                  transactionGetStatus(transaction).type);
@@ -1981,10 +1981,10 @@ ewmHandleLog (BREthereumEWM ewm,
 
     if (needStatusEvent) {
         BREthereumHashString logHashString;
-        hashFillString(logHash, logHashString);
+        ethHashFillString(logHash, logHashString);
 
         BREthereumHashString transactionHashString;
-        hashFillString(transactionHash, transactionHashString);
+        ethHashFillString(transactionHash, transactionHashString);
 
         eth_log ("EWM", "Log: %s { %8s @ %zu }, Change: %s, Status: %d",
                  logHashString, transactionHashString, logIndex,
@@ -2027,7 +2027,7 @@ ewmHandleSaveTransaction (BREthereumEWM ewm,
                           BREthereumClientChangeType type) {
     BREthereumHash hash = transactionGetHash(transaction);
     BREthereumHashString fileName;
-    hashFillString(hash, fileName);
+    ethHashFillString(hash, fileName);
 
     eth_log("EWM", "Transaction: Save: %s: %s",
             CLIENT_CHANGE_TYPE_NAME (type),
@@ -2047,7 +2047,7 @@ ewmHandleSaveLog (BREthereumEWM ewm,
                   BREthereumClientChangeType type) {
     BREthereumHash hash = logGetHash(log);
     BREthereumHashString filename;
-    hashFillString(hash, filename);
+    ethHashFillString(hash, filename);
 
     eth_log("EWM", "Log: Save: %s: %s",
             CLIENT_CHANGE_TYPE_NAME (type),
@@ -2076,7 +2076,7 @@ ewmHandleSaveWallet (BREthereumEWM ewm,
 
     BREthereumHash hash = walletStateGetHash(state);
     BREthereumHashString filename;
-    hashFillString(hash, filename);
+    ethHashFillString(hash, filename);
 
     eth_log ("EWM", "Wallet: Save: %s: %s",
              CLIENT_CHANGE_TYPE_NAME (type),
@@ -2608,7 +2608,7 @@ ewmTransferGetBlockHash(BREthereumEWM ewm,
     BREthereumHash blockHash;
     return (transferExtractStatusIncluded(transfer, &blockHash, NULL, NULL, NULL, NULL)
             ? blockHash
-            : hashCreateEmpty());
+            : ethHashCreateEmpty());
 }
 
 extern uint64_t

--- a/ethereum/ewm/BREthereumEWM.c
+++ b/ethereum/ewm/BREthereumEWM.c
@@ -358,7 +358,7 @@ ewmCreate (BREthereumNetwork network,
 
          // Get the balance
         BREthereumAmount balance = (NULL == token
-                                    ? ethAmountCreateEther (etherCreate (walletStateGetAmount (state)))
+                                    ? ethAmountCreateEther (ethEtherCreate (walletStateGetAmount (state)))
                                     : ethAmountCreateToken (ethTokenQuantityCreate (token, walletStateGetAmount (state))));
 
         // Finally, update the balance; this will create TOK wallets as required.
@@ -1335,14 +1335,14 @@ ewmWalletCreateTransferToCancel(BREthereumEWM ewm,
 
     int overflow;
     BREthereumEther oldGasPrice = transactionGetGasPrice(oldTransaction).etherPerGas;
-    BREthereumEther newGasPrice = etherAdd (oldGasPrice, oldGasPrice, &overflow);
+    BREthereumEther newGasPrice = ethEtherAdd (oldGasPrice, oldGasPrice, &overflow);
 
     // Create a new transaction with: a) targetAddress to self (sourceAddress), b) 0 ETH, c)
     // gasPrice increased (to replacement value).
     BREthereumTransaction transaction =
     transactionCreate (transactionGetSourceAddress(oldTransaction),
                        transactionGetSourceAddress(oldTransaction),
-                       etherCreateZero(),
+                       ethEtherCreateZero(),
                        ethGasPriceCreate(newGasPrice),
                        transactionGetGasLimit(oldTransaction),
                        transactionGetData(oldTransaction),
@@ -1404,7 +1404,7 @@ ewmWalletCreateTransferToReplace (BREthereumEWM ewm,
 
     BREthereumGasPrice gasPrice = transactionGetGasPrice(oldTransaction);
     if (ETHEREUM_BOOLEAN_IS_TRUE (updateGasPrice)) {
-        gasPrice = ethGasPriceCreate (etherAdd (gasPrice.etherPerGas, gasPrice.etherPerGas, &overflow)); // double
+        gasPrice = ethGasPriceCreate (ethEtherAdd (gasPrice.etherPerGas, gasPrice.etherPerGas, &overflow)); // double
         assert (0 == overflow);
     }
 
@@ -1709,7 +1709,7 @@ ewmHandleBalance (BREthereumEWM ewm,
 
         {
             char *amountAsString = (AMOUNT_ETHER == ethAmountGetType(amount)
-                                    ? etherGetValueString (ethAmountGetEther(amount), WEI)
+                                    ? ethEtherGetValueString (ethAmountGetEther(amount), WEI)
                                     : ethTokenQuantityGetValueString (ethAmountGetTokenQuantity(amount), TOKEN_QUANTITY_TYPE_INTEGER));
             eth_log("EWM", "Balance: %s %s (%s)", amountAsString,
                     (AMOUNT_ETHER == ethAmountGetType(amount) ? "ETH" : ethTokenGetName(ethAmountGetToken(amount))),
@@ -2534,7 +2534,7 @@ ewmTransferGetAmountEther(BREthereumEWM ewm,
                           BREthereumEtherUnit unit) {
     BREthereumAmount amount = transferGetAmount(transfer);
     return (AMOUNT_ETHER == ethAmountGetType(amount)
-            ? etherGetValueString(ethAmountGetEther(amount), unit)
+            ? ethEtherGetValueString(ethAmountGetEther(amount), unit)
             : "");
 }
 
@@ -2740,14 +2740,14 @@ ewmCreateEtherAmountString(BREthereumEWM ewm,
                            const char *number,
                            BREthereumEtherUnit unit,
                            BRCoreParseStatus *status) {
-    return ethAmountCreateEther (etherCreateString(number, unit, status));
+    return ethAmountCreateEther (ethEtherCreateString(number, unit, status));
 }
 
 extern BREthereumAmount
 ewmCreateEtherAmountUnit(BREthereumEWM ewm,
                          uint64_t amountInUnit,
                          BREthereumEtherUnit unit) {
-    return ethAmountCreateEther (etherCreateNumber(amountInUnit, unit));
+    return ethAmountCreateEther (ethEtherCreateNumber(amountInUnit, unit));
 }
 
 extern BREthereumAmount
@@ -2763,7 +2763,7 @@ extern char *
 ewmCoerceEtherAmountToString(BREthereumEWM ewm,
                              BREthereumEther ether,
                              BREthereumEtherUnit unit) {
-    return etherGetValueString(ether, unit);
+    return ethEtherGetValueString(ether, unit);
 }
 
 extern char *
@@ -2778,7 +2778,7 @@ ewmCoerceTokenAmountToString(BREthereumEWM ewm,
 extern BREthereumGasPrice
 ewmCreateGasPrice (uint64_t value,
                    BREthereumEtherUnit unit) {
-    return ethGasPriceCreate(etherCreateNumber(value, unit));
+    return ethGasPriceCreate(ethEtherCreateNumber(value, unit));
 }
 
 extern BREthereumGas

--- a/ethereum/ewm/BREthereumEWM.c
+++ b/ethereum/ewm/BREthereumEWM.c
@@ -1750,7 +1750,7 @@ ewmReportTransferStatusAsEvent (BREthereumEWM ewm,
         char *reason = NULL;
         transferExtractStatusError (transfer, &reason);
         ewmSignalTransferEvent (ewm, wallet, transfer,
-                                transferEventCreateError (TRANSFER_EVENT_ERRORED,
+                                ethTransferEventCreateError (TRANSFER_EVENT_ERRORED,
                                                           ERROR_TRANSACTION_SUBMISSION,
                                                           reason));
 
@@ -2168,13 +2168,13 @@ ewmUpdateWalletBalance(BREthereumEWM ewm,
 
     if (NULL == wallet) {
         ewmSignalWalletEvent (ewm, wallet,
-                              walletEventCreateError (WALLET_EVENT_BALANCE_UPDATED,
+                              ethWalletEventCreateError (WALLET_EVENT_BALANCE_UPDATED,
                                                       ERROR_UNKNOWN_WALLET,
                                                       NULL));
 
     } else if (ETHEREUM_BOOLEAN_IS_FALSE(ewmIsConnected(ewm))) {
         ewmSignalWalletEvent(ewm, wallet,
-                             walletEventCreateError (WALLET_EVENT_BALANCE_UPDATED,
+                             ethWalletEventCreateError (WALLET_EVENT_BALANCE_UPDATED,
                                                      ERROR_NODE_NOT_CONNECTED,
                                                      NULL));
     } else {

--- a/ethereum/ewm/BREthereumEWM.c
+++ b/ethereum/ewm/BREthereumEWM.c
@@ -2468,12 +2468,12 @@ ewmTransferFillRawData (BREthereumEWM ewm,
                                            ? RLP_TYPE_TRANSACTION_SIGNED
                                            : RLP_TYPE_TRANSACTION_UNSIGNED),
                                           ewm->coder);
-    BRRlpData data = rlpGetData (ewm->coder, item);
+    BRRlpData data = rlpItemGetData (ewm->coder, item);
 
     *bytesCountPtr = data.bytesCount;
     *bytesPtr = data.bytes;
 
-    rlpReleaseItem(ewm->coder, item);
+    rlpItemRelease(ewm->coder, item);
 }
 
 extern const char *

--- a/ethereum/ewm/BREthereumEWM.c
+++ b/ethereum/ewm/BREthereumEWM.c
@@ -2558,13 +2558,13 @@ extern BREthereumGasPrice
 ewmTransferGetGasPrice(BREthereumEWM ewm,
                        BREthereumTransfer transfer,
                        BREthereumEtherUnit unit) {
-    return feeBasisGetGasPrice (transferGetFeeBasis(transfer));
+    return ethFeeBasisGetGasPrice (transferGetFeeBasis(transfer));
 }
 
 extern BREthereumGas
 ewmTransferGetGasLimit(BREthereumEWM ewm,
                        BREthereumTransfer transfer) {
-    return feeBasisGetGasLimit(transferGetFeeBasis(transfer));
+    return ethFeeBasisGetGasLimit(transferGetFeeBasis(transfer));
 }
 
 extern BREthereumFeeBasis

--- a/ethereum/ewm/BREthereumEWM.c
+++ b/ethereum/ewm/BREthereumEWM.c
@@ -1343,7 +1343,7 @@ ewmWalletCreateTransferToCancel(BREthereumEWM ewm,
     transactionCreate (transactionGetSourceAddress(oldTransaction),
                        transactionGetSourceAddress(oldTransaction),
                        etherCreateZero(),
-                       gasPriceCreate(newGasPrice),
+                       ethGasPriceCreate(newGasPrice),
                        transactionGetGasLimit(oldTransaction),
                        transactionGetData(oldTransaction),
                        transactionGetNonce(oldTransaction));
@@ -1404,13 +1404,13 @@ ewmWalletCreateTransferToReplace (BREthereumEWM ewm,
 
     BREthereumGasPrice gasPrice = transactionGetGasPrice(oldTransaction);
     if (ETHEREUM_BOOLEAN_IS_TRUE (updateGasPrice)) {
-        gasPrice = gasPriceCreate (etherAdd (gasPrice.etherPerGas, gasPrice.etherPerGas, &overflow)); // double
+        gasPrice = ethGasPriceCreate (etherAdd (gasPrice.etherPerGas, gasPrice.etherPerGas, &overflow)); // double
         assert (0 == overflow);
     }
 
     BREthereumGas gasLimit = transactionGetGasLimit (oldTransaction);
     if (ETHEREUM_BOOLEAN_IS_TRUE (updateGasLimit))
-        gasLimit = gasCreate (gasLimit.amountOfGas + gasLimit.amountOfGas); // double
+        gasLimit = ethGasCreate (gasLimit.amountOfGas + gasLimit.amountOfGas); // double
 
     BREthereumTransaction transaction =
     transactionCreate (transactionGetSourceAddress(oldTransaction),
@@ -2645,7 +2645,7 @@ ewmTransferGetGasUsed(BREthereumEWM ewm,
     BREthereumGas gasUsed;
     return (transferExtractStatusIncluded(transfer, NULL, NULL, NULL, NULL, &gasUsed)
             ? gasUsed
-            : gasCreate(0));
+            : ethGasCreate(0));
 }
 
 extern uint64_t
@@ -2778,12 +2778,12 @@ ewmCoerceTokenAmountToString(BREthereumEWM ewm,
 extern BREthereumGasPrice
 ewmCreateGasPrice (uint64_t value,
                    BREthereumEtherUnit unit) {
-    return gasPriceCreate(etherCreateNumber(value, unit));
+    return ethGasPriceCreate(etherCreateNumber(value, unit));
 }
 
 extern BREthereumGas
 ewmCreateGas (uint64_t value) {
-    return gasCreate(value);
+    return ethGasCreate(value);
 }
 
 extern void

--- a/ethereum/ewm/BREthereumEWM.c
+++ b/ethereum/ewm/BREthereumEWM.c
@@ -358,8 +358,8 @@ ewmCreate (BREthereumNetwork network,
 
          // Get the balance
         BREthereumAmount balance = (NULL == token
-                                    ? amountCreateEther (etherCreate (walletStateGetAmount (state)))
-                                    : amountCreateToken (ethTokenQuantityCreate (token, walletStateGetAmount (state))));
+                                    ? ethAmountCreateEther (etherCreate (walletStateGetAmount (state)))
+                                    : ethAmountCreateToken (ethTokenQuantityCreate (token, walletStateGetAmount (state))));
 
         // Finally, update the balance; this will create TOK wallets as required.
         ewmHandleBalance (ewm, balance);
@@ -1686,19 +1686,19 @@ ewmHandleAccountState (BREthereumEWM ewm,
                        BREthereumAccountState accountState) {
     eth_log("EWM", "AccountState: Nonce: %" PRIu64, accountState.nonce);
     ewmHandleAnnounceNonce (ewm, ethAccountGetPrimaryAddress(ewm->account), accountState.nonce, 0);
-    ewmSignalBalance(ewm, amountCreateEther(accountState.balance));
+    ewmSignalBalance(ewm, ethAmountCreateEther(accountState.balance));
 }
 
 extern void
 ewmHandleBalance (BREthereumEWM ewm,
                   BREthereumAmount amount) {
-    BREthereumWallet wallet = (AMOUNT_ETHER == amountGetType(amount)
+    BREthereumWallet wallet = (AMOUNT_ETHER == ethAmountGetType(amount)
                                ? ewmGetWallet(ewm)
-                               : ewmGetWalletHoldingToken(ewm, amountGetToken (amount)));
+                               : ewmGetWalletHoldingToken(ewm, ethAmountGetToken (amount)));
 
     int amountTypeMismatch;
 
-    if (ETHEREUM_COMPARISON_EQ != amountCompare(amount, walletGetBalance(wallet), &amountTypeMismatch)) {
+    if (ETHEREUM_COMPARISON_EQ != ethAmountCompare(amount, walletGetBalance(wallet), &amountTypeMismatch)) {
         walletSetBalance(wallet, amount);
         ewmSignalWalletEvent (ewm,
                               wallet,
@@ -1708,12 +1708,12 @@ ewmHandleBalance (BREthereumEWM ewm,
                               });
 
         {
-            char *amountAsString = (AMOUNT_ETHER == amountGetType(amount)
-                                    ? etherGetValueString (amountGetEther(amount), WEI)
-                                    : ethTokenQuantityGetValueString (amountGetTokenQuantity(amount), TOKEN_QUANTITY_TYPE_INTEGER));
+            char *amountAsString = (AMOUNT_ETHER == ethAmountGetType(amount)
+                                    ? etherGetValueString (ethAmountGetEther(amount), WEI)
+                                    : ethTokenQuantityGetValueString (ethAmountGetTokenQuantity(amount), TOKEN_QUANTITY_TYPE_INTEGER));
             eth_log("EWM", "Balance: %s %s (%s)", amountAsString,
-                    (AMOUNT_ETHER == amountGetType(amount) ? "ETH" : ethTokenGetName(amountGetToken(amount))),
-                    (AMOUNT_ETHER == amountGetType(amount) ? "WEI"    : "INTEGER"));
+                    (AMOUNT_ETHER == ethAmountGetType(amount) ? "ETH" : ethTokenGetName(ethAmountGetToken(amount))),
+                    (AMOUNT_ETHER == ethAmountGetType(amount) ? "WEI"    : "INTEGER"));
             free (amountAsString);
         }
     }
@@ -2533,8 +2533,8 @@ ewmTransferGetAmountEther(BREthereumEWM ewm,
                           BREthereumTransfer transfer,
                           BREthereumEtherUnit unit) {
     BREthereumAmount amount = transferGetAmount(transfer);
-    return (AMOUNT_ETHER == amountGetType(amount)
-            ? etherGetValueString(amountGetEther(amount), unit)
+    return (AMOUNT_ETHER == ethAmountGetType(amount)
+            ? etherGetValueString(ethAmountGetEther(amount), unit)
             : "");
 }
 
@@ -2543,8 +2543,8 @@ ewmTransferGetAmountTokenQuantity(BREthereumEWM ewm,
                                   BREthereumTransfer transfer,
                                   BREthereumTokenQuantityUnit unit) {
     BREthereumAmount amount = transferGetAmount(transfer);
-    return (AMOUNT_TOKEN == amountGetType(amount)
-            ? ethTokenQuantityGetValueString(amountGetTokenQuantity(amount), unit)
+    return (AMOUNT_TOKEN == ethAmountGetType(amount)
+            ? ethTokenQuantityGetValueString(ethAmountGetTokenQuantity(amount), unit)
             : "");
 }
 
@@ -2740,14 +2740,14 @@ ewmCreateEtherAmountString(BREthereumEWM ewm,
                            const char *number,
                            BREthereumEtherUnit unit,
                            BRCoreParseStatus *status) {
-    return amountCreateEther (etherCreateString(number, unit, status));
+    return ethAmountCreateEther (etherCreateString(number, unit, status));
 }
 
 extern BREthereumAmount
 ewmCreateEtherAmountUnit(BREthereumEWM ewm,
                          uint64_t amountInUnit,
                          BREthereumEtherUnit unit) {
-    return amountCreateEther (etherCreateNumber(amountInUnit, unit));
+    return ethAmountCreateEther (etherCreateNumber(amountInUnit, unit));
 }
 
 extern BREthereumAmount
@@ -2756,7 +2756,7 @@ ewmCreateTokenAmountString(BREthereumEWM ewm,
                            const char *number,
                            BREthereumTokenQuantityUnit unit,
                            BRCoreParseStatus *status) {
-    return amountCreateTokenQuantityString(token, number, unit, status);
+    return ethAmountCreateTokenQuantityString(token, number, unit, status);
 }
 
 extern char *

--- a/ethereum/ewm/BREthereumEWMClient.c
+++ b/ethereum/ewm/BREthereumEWMClient.c
@@ -519,8 +519,8 @@ ewmHandleAnnounceLog (BREthereumEWM ewm,
             BREthereumLog log = logCreate(bundle->contract,
                                           bundle->topicCount,
                                           topics,
-                                          rlpGetDataSharedDontRelease(ewm->coder, item));
-            rlpReleaseItem (ewm->coder, item);
+                                          rlpItemGetDataSharedDontRelease(ewm->coder, item));
+            rlpItemRelease (ewm->coder, item);
 
             // Given {hash,logIndex}, initialize the log's identifier
             assert (bundle->logIndex <= (uint64_t) SIZE_MAX);

--- a/ethereum/ewm/BREthereumEWMClient.c
+++ b/ethereum/ewm/BREthereumEWMClient.c
@@ -359,12 +359,12 @@ ewmHandleAnnounceNonce (BREthereumEWM ewm,
                         uint64_t newNonce,
                         int rid) {
     pthread_mutex_lock (&ewm->lock);
-    uint64_t oldNonce = accountGetAddressNonce (ewm->account, address);
+    uint64_t oldNonce = ethAccountGetAddressNonce (ewm->account, address);
     if (oldNonce != newNonce) {
         // This may not change the nonce
-        accountSetAddressNonce (ewm->account, address, newNonce, ETHEREUM_BOOLEAN_FALSE);
+        ethAccountSetAddressNonce (ewm->account, address, newNonce, ETHEREUM_BOOLEAN_FALSE);
         // Only save the primaryWallet if the nonce has, in fact, changed.
-        if (oldNonce != accountGetAddressNonce (ewm->account, address))
+        if (oldNonce != ethAccountGetAddressNonce (ewm->account, address))
             ewmHandleSaveWallet (ewm, ewmGetWallet(ewm), CLIENT_CHANGE_UPD);
     }
     pthread_mutex_unlock (&ewm->lock);

--- a/ethereum/ewm/BREthereumEWMClient.c
+++ b/ethereum/ewm/BREthereumEWMClient.c
@@ -157,7 +157,7 @@ ewmHandleAnnounceGasPrice (BREthereumEWM ewm,
                            BREthereumWallet wallet,
                            UInt256 amount,
                            int rid) {
-    ewmSignalGasPrice(ewm, wallet, gasPriceCreate(etherCreate(amount)));
+    ewmSignalGasPrice(ewm, wallet, ethGasPriceCreate(etherCreate(amount)));
 }
 
 extern BREthereumStatus
@@ -254,7 +254,7 @@ ewmAnnounceGasEstimateSuccess (BREthereumEWM ewm,
         ewmSignalGasEstimateFailure(ewm, wallet, cookie, ERROR_NUMERIC_PARSE);
 
     } else {
-        ewmSignalGasEstimateSuccess(ewm, wallet, cookie, gasCreate(estimate.u64[0]), gasPriceCreate(etherCreate(price)));
+        ewmSignalGasEstimateSuccess(ewm, wallet, cookie, ethGasCreate(estimate.u64[0]), ethGasPriceCreate(etherCreate(price)));
     }
 
     return SUCCESS;
@@ -392,8 +392,8 @@ ewmHandleAnnounceTransaction (BREthereumEWM ewm,
             BREthereumTransaction transaction = transactionCreate (bundle->from,
                                                                    bundle->to,
                                                                    etherCreate(bundle->amount),
-                                                                   gasPriceCreate(etherCreate(bundle->gasPrice)),
-                                                                   gasCreate(bundle->gasLimit),
+                                                                   ethGasPriceCreate(etherCreate(bundle->gasPrice)),
+                                                                   ethGasCreate(bundle->gasLimit),
                                                                    bundle->data,
                                                                    bundle->nonce);
 
@@ -409,7 +409,7 @@ ewmHandleAnnounceTransaction (BREthereumEWM ewm,
                                                                                   bundle->blockNumber,
                                                                                   bundle->blockTransactionIndex,
                                                                                   bundle->blockTimestamp,
-                                                                                  gasCreate(bundle->gasUsed));
+                                                                                  ethGasCreate(bundle->gasUsed));
             transactionSetStatus (transaction, status);
 
             // If we had a `bcs` we might think about `bcsSignalTransaction(ewm->bcs, transaction);`
@@ -531,7 +531,7 @@ ewmHandleAnnounceLog (BREthereumEWM ewm,
                                              bundle->blockNumber,
                                              bundle->blockTransactionIndex,
                                              bundle->blockTimestamp,
-                                             gasCreate(bundle->gasUsed));
+                                             ethGasCreate(bundle->gasUsed));
             logSetStatus(log, status);
 
             // If we had a `bcs` we might think about `bcsSignalLog(ewm->bcs, log);`
@@ -861,8 +861,8 @@ ewmAnnounceToken(BREthereumEWM ewm,
     bundle->name        = strdup (name);
     bundle->description = strdup (description);
     bundle->decimals    = decimals;
-    bundle->gasLimit    = gasCreate(gasLimitValue);
-    bundle->gasPrice    = gasPriceCreate(etherCreate(gasPriceValue));
+    bundle->gasLimit    = ethGasCreate(gasLimitValue);
+    bundle->gasPrice    = ethGasPriceCreate(etherCreate(gasPriceValue));
 
     ewmSignalAnnounceToken (ewm, bundle, rid);
 }

--- a/ethereum/ewm/BREthereumEWMClient.c
+++ b/ethereum/ewm/BREthereumEWMClient.c
@@ -66,7 +66,7 @@ ewmHandleAnnounceBalance (BREthereumEWM ewm,
                           int rid) {
     BREthereumAmount amount = (AMOUNT_ETHER == walletGetAmountType(wallet)
                                ? amountCreateEther(etherCreate(value))
-                               : amountCreateToken(createTokenQuantity(walletGetToken(wallet), value)));
+                               : amountCreateToken(ethTokenQuantityCreate(walletGetToken(wallet), value)));
 
     ewmSignalBalance(ewm, amount);
 }

--- a/ethereum/ewm/BREthereumEWMClient.c
+++ b/ethereum/ewm/BREthereumEWMClient.c
@@ -80,7 +80,7 @@ ewmAnnounceWalletBalance (BREthereumEWM ewm,
 
     // Passed in `balance` can be base 10 or 16.  Let UInt256Prase decide.
     BRCoreParseStatus parseStatus;
-    UInt256 value = createUInt256Parse(balance, 0, &parseStatus);
+    UInt256 value = uint256CreateParse(balance, 0, &parseStatus);
     if (CORE_PARSE_OK != parseStatus) { return ERROR_NUMERIC_PARSE; }
 
     ewmSignalAnnounceBalance(ewm, wallet, value, rid);
@@ -168,7 +168,7 @@ ewmAnnounceGasPrice(BREthereumEWM ewm,
     if (NULL == wallet) { return ERROR_UNKNOWN_WALLET; }
 
     BRCoreParseStatus parseStatus;
-    UInt256 amount = createUInt256Parse(gasPrice, 0, &parseStatus);
+    UInt256 amount = uint256CreateParse(gasPrice, 0, &parseStatus);
     if (CORE_PARSE_OK != parseStatus) { return ERROR_NUMERIC_PARSE; }
 
     ewmSignalAnnounceGasPrice(ewm, wallet, amount, rid);
@@ -205,8 +205,8 @@ ewmGetGasEstimate (BREthereumEWM ewm,
 
                 char *from = addressGetEncodedString (transferGetEffectiveSourceAddress(transfer), 0);
                 char *to   = addressGetEncodedString (transferGetEffectiveTargetAddress(transfer), 0);
-                char *amount = coerceStringPrefaced (amountInEther.valueInWEI, 16, "0x");
-                char *price  = coerceStringPrefaced (gasPrice.etherPerGas.valueInWEI, 16, "0x");
+                char *amount = uint256CoerceStringPrefaced (amountInEther.valueInWEI, 16, "0x");
+                char *price  = uint256CoerceStringPrefaced (gasPrice.etherPerGas.valueInWEI, 16, "0x");
                 char *data = (char *) transactionGetData(transaction);
 
                 ewm->client.funcEstimateGas (ewm->client.context,
@@ -246,8 +246,8 @@ ewmAnnounceGasEstimateSuccess (BREthereumEWM ewm,
                                int rid) {
     BRCoreParseStatus estimateStatus        = CORE_PARSE_OK;
     BRCoreParseStatus priceStatus           = CORE_PARSE_OK;
-    UInt256 estimate                        = createUInt256Parse(gasEstimate, 0, &estimateStatus);
-    UInt256 price                           = createUInt256Parse(gasPrice, 0, &priceStatus);
+    UInt256 estimate                        = uint256CreateParse(gasEstimate, 0, &estimateStatus);
+    UInt256 price                           = uint256CreateParse(gasPrice, 0, &priceStatus);
 
     if (CORE_PARSE_OK != estimateStatus || 0 != estimate.u64[1] || 0 != estimate.u64[2] || 0 != estimate.u64[3] ||
         CORE_PARSE_OK != priceStatus    || 0 != price.u64[1]    || 0 != price.u64[2]    || 0 != price.u64[3]) {
@@ -459,10 +459,10 @@ ewmAnnounceTransaction(BREthereumEWM ewm,
                         ? EMPTY_ADDRESS_INIT
                         : addressCreate(contract));
 
-    bundle->amount = createUInt256Parse(strAmount, 0, &parseStatus);
+    bundle->amount = uint256CreateParse(strAmount, 0, &parseStatus);
 
     bundle->gasLimit = strtoull(strGasLimit, NULL, 0);
-    bundle->gasPrice = createUInt256Parse(strGasPrice, 0, &parseStatus);
+    bundle->gasPrice = uint256CreateParse(strGasPrice, 0, &parseStatus);
     bundle->data = strdup(data);
 
     bundle->nonce = strtoull(strNonce, NULL, 0); // TODO: Assumes `nonce` is uint64_t; which it is for now
@@ -511,7 +511,7 @@ ewmHandleAnnounceLog (BREthereumEWM ewm,
             // thing, somehow
 
             BRCoreParseStatus parseStatus = CORE_PARSE_OK;
-            UInt256 value = createUInt256Parse(bundle->data, 0, &parseStatus);
+            UInt256 value = uint256CreateParse(bundle->data, 0, &parseStatus);
             assert (CORE_PARSE_OK == parseStatus);
 
             BRRlpItem  item  = rlpEncodeUInt256 (ewm->coder, value, 1);
@@ -588,7 +588,7 @@ ewmAnnounceLog (BREthereumEWM ewm,
     for (int i = 0; i < topicCount; i++)
         bundle->arrayTopics[i] = strdup (arrayTopics[i]);
     bundle->data = strdup (strData);
-    bundle->gasPrice = createUInt256Parse(strGasPrice, 0, &parseStatus);
+    bundle->gasPrice = uint256CreateParse(strGasPrice, 0, &parseStatus);
     bundle->gasUsed = strtoull(strGasUsed, NULL, 0);
     bundle->logIndex = strtoull(strLogIndex, NULL, 0);
     bundle->blockNumber = strtoull(strBlockNumber, NULL, 0);
@@ -850,9 +850,9 @@ ewmAnnounceToken(BREthereumEWM ewm,
     BRCoreParseStatus status = CORE_PARSE_STRANGE_DIGITS;
     UInt256 gasPriceValue = UINT256_ZERO;
     if (NULL != strDefaultGasPrice)
-        gasPriceValue = createUInt256Parse(strDefaultGasPrice, 0, &status);
+        gasPriceValue = uint256CreateParse(strDefaultGasPrice, 0, &status);
     if (status != CORE_PARSE_OK)
-        gasPriceValue = createUInt256(TOKEN_BRD_DEFAULT_GAS_PRICE_IN_WEI_UINT64);
+        gasPriceValue = uint256Create(TOKEN_BRD_DEFAULT_GAS_PRICE_IN_WEI_UINT64);
 
     BREthereumEWMClientAnnounceTokenBundle *bundle = malloc(sizeof (BREthereumEWMClientAnnounceTokenBundle));
 

--- a/ethereum/ewm/BREthereumEWMClient.c
+++ b/ethereum/ewm/BREthereumEWMClient.c
@@ -763,13 +763,13 @@ extern void
 ewmUpdateTokens (BREthereumEWM ewm) {
     unsigned int rid = ++ewm->requestId;
 
-    if (ethereumMainnet == ewm->network)
+    if (ethNetworkMainnet == ewm->network)
         ewm->client.funcGetTokens
         (ewm->client.context,
          ewm,
          rid);
 
-    else if (ethereumTestnet == ewm->network) {
+    else if (ethNetworkTestnet == ewm->network) {
         ewmAnnounceToken (ewm, rid,
                           "0x7108ca7c4718efa810457f228305c9c71390931a",
                           "BRD",
@@ -789,7 +789,7 @@ ewmUpdateTokens (BREthereumEWM ewm) {
         ewmAnnounceTokenComplete (ewm, rid, ETHEREUM_BOOLEAN_TRUE);
     }
 
-    else if (ethereumRinkeby == ewm->network)
+    else if (ethNetworkRinkeby == ewm->network)
         ewmAnnounceTokenComplete (ewm, rid, ETHEREUM_BOOLEAN_TRUE);
 
     else

--- a/ethereum/ewm/BREthereumEWMClient.c
+++ b/ethereum/ewm/BREthereumEWMClient.c
@@ -451,7 +451,7 @@ ewmAnnounceTransaction(BREthereumEWM ewm,
     BRCoreParseStatus parseStatus;
     BREthereumEWMClientAnnounceTransactionBundle *bundle = malloc(sizeof (BREthereumEWMClientAnnounceTransactionBundle));
 
-    bundle->hash = hashCreate(hashString);
+    bundle->hash = ethHashCreate(hashString);
 
     bundle->from = addressCreate(from);
     bundle->to = addressCreate(to);
@@ -469,7 +469,7 @@ ewmAnnounceTransaction(BREthereumEWM ewm,
     bundle->gasUsed = strtoull(strGasUsed, NULL, 0);
 
     bundle->blockNumber = strtoull(strBlockNumber, NULL, 0);
-    bundle->blockHash = hashCreate (strBlockHash);
+    bundle->blockHash = ethHashCreate (strBlockHash);
     bundle->blockConfirmations = strtoull(strBlockConfirmations, NULL, 0);
     bundle->blockTransactionIndex = (unsigned int) strtoul(strBlockTransactionIndex, NULL, 0);
     bundle->blockTimestamp = strtoull(strBlockTimestamp, NULL, 0);
@@ -527,7 +527,7 @@ ewmHandleAnnounceLog (BREthereumEWM ewm,
             logInitializeIdentifier(log, bundle->hash, (size_t) bundle->logIndex);
 
             BREthereumTransactionStatus status =
-            transactionStatusCreateIncluded (hashCreateEmpty(),
+            transactionStatusCreateIncluded (ethHashCreateEmpty(),
                                              bundle->blockNumber,
                                              bundle->blockTransactionIndex,
                                              bundle->blockTimestamp,
@@ -581,7 +581,7 @@ ewmAnnounceLog (BREthereumEWM ewm,
     BRCoreParseStatus parseStatus;
     BREthereumEWMClientAnnounceLogBundle *bundle = malloc(sizeof (BREthereumEWMClientAnnounceLogBundle));
 
-    bundle->hash = hashCreate(strHash);
+    bundle->hash = ethHashCreate(strHash);
     bundle->contract = addressCreate(strContract);
     bundle->topicCount = topicCount;
     bundle->arrayTopics = calloc (topicCount, sizeof (char *));
@@ -667,7 +667,7 @@ ewmWalletSubmitTransfer(BREthereumEWM ewm,
                                                      ? RLP_TYPE_TRANSACTION_SIGNED
                                                      : RLP_TYPE_TRANSACTION_UNSIGNED));
 
-            char *transactionHash = hashAsString (transactionGetHash(transaction));
+            char *transactionHash = ethHashAsString (transactionGetHash(transaction));
 
             ewm->client.funcSubmitTransaction (ewm->client.context,
                                                ewm,
@@ -744,10 +744,10 @@ ewmAnnounceSubmitTransfer (BREthereumEWM ewm,
     if (NULL == transfer) { return ERROR_UNKNOWN_TRANSACTION; }
 
     if (NULL != strHash) {
-        BREthereumHash hash = hashCreate(strHash);
+        BREthereumHash hash = ethHashCreate(strHash);
         // We announce a submitted transfer => there is an originating transaction.
-        if (ETHEREUM_BOOLEAN_IS_TRUE (hashEqual (hash, EMPTY_HASH_INIT))
-            || ETHEREUM_BOOLEAN_IS_FALSE (hashEqual (hash, ewmTransferGetOriginatingTransactionHash (ewm, transfer))))
+        if (ETHEREUM_BOOLEAN_IS_TRUE (ethHashEqual (hash, EMPTY_HASH_INIT))
+            || ETHEREUM_BOOLEAN_IS_FALSE (ethHashEqual (hash, ewmTransferGetOriginatingTransactionHash (ewm, transfer))))
             return ERROR_TRANSACTION_HASH_MISMATCH;
     }
 
@@ -946,7 +946,7 @@ ewmHandleTransferEvent (BREthereumEWM ewm,
 
         // If we have a hash, then we've got something to save.
         BREthereumHash hash = transferGetIdentifier(transfer);
-        if (ETHEREUM_BOOLEAN_IS_FALSE (hashCompare (hash, EMPTY_HASH_INIT))) {
+        if (ETHEREUM_BOOLEAN_IS_FALSE (ethHashCompare (hash, EMPTY_HASH_INIT))) {
 
             // One of `transaction` or `log` will always be null
             assert (NULL == transaction || NULL == log);

--- a/ethereum/ewm/BREthereumEWMClient.c
+++ b/ethereum/ewm/BREthereumEWMClient.c
@@ -17,7 +17,7 @@
 #include "BREthereumEWMPrivate.h"
 
 extern BREthereumWalletEvent
-walletEventCreateError (BREthereumWalletEventType type,
+ethWalletEventCreateError (BREthereumWalletEventType type,
                         BREthereumStatus status,
                         const char *errorDescription) {
     BREthereumWalletEvent event = { type, status, {}, { '\0' } };
@@ -27,7 +27,7 @@ walletEventCreateError (BREthereumWalletEventType type,
 }
 
 extern BREthereumTransferEvent
-transferEventCreateError (BREthereumTransferEventType type,
+ethTransferEventCreateError (BREthereumTransferEventType type,
                           BREthereumStatus status,
                           const char *errorDescription) {
     BREthereumTransferEvent event = { type, status, { '\0' } };
@@ -121,13 +121,13 @@ ewmUpdateGasPrice (BREthereumEWM ewm,
 
     if (NULL == wallet) {
         ewmSignalWalletEvent(ewm, wallet,
-                             walletEventCreateError (WALLET_EVENT_DEFAULT_GAS_PRICE_UPDATED,
+                             ethWalletEventCreateError (WALLET_EVENT_DEFAULT_GAS_PRICE_UPDATED,
                                                      ERROR_UNKNOWN_WALLET,
                                                      NULL));
 
     } else if (ETHEREUM_BOOLEAN_IS_FALSE(ewmIsConnected(ewm))) {
         ewmSignalWalletEvent(ewm, wallet,
-                             walletEventCreateError (WALLET_EVENT_DEFAULT_GAS_PRICE_UPDATED,
+                             ethWalletEventCreateError (WALLET_EVENT_DEFAULT_GAS_PRICE_UPDATED,
                                                      ERROR_NODE_NOT_CONNECTED,
                                                      NULL));
 

--- a/ethereum/ewm/BREthereumEWMClient.c
+++ b/ethereum/ewm/BREthereumEWMClient.c
@@ -65,7 +65,7 @@ ewmHandleAnnounceBalance (BREthereumEWM ewm,
                           UInt256 value,
                           int rid) {
     BREthereumAmount amount = (AMOUNT_ETHER == walletGetAmountType(wallet)
-                               ? ethAmountCreateEther(etherCreate(value))
+                               ? ethAmountCreateEther(ethEtherCreate(value))
                                : ethAmountCreateToken(ethTokenQuantityCreate(walletGetToken(wallet), value)));
 
     ewmSignalBalance(ewm, amount);
@@ -157,7 +157,7 @@ ewmHandleAnnounceGasPrice (BREthereumEWM ewm,
                            BREthereumWallet wallet,
                            UInt256 amount,
                            int rid) {
-    ewmSignalGasPrice(ewm, wallet, ethGasPriceCreate(etherCreate(amount)));
+    ewmSignalGasPrice(ewm, wallet, ethGasPriceCreate(ethEtherCreate(amount)));
 }
 
 extern BREthereumStatus
@@ -254,7 +254,7 @@ ewmAnnounceGasEstimateSuccess (BREthereumEWM ewm,
         ewmSignalGasEstimateFailure(ewm, wallet, cookie, ERROR_NUMERIC_PARSE);
 
     } else {
-        ewmSignalGasEstimateSuccess(ewm, wallet, cookie, ethGasCreate(estimate.u64[0]), ethGasPriceCreate(etherCreate(price)));
+        ewmSignalGasEstimateSuccess(ewm, wallet, cookie, ethGasCreate(estimate.u64[0]), ethGasPriceCreate(ethEtherCreate(price)));
     }
 
     return SUCCESS;
@@ -391,8 +391,8 @@ ewmHandleAnnounceTransaction (BREthereumEWM ewm,
             // TODO: Confirm we are not repeatedly creating transactions
             BREthereumTransaction transaction = transactionCreate (bundle->from,
                                                                    bundle->to,
-                                                                   etherCreate(bundle->amount),
-                                                                   ethGasPriceCreate(etherCreate(bundle->gasPrice)),
+                                                                   ethEtherCreate(bundle->amount),
+                                                                   ethGasPriceCreate(ethEtherCreate(bundle->gasPrice)),
                                                                    ethGasCreate(bundle->gasLimit),
                                                                    bundle->data,
                                                                    bundle->nonce);
@@ -862,7 +862,7 @@ ewmAnnounceToken(BREthereumEWM ewm,
     bundle->description = strdup (description);
     bundle->decimals    = decimals;
     bundle->gasLimit    = ethGasCreate(gasLimitValue);
-    bundle->gasPrice    = ethGasPriceCreate(etherCreate(gasPriceValue));
+    bundle->gasPrice    = ethGasPriceCreate(ethEtherCreate(gasPriceValue));
 
     ewmSignalAnnounceToken (ewm, bundle, rid);
 }

--- a/ethereum/ewm/BREthereumEWMClient.c
+++ b/ethereum/ewm/BREthereumEWMClient.c
@@ -203,8 +203,8 @@ ewmGetGasEstimate (BREthereumEWM ewm,
                 BREthereumGasPrice gasPrice = ethFeeBasisGetGasPrice (feeBasis);
                 BREthereumTransaction transaction = transferGetOriginatingTransaction(transfer);
 
-                char *from = addressGetEncodedString (transferGetEffectiveSourceAddress(transfer), 0);
-                char *to   = addressGetEncodedString (transferGetEffectiveTargetAddress(transfer), 0);
+                char *from = ethAddressGetEncodedString (transferGetEffectiveSourceAddress(transfer), 0);
+                char *to   = ethAddressGetEncodedString (transferGetEffectiveTargetAddress(transfer), 0);
                 char *amount = uint256CoerceStringPrefaced (amountInEther.valueInWEI, 16, "0x");
                 char *price  = uint256CoerceStringPrefaced (gasPrice.etherPerGas.valueInWEI, 16, "0x");
                 char *data = (char *) transactionGetData(transaction);
@@ -338,7 +338,7 @@ ewmAnnounceNonce (BREthereumEWM ewm,
                   const char *strAddress,
                   const char *strNonce,
                   int rid) {
-    BREthereumAddress address = addressCreate(strAddress);
+    BREthereumAddress address = ethAddressCreate(strAddress);
     uint64_t nonce = strtoull (strNonce, NULL, 0);
     ewmSignalAnnounceNonce(ewm, address, nonce, rid);
     return SUCCESS;
@@ -453,11 +453,11 @@ ewmAnnounceTransaction(BREthereumEWM ewm,
 
     bundle->hash = ethHashCreate(hashString);
 
-    bundle->from = addressCreate(from);
-    bundle->to = addressCreate(to);
+    bundle->from = ethAddressCreate(from);
+    bundle->to = ethAddressCreate(to);
     bundle->contract = (NULL == contract || '\0' == contract[0]
                         ? EMPTY_ADDRESS_INIT
-                        : addressCreate(contract));
+                        : ethAddressCreate(contract));
 
     bundle->amount = uint256CreateParse(strAmount, 0, &parseStatus);
 
@@ -582,7 +582,7 @@ ewmAnnounceLog (BREthereumEWM ewm,
     BREthereumEWMClientAnnounceLogBundle *bundle = malloc(sizeof (BREthereumEWMClientAnnounceLogBundle));
 
     bundle->hash = ethHashCreate(strHash);
-    bundle->contract = addressCreate(strContract);
+    bundle->contract = ethAddressCreate(strContract);
     bundle->topicCount = topicCount;
     bundle->arrayTopics = calloc (topicCount, sizeof (char *));
     for (int i = 0; i < topicCount; i++)

--- a/ethereum/ewm/BREthereumEWMClient.c
+++ b/ethereum/ewm/BREthereumEWMClient.c
@@ -65,8 +65,8 @@ ewmHandleAnnounceBalance (BREthereumEWM ewm,
                           UInt256 value,
                           int rid) {
     BREthereumAmount amount = (AMOUNT_ETHER == walletGetAmountType(wallet)
-                               ? amountCreateEther(etherCreate(value))
-                               : amountCreateToken(ethTokenQuantityCreate(walletGetToken(wallet), value)));
+                               ? ethAmountCreateEther(etherCreate(value))
+                               : ethAmountCreateToken(ethTokenQuantityCreate(walletGetToken(wallet), value)));
 
     ewmSignalBalance(ewm, amount);
 }
@@ -99,7 +99,7 @@ ewmHandleUpdateWalletBalances (BREthereumEWM ewm) {
         walletUpdateBalance (wallet);
         BREthereumAmount newBalance = walletGetBalance (wallet);
 
-        BREthereumComparison comparison = amountCompare (oldBalance, newBalance, &typeMismatch);
+        BREthereumComparison comparison = ethAmountCompare (oldBalance, newBalance, &typeMismatch);
         assert (0 == typeMismatch);
 
         if (ETHEREUM_COMPARISON_EQ != comparison)

--- a/ethereum/ewm/BREthereumEWMClient.c
+++ b/ethereum/ewm/BREthereumEWMClient.c
@@ -200,7 +200,7 @@ ewmGetGasEstimate (BREthereumEWM ewm,
                 // This will be ZERO if transaction amount is in TOKEN.
                 BREthereumEther amountInEther = transferGetEffectiveAmountInEther(transfer);
                 BREthereumFeeBasis feeBasis = transferGetFeeBasis (transfer);
-                BREthereumGasPrice gasPrice = feeBasisGetGasPrice (feeBasis);
+                BREthereumGasPrice gasPrice = ethFeeBasisGetGasPrice (feeBasis);
                 BREthereumTransaction transaction = transferGetOriginatingTransaction(transfer);
 
                 char *from = addressGetEncodedString (transferGetEffectiveSourceAddress(transfer), 0);

--- a/ethereum/ewm/BREthereumEWMPersist.c
+++ b/ethereum/ewm/BREthereumEWMPersist.c
@@ -230,7 +230,7 @@ fileServiceTypeTokenV1Identifier (BRFileServiceContext context,
                                         BRFileService fs,
                                         const void *entity) {
     BREthereumToken token = (BREthereumToken) entity;
-    BREthereumHash hash = tokenGetHash(token);
+    BREthereumHash hash = ethTokenGetHash(token);
 
     UInt256 result;
     memcpy (result.u8, hash.bytes, ETHEREUM_HASH_BYTES);
@@ -245,7 +245,7 @@ fileServiceTypeTokenV1Writer (BRFileServiceContext context,
     BREthereumEWM ewm = context;
     BREthereumToken token = (BREthereumToken) entity;
 
-    BRRlpItem item = tokenEncode(token, ewm->coder);
+    BRRlpItem item = ethTokenRlpEncode(token, ewm->coder);
     BRRlpData data = rlpItemGetData (ewm->coder, item);
     rlpItemRelease (ewm->coder, item);
 
@@ -263,7 +263,7 @@ fileServiceTypeTokenV1Reader (BRFileServiceContext context,
     BRRlpData data = { bytesCount, bytes };
     BRRlpItem item = rlpDataGetItem (ewm->coder, data);
 
-    BREthereumToken token = tokenDecode(item, ewm->coder);
+    BREthereumToken token = ethTokenRlpDecode(item, ewm->coder);
     rlpItemRelease (ewm->coder, item);
 
     return token;

--- a/ethereum/ewm/BREthereumEWMPersist.c
+++ b/ethereum/ewm/BREthereumEWMPersist.c
@@ -39,8 +39,8 @@ fileServiceTypeTransactionV1Writer (BRFileServiceContext context,
     BREthereumTransaction transaction = (BREthereumTransaction) entity;
 
     BRRlpItem item = transactionRlpEncode(transaction, ewm->network, RLP_TYPE_ARCHIVE, ewm->coder);
-    BRRlpData data = rlpGetData (ewm->coder, item);
-    rlpReleaseItem (ewm->coder, item);
+    BRRlpData data = rlpItemGetData (ewm->coder, item);
+    rlpItemRelease (ewm->coder, item);
 
     *bytesCount = (uint32_t) data.bytesCount;
     return data.bytes;
@@ -54,10 +54,10 @@ fileServiceTypeTransactionV1Reader (BRFileServiceContext context,
     BREthereumEWM ewm = context;
 
     BRRlpData data = { bytesCount, bytes };
-    BRRlpItem item = rlpGetItem (ewm->coder, data);
+    BRRlpItem item = rlpDataGetItem (ewm->coder, data);
 
     BREthereumTransaction transaction = transactionRlpDecode(item, ewm->network, RLP_TYPE_ARCHIVE, ewm->coder);
-    rlpReleaseItem (ewm->coder, item);
+    rlpItemRelease (ewm->coder, item);
 
     return transaction;
 }
@@ -91,8 +91,8 @@ fileServiceTypeLogV1Writer (BRFileServiceContext context,
     BREthereumLog log = (BREthereumLog) entity;
 
     BRRlpItem item = logRlpEncode (log, RLP_TYPE_ARCHIVE, ewm->coder);
-    BRRlpData data = rlpGetData (ewm->coder, item);
-    rlpReleaseItem (ewm->coder, item);
+    BRRlpData data = rlpItemGetData (ewm->coder, item);
+    rlpItemRelease (ewm->coder, item);
 
     *bytesCount = (uint32_t) data.bytesCount;
     return data.bytes;
@@ -106,10 +106,10 @@ fileServiceTypeLogV1Reader (BRFileServiceContext context,
     BREthereumEWM ewm = context;
 
     BRRlpData data = { bytesCount, bytes };
-    BRRlpItem item = rlpGetItem (ewm->coder, data);
+    BRRlpItem item = rlpDataGetItem (ewm->coder, data);
 
     BREthereumLog log = logRlpDecode(item, RLP_TYPE_ARCHIVE, ewm->coder);
-    rlpReleaseItem (ewm->coder, item);
+    rlpItemRelease (ewm->coder, item);
 
     return log;
 }
@@ -142,8 +142,8 @@ fileServiceTypeBlockV1Writer (BRFileServiceContext context,
     BREthereumBlock block = (BREthereumBlock) entity;
 
     BRRlpItem item = blockRlpEncode(block, ewm->network, RLP_TYPE_ARCHIVE, ewm->coder);
-    BRRlpData data = rlpGetData (ewm->coder, item);
-    rlpReleaseItem (ewm->coder, item);
+    BRRlpData data = rlpItemGetData (ewm->coder, item);
+    rlpItemRelease (ewm->coder, item);
 
     *bytesCount = (uint32_t) data.bytesCount;
     return data.bytes;
@@ -157,10 +157,10 @@ fileServiceTypeBlockV1Reader (BRFileServiceContext context,
     BREthereumEWM ewm = context;
 
     BRRlpData data = { bytesCount, bytes };
-    BRRlpItem item = rlpGetItem (ewm->coder, data);
+    BRRlpItem item = rlpDataGetItem (ewm->coder, data);
 
     BREthereumBlock block = blockRlpDecode (item, ewm->network, RLP_TYPE_ARCHIVE, ewm->coder);
-    rlpReleaseItem (ewm->coder, item);
+    rlpItemRelease (ewm->coder, item);
 
     return block;
 }
@@ -194,8 +194,8 @@ fileServiceTypeNodeV1Writer (BRFileServiceContext context,
     const BREthereumNodeConfig node = (BREthereumNodeConfig) entity;
 
     BRRlpItem item = nodeConfigEncode (node, ewm->coder);
-    BRRlpData data = rlpGetData (ewm->coder, item);
-    rlpReleaseItem (ewm->coder, item);
+    BRRlpData data = rlpItemGetData (ewm->coder, item);
+    rlpItemRelease (ewm->coder, item);
 
     *bytesCount = (uint32_t) data.bytesCount;
     return data.bytes;
@@ -209,10 +209,10 @@ fileServiceTypeNodeV1Reader (BRFileServiceContext context,
     BREthereumEWM ewm = context;
 
     BRRlpData data = { bytesCount, bytes };
-    BRRlpItem item = rlpGetItem (ewm->coder, data);
+    BRRlpItem item = rlpDataGetItem (ewm->coder, data);
 
     BREthereumNodeConfig node = nodeConfigDecode (item, ewm->coder);
-    rlpReleaseItem (ewm->coder, item);
+    rlpItemRelease (ewm->coder, item);
 
     return node;
 }
@@ -246,8 +246,8 @@ fileServiceTypeTokenV1Writer (BRFileServiceContext context,
     BREthereumToken token = (BREthereumToken) entity;
 
     BRRlpItem item = tokenEncode(token, ewm->coder);
-    BRRlpData data = rlpGetData (ewm->coder, item);
-    rlpReleaseItem (ewm->coder, item);
+    BRRlpData data = rlpItemGetData (ewm->coder, item);
+    rlpItemRelease (ewm->coder, item);
 
     *bytesCount = (uint32_t) data.bytesCount;
     return data.bytes;
@@ -261,10 +261,10 @@ fileServiceTypeTokenV1Reader (BRFileServiceContext context,
     BREthereumEWM ewm = context;
 
     BRRlpData data = { bytesCount, bytes };
-    BRRlpItem item = rlpGetItem (ewm->coder, data);
+    BRRlpItem item = rlpDataGetItem (ewm->coder, data);
 
     BREthereumToken token = tokenDecode(item, ewm->coder);
-    rlpReleaseItem (ewm->coder, item);
+    rlpItemRelease (ewm->coder, item);
 
     return token;
 }
@@ -298,8 +298,8 @@ fileServiceTypeWalletV1Writer (BRFileServiceContext context,
     BREthereumWalletState state = (BREthereumWalletState) entity;
 
     BRRlpItem item = walletStateEncode (state, ewm->coder);
-    BRRlpData data = rlpGetData (ewm->coder, item);
-    rlpReleaseItem (ewm->coder, item);
+    BRRlpData data = rlpItemGetData (ewm->coder, item);
+    rlpItemRelease (ewm->coder, item);
 
     *bytesCount = (uint32_t) data.bytesCount;
     return data.bytes;
@@ -313,10 +313,10 @@ fileServiceTypeWalletV1Reader (BRFileServiceContext context,
     BREthereumEWM ewm = context;
 
     BRRlpData data = { bytesCount, bytes };
-    BRRlpItem item = rlpGetItem (ewm->coder, data);
+    BRRlpItem item = rlpDataGetItem (ewm->coder, data);
 
     BREthereumWalletState state = walletStateDecode(item, ewm->coder);
-    rlpReleaseItem (ewm->coder, item);
+    rlpItemRelease (ewm->coder, item);
 
     return state;
 }

--- a/ethereum/ewm/BREthereumTransfer.c
+++ b/ethereum/ewm/BREthereumTransfer.c
@@ -696,7 +696,7 @@ transferProvideOriginatingTransactionData (BREthereumTransfer transfer) {
             UInt256 value = amountGetTokenQuantity(transfer->amount).valueAsInteger;
             
             char address[ADDRESS_ENCODED_CHARS];
-            addressFillEncodedString(transfer->targetAddress, 0, address);
+            ethAddressFillEncodedString(transfer->targetAddress, 0, address);
             
             // Data is a HEX ENCODED string
             return (char *) contractEncode (contractERC20, functionERC20Transfer,

--- a/ethereum/ewm/BREthereumTransfer.c
+++ b/ethereum/ewm/BREthereumTransfer.c
@@ -194,7 +194,7 @@ transferCreateDetailed (BREthereumAddress sourceAddress,
     transfer->targetAddress = targetAddress;
     transfer->amount = amount;
     transfer->feeBasis = feeBasis;
-    transfer->gasEstimate = gasCreate(0);
+    transfer->gasEstimate = ethGasCreate(0);
     transfer->originatingTransaction = originatingTransaction;
     transfer->status = TRANSFER_STATUS_CREATED;
 

--- a/ethereum/ewm/BREthereumTransfer.c
+++ b/ethereum/ewm/BREthereumTransfer.c
@@ -310,9 +310,9 @@ transferCreateWithLog (OwnershipGiven BREthereumLog log,
     BREthereumAddress targetAddress = logTopicAsAddress(logGetTopic(log, 2));
 
     // Only at this point do we know that log->data is a number.
-    BRRlpItem  item  = rlpGetItem (coder, logGetDataShared(log));
+    BRRlpItem  item  = rlpDataGetItem (coder, logGetDataShared(log));
     UInt256 value = rlpDecodeUInt256(coder, item, 1);
-    rlpReleaseItem (coder, item);
+    rlpItemRelease (coder, item);
 
     BREthereumAmount  amount = amountCreateToken (createTokenQuantity(token, value));
 
@@ -429,7 +429,7 @@ transferSign (BREthereumTransfer transfer,
                                            network,
                                            RLP_TYPE_TRANSACTION_UNSIGNED,
                                            coder);
-    BRRlpData data = rlpGetDataSharedDontRelease(coder, item);
+    BRRlpData data = rlpItemGetDataSharedDontRelease(coder, item);
     
     // Sign the RLP Encoded bytes.
     BREthereumSignature signature = accountSignBytes (account,
@@ -439,7 +439,7 @@ transferSign (BREthereumTransfer transfer,
                                                       data.bytesCount,
                                                       paperKey);
     
-    rlpReleaseItem(coder, item);
+    rlpItemRelease(coder, item);
 
     // Attach the signature
     transactionSign (transfer->originatingTransaction, signature);
@@ -449,9 +449,9 @@ transferSign (BREthereumTransfer transfer,
                                  RLP_TYPE_TRANSACTION_SIGNED,
                                  coder);
     transactionSetHash (transfer->originatingTransaction,
-                        hashCreateFromData (rlpGetDataSharedDontRelease (coder, item)));
+                        hashCreateFromData (rlpItemGetDataSharedDontRelease (coder, item)));
 
-    rlpReleaseItem(coder, item);
+    rlpItemRelease(coder, item);
     rlpCoderRelease(coder);
 }
 
@@ -472,7 +472,7 @@ transferSignWithKey (BREthereumTransfer transfer,
                                            network,
                                            RLP_TYPE_TRANSACTION_UNSIGNED,
                                            coder);
-    BRRlpData data = rlpGetDataSharedDontRelease (coder, item);
+    BRRlpData data = rlpItemGetDataSharedDontRelease (coder, item);
     
     // Sign the RLP Encoded bytes.
     BREthereumSignature signature = accountSignBytesWithPrivateKey (account,
@@ -482,7 +482,7 @@ transferSignWithKey (BREthereumTransfer transfer,
                                                                     data.bytesCount,
                                                                     privateKey);
     
-    rlpReleaseItem(coder, item);
+    rlpItemRelease(coder, item);
 
     // Attach the signature
     transactionSign(transfer->originatingTransaction, signature);
@@ -493,9 +493,9 @@ transferSignWithKey (BREthereumTransfer transfer,
                                  RLP_TYPE_TRANSACTION_SIGNED,
                                  coder);
     transactionSetHash (transfer->originatingTransaction,
-                        hashCreateFromData (rlpGetDataSharedDontRelease (coder, item)));
+                        hashCreateFromData (rlpItemGetDataSharedDontRelease (coder, item)));
 
-    rlpReleaseItem(coder, item);
+    rlpItemRelease(coder, item);
     rlpCoderRelease(coder);
 }
 

--- a/ethereum/ewm/BREthereumTransfer.c
+++ b/ethereum/ewm/BREthereumTransfer.c
@@ -544,7 +544,7 @@ transferGetFee (BREthereumTransfer transfer, int *overflow) {
 
     // If we have a basis, then the transfer is confirmed; use the actual fee.
     if (TRANSFER_BASIS_LOG == transfer->basis.type && NULL != transfer->basis.u.log)
-        return etherCreateZero();
+        return ethEtherCreateZero();
 
     else if (TRANSFER_BASIS_TRANSACTION == transfer->basis.type && NULL != transfer->basis.u.transaction)
         return transactionGetFee (transfer->basis.u.transaction, overflow);
@@ -552,7 +552,7 @@ transferGetFee (BREthereumTransfer transfer, int *overflow) {
     else if (NULL != transfer->originatingTransaction)
         return transactionGetFee (transfer->originatingTransaction, overflow);
 
-    else return etherCreateZero();
+    else return ethEtherCreateZero();
 }
 
 /// MARK: - Basis
@@ -725,7 +725,7 @@ transferProvideOriginatingTransactionAmount (BREthereumTransfer transfer) {
         case AMOUNT_ETHER:
             return transfer->amount.u.ether;
         case AMOUNT_TOKEN:
-            return etherCreateZero();
+            return ethEtherCreateZero();
     }
 }
 
@@ -752,7 +752,7 @@ private_extern BREthereumEther
 transferGetEffectiveAmountInEther(BREthereumTransfer transfer) {
     switch (transfer->basis.type) {
         case TRANSFER_BASIS_LOG:
-            return etherCreateZero();
+            return ethEtherCreateZero();
         case TRANSFER_BASIS_TRANSACTION:
             return transactionGetAmount(NULL != transfer->basis.u.transaction
                                         ? transfer->basis.u.transaction

--- a/ethereum/ewm/BREthereumTransfer.c
+++ b/ethereum/ewm/BREthereumTransfer.c
@@ -421,7 +421,7 @@ transferSign (BREthereumTransfer transfer,
     
     if (TRANSACTION_NONCE_IS_NOT_ASSIGNED == transactionGetNonce(transfer->originatingTransaction))
         transactionSetNonce (transfer->originatingTransaction,
-                             accountGetThenIncrementAddressNonce(account, address));
+                             ethAccountGetThenIncrementAddressNonce(account, address));
     
     // RLP Encode the UNSIGNED transfer
     BRRlpCoder coder = rlpCoderCreate();
@@ -432,7 +432,7 @@ transferSign (BREthereumTransfer transfer,
     BRRlpData data = rlpItemGetDataSharedDontRelease(coder, item);
     
     // Sign the RLP Encoded bytes.
-    BREthereumSignature signature = accountSignBytes (account,
+    BREthereumSignature signature = ethAccountSignBytes (account,
                                                       address,
                                                       SIGNATURE_TYPE_RECOVERABLE_VRS_EIP,
                                                       data.bytes,
@@ -464,7 +464,7 @@ transferSignWithKey (BREthereumTransfer transfer,
     
     if (TRANSACTION_NONCE_IS_NOT_ASSIGNED == transactionGetNonce(transfer->originatingTransaction))
         transactionSetNonce (transfer->originatingTransaction,
-                             accountGetThenIncrementAddressNonce(account, address));
+                             ethAccountGetThenIncrementAddressNonce(account, address));
     
     // RLP Encode the UNSIGNED transfer
     BRRlpCoder coder = rlpCoderCreate();
@@ -475,7 +475,7 @@ transferSignWithKey (BREthereumTransfer transfer,
     BRRlpData data = rlpItemGetDataSharedDontRelease (coder, item);
     
     // Sign the RLP Encoded bytes.
-    BREthereumSignature signature = accountSignBytesWithPrivateKey (account,
+    BREthereumSignature signature = ethAccountSignBytesWithPrivateKey (account,
                                                                     address,
                                                                     SIGNATURE_TYPE_RECOVERABLE_VRS_EIP,
                                                                     data.bytes,

--- a/ethereum/ewm/BREthereumTransfer.c
+++ b/ethereum/ewm/BREthereumTransfer.c
@@ -449,7 +449,7 @@ transferSign (BREthereumTransfer transfer,
                                  RLP_TYPE_TRANSACTION_SIGNED,
                                  coder);
     transactionSetHash (transfer->originatingTransaction,
-                        hashCreateFromData (rlpItemGetDataSharedDontRelease (coder, item)));
+                        ethHashCreateFromData (rlpItemGetDataSharedDontRelease (coder, item)));
 
     rlpItemRelease(coder, item);
     rlpCoderRelease(coder);
@@ -493,7 +493,7 @@ transferSignWithKey (BREthereumTransfer transfer,
                                  RLP_TYPE_TRANSACTION_SIGNED,
                                  coder);
     transactionSetHash (transfer->originatingTransaction,
-                        hashCreateFromData (rlpItemGetDataSharedDontRelease (coder, item)));
+                        ethHashCreateFromData (rlpItemGetDataSharedDontRelease (coder, item)));
 
     rlpItemRelease(coder, item);
     rlpCoderRelease(coder);

--- a/ethereum/ewm/BREthereumTransfer.c
+++ b/ethereum/ewm/BREthereumTransfer.c
@@ -314,7 +314,7 @@ transferCreateWithLog (OwnershipGiven BREthereumLog log,
     UInt256 value = rlpDecodeUInt256(coder, item, 1);
     rlpItemRelease (coder, item);
 
-    BREthereumAmount  amount = amountCreateToken (createTokenQuantity(token, value));
+    BREthereumAmount  amount = amountCreateToken (ethTokenQuantityCreate(token, value));
 
     // No originating transaction
     BREthereumTransfer transfer = transferCreateDetailed (sourceAddress,
@@ -699,7 +699,7 @@ transferProvideOriginatingTransactionData (BREthereumTransfer transfer) {
             ethAddressFillEncodedString(transfer->targetAddress, 0, address);
             
             // Data is a HEX ENCODED string
-            return (char *) contractEncode (contractERC20, functionERC20Transfer,
+            return (char *) ethContractEncode (ethContractERC20, ethFunctionERC20Transfer,
                                             // Address
                                             (uint8_t *) &address[2], strlen(address) - 2,
                                             // Amount
@@ -715,7 +715,7 @@ transferProvideOriginatingTransactionTargetAddress (BREthereumTransfer transfer)
         case AMOUNT_ETHER:
             return transfer->targetAddress;
         case AMOUNT_TOKEN:
-            return tokenGetAddressRaw(amountGetToken(transfer->amount));
+            return ethTokenGetAddressRaw(amountGetToken(transfer->amount));
     }
 }
 

--- a/ethereum/ewm/BREthereumTransfer.c
+++ b/ethereum/ewm/BREthereumTransfer.c
@@ -251,7 +251,7 @@ transferCreateWithTransactionOriginating (OwnershipGiven BREthereumTransaction t
     // Use `transaction` as the `originatingTransaction`; takes ownership
     BREthereumTransfer transfer = transferCreateDetailed (transactionGetSourceAddress(transaction),
                                                           transactionGetTargetAddress(transaction),
-                                                          amountCreateEther (transactionGetAmount(transaction)),
+                                                          ethAmountCreateEther (transactionGetAmount(transaction)),
                                                           feeBasis,
                                                           transaction);
 
@@ -278,7 +278,7 @@ transferCreateWithTransaction (OwnershipGiven BREthereumTransaction transaction)
     // No originating transaction
     BREthereumTransfer transfer = transferCreateDetailed (transactionGetSourceAddress(transaction),
                                                           transactionGetTargetAddress(transaction),
-                                                          amountCreateEther (transactionGetAmount(transaction)),
+                                                          ethAmountCreateEther (transactionGetAmount(transaction)),
                                                           feeBasis,
                                                           NULL);
     // Basis - the transfer now owns the transaction.
@@ -314,7 +314,7 @@ transferCreateWithLog (OwnershipGiven BREthereumLog log,
     UInt256 value = rlpDecodeUInt256(coder, item, 1);
     rlpItemRelease (coder, item);
 
-    BREthereumAmount  amount = amountCreateToken (ethTokenQuantityCreate(token, value));
+    BREthereumAmount  amount = ethAmountCreateToken (ethTokenQuantityCreate(token, value));
 
     // No originating transaction
     BREthereumTransfer transfer = transferCreateDetailed (sourceAddress,
@@ -358,8 +358,8 @@ transferGetAmount (BREthereumTransfer transfer) {
 
 extern BREthereumToken
 transferGetToken (BREthereumTransfer transfer) {
-    return (AMOUNT_TOKEN == amountGetType(transfer->amount)
-            ? amountGetToken(transfer->amount)
+    return (AMOUNT_TOKEN == ethAmountGetType(transfer->amount)
+            ? ethAmountGetToken(transfer->amount)
             : NULL);
 }
 
@@ -689,11 +689,11 @@ transferExtractStatusErrorType (BREthereumTransfer transfer,
 
 static char *
 transferProvideOriginatingTransactionData (BREthereumTransfer transfer) {
-    switch (amountGetType(transfer->amount)) {
+    switch (ethAmountGetType(transfer->amount)) {
         case AMOUNT_ETHER:
             return strdup ("");
         case AMOUNT_TOKEN: {
-            UInt256 value = amountGetTokenQuantity(transfer->amount).valueAsInteger;
+            UInt256 value = ethAmountGetTokenQuantity(transfer->amount).valueAsInteger;
             
             char address[ADDRESS_ENCODED_CHARS];
             ethAddressFillEncodedString(transfer->targetAddress, 0, address);
@@ -711,17 +711,17 @@ transferProvideOriginatingTransactionData (BREthereumTransfer transfer) {
 
 static BREthereumAddress
 transferProvideOriginatingTransactionTargetAddress (BREthereumTransfer transfer) {
-    switch (amountGetType(transfer->amount)) {
+    switch (ethAmountGetType(transfer->amount)) {
         case AMOUNT_ETHER:
             return transfer->targetAddress;
         case AMOUNT_TOKEN:
-            return ethTokenGetAddressRaw(amountGetToken(transfer->amount));
+            return ethTokenGetAddressRaw(ethAmountGetToken(transfer->amount));
     }
 }
 
 static BREthereumEther
 transferProvideOriginatingTransactionAmount (BREthereumTransfer transfer) {
-    switch (amountGetType(transfer->amount)) {
+    switch (ethAmountGetType(transfer->amount)) {
         case AMOUNT_ETHER:
             return transfer->amount.u.ether;
         case AMOUNT_TOKEN:

--- a/ethereum/ewm/BREthereumTransfer.c
+++ b/ethereum/ewm/BREthereumTransfer.c
@@ -740,8 +740,8 @@ transferProvideOriginatingTransaction (BREthereumTransfer transfer) {
     transactionCreate (transfer->sourceAddress,
                        transferProvideOriginatingTransactionTargetAddress (transfer),
                        transferProvideOriginatingTransactionAmount (transfer),
-                       feeBasisGetGasPrice(transfer->feeBasis),
-                       feeBasisGetGasLimit(transfer->feeBasis),
+                       ethFeeBasisGetGasPrice(transfer->feeBasis),
+                       ethFeeBasisGetGasLimit(transfer->feeBasis),
                        data,
                        TRANSACTION_NONCE_IS_NOT_ASSIGNED);
     free (data);

--- a/ethereum/ewm/BREthereumWallet.c
+++ b/ethereum/ewm/BREthereumWallet.c
@@ -161,7 +161,7 @@ walletCreate(BREthereumAccount account,
              BREthereumNetwork network)
 {
     return walletCreateDetailed (account,
-                                 accountGetPrimaryAddress(account),
+                                 ethAccountGetPrimaryAddress(account),
                                  network,
                                  AMOUNT_ETHER,
                                  NULL);
@@ -172,7 +172,7 @@ walletCreateHoldingToken(BREthereumAccount account,
                          BREthereumNetwork network,
                          BREthereumToken token) {
     return walletCreateDetailed (account,
-                                 accountGetPrimaryAddress(account),
+                                 ethAccountGetPrimaryAddress(account),
                                  network,
                                  AMOUNT_TOKEN,
                                  token);

--- a/ethereum/ewm/BREthereumWallet.c
+++ b/ethereum/ewm/BREthereumWallet.c
@@ -449,7 +449,7 @@ static BREthereumGasPrice
 walletCreateDefaultGasPrice (BREthereumWallet wallet) {
     switch (amountGetType(wallet->balance)) {
         case AMOUNT_ETHER:
-            return gasPriceCreate(etherCreateNumber
+            return ethGasPriceCreate(etherCreateNumber
                                   (DEFAULT_ETHER_GAS_PRICE_NUMBER,
                                    DEFAULT_ETHER_GAS_PRICE_UNIT));
         case AMOUNT_TOKEN:

--- a/ethereum/ewm/BREthereumWallet.c
+++ b/ethereum/ewm/BREthereumWallet.c
@@ -141,7 +141,7 @@ walletCreateDetailed (BREthereumAccount account,
     
     wallet->token = optionalToken;
     wallet->balance = (AMOUNT_ETHER == type
-                       ? ethAmountCreateEther(etherCreate(UINT256_ZERO))
+                       ? ethAmountCreateEther(ethEtherCreate(UINT256_ZERO))
                        : ethAmountCreateToken(ethTokenQuantityCreate (wallet->token, UINT256_ZERO)));
     
     wallet->defaultGasLimit = AMOUNT_ETHER == type
@@ -220,7 +220,7 @@ walletEstimateTransferFeeDetailed (BREthereumWallet wallet,
                                    BREthereumGasPrice price,
                                    BREthereumGas gas,
                                    int *overflow) {
-    return etherCreate (uint256Mul_Overflow (price.etherPerGas.valueInWEI,
+    return ethEtherCreate (uint256Mul_Overflow (price.etherPerGas.valueInWEI,
                                              uint256Create(gas.amountOfGas),
                                              overflow));
 }
@@ -409,7 +409,7 @@ walletUpdateBalance (BREthereumWallet wallet) {
 
     if (AMOUNT_ETHER == ethAmountGetType(wallet->balance)) {
         balance = uint256Sub_Negative(balance, fees, &negative);
-        wallet->balance = ethAmountCreateEther (etherCreate(balance));
+        wallet->balance = ethAmountCreateEther (ethEtherCreate(balance));
     }
     else
         wallet->balance = ethAmountCreateToken (ethTokenQuantityCreate(ethAmountGetToken (wallet->balance), balance));
@@ -449,7 +449,7 @@ static BREthereumGasPrice
 walletCreateDefaultGasPrice (BREthereumWallet wallet) {
     switch (ethAmountGetType(wallet->balance)) {
         case AMOUNT_ETHER:
-            return ethGasPriceCreate(etherCreateNumber
+            return ethGasPriceCreate(ethEtherCreateNumber
                                   (DEFAULT_ETHER_GAS_PRICE_NUMBER,
                                    DEFAULT_ETHER_GAS_PRICE_UNIT));
         case AMOUNT_TOKEN:
@@ -641,7 +641,7 @@ walletStateCreate (const BREthereumWallet wallet) {
 
     if (NULL == token) {
         state->address = FAKE_ETHER_ADDRESS_INIT;
-        state->amount  = etherGetValue (ethAmountGetEther(balance), WEI);
+        state->amount  = ethEtherGetValue (ethAmountGetEther(balance), WEI);
     }
     else {
         state->address = ethTokenGetAddressRaw(token);

--- a/ethereum/ewm/BREthereumWallet.c
+++ b/ethereum/ewm/BREthereumWallet.c
@@ -389,7 +389,7 @@ walletUpdateBalance (BREthereumWallet wallet) {
                          ? amountGetEther(amount).valueInWEI
                          : amountGetTokenQuantity(amount).valueAsInteger);
 
-        if (ETHEREUM_BOOLEAN_IS_TRUE(addressEqual(wallet->address, transferGetSourceAddress(transfer)))) {
+        if (ETHEREUM_BOOLEAN_IS_TRUE(ethAddressEqual(wallet->address, transferGetSourceAddress(transfer)))) {
             sent = uint256Add_Overflow(sent, value, &overflow);
 
             BREthereumEther fee = transferGetFee(transfer, &fee_overflow);
@@ -515,7 +515,7 @@ walletGetTransferByNonce(BREthereumWallet wallet,
                          uint64_t nonce) {
     for (int i = 0; i < array_count(wallet->transfers); i++)
         if (nonce == transferGetNonce (wallet->transfers[i])
-            && ETHEREUM_BOOLEAN_IS_TRUE(addressEqual(sourceAddress, transferGetSourceAddress(wallet->transfers[i]))))
+            && ETHEREUM_BOOLEAN_IS_TRUE(ethAddressEqual(sourceAddress, transferGetSourceAddress(wallet->transfers[i]))))
             return wallet->transfers [i];
     return NULL;
 }
@@ -658,7 +658,7 @@ walletStateRelease (BREthereumWalletState state) {
 
 extern BREthereumAddress
 walletStateGetAddress (const BREthereumWalletState walletState) {
-    return (ETHEREUM_BOOLEAN_IS_TRUE (addressEqual (FAKE_ETHER_ADDRESS_INIT, walletState->address))
+    return (ETHEREUM_BOOLEAN_IS_TRUE (ethAddressEqual (FAKE_ETHER_ADDRESS_INIT, walletState->address))
             ? EMPTY_ADDRESS_INIT
             : walletState->address);
 }
@@ -683,7 +683,7 @@ extern BRRlpItem
 walletStateEncode (const BREthereumWalletState state,
                    BRRlpCoder coder) {
     return rlpEncodeList (coder, 3,
-                          addressRlpEncode (state->address, coder),
+                          ethAddressRlpEncode (state->address, coder),
                           rlpEncodeUInt256 (coder, state->amount, 0),
                           rlpEncodeUInt64  (coder, state->nonce, 0));
 }
@@ -697,7 +697,7 @@ walletStateDecode (BRRlpItem item,
     const BRRlpItem *items = rlpDecodeList (coder, item, &itemsCount);
     assert (3 == itemsCount);
 
-    state->address = addressRlpDecode (items[0], coder);
+    state->address = ethAddressRlpDecode (items[0], coder);
     state->amount  = rlpDecodeUInt256 (coder, items[1], 0);
     state->nonce   = rlpDecodeUInt64  (coder, items[2], 0);
 
@@ -706,18 +706,18 @@ walletStateDecode (BRRlpItem item,
 
 extern BREthereumHash
 walletStateGetHash (const BREthereumWalletState state) {
-    return addressGetHash (state->address);
+    return ethAddressGetHash (state->address);
 }
 
 static inline size_t
 walletStateHashValue (const void *t)
 {
-    return addressHashValue(((BREthereumWalletState) t)->address);
+    return ethAddressHashValue(((BREthereumWalletState) t)->address);
 }
 
 static inline int
 walletStateHashEqual (const void *t1, const void *t2) {
-    return t1 == t2 || addressHashEqual (((BREthereumWalletState) t1)->address,
+    return t1 == t2 || ethAddressHashEqual (((BREthereumWalletState) t1)->address,
                                          ((BREthereumWalletState) t2)->address);
 }
 

--- a/ethereum/ewm/BREthereumWallet.c
+++ b/ethereum/ewm/BREthereumWallet.c
@@ -142,15 +142,15 @@ walletCreateDetailed (BREthereumAccount account,
     wallet->token = optionalToken;
     wallet->balance = (AMOUNT_ETHER == type
                        ? amountCreateEther(etherCreate(UINT256_ZERO))
-                       : amountCreateToken(createTokenQuantity (wallet->token, UINT256_ZERO)));
+                       : amountCreateToken(ethTokenQuantityCreate (wallet->token, UINT256_ZERO)));
     
     wallet->defaultGasLimit = AMOUNT_ETHER == type
     ? walletCreateDefaultGasLimit(wallet)
-    : tokenGetGasLimit (optionalToken);
+    : ethTokenGetGasLimit (optionalToken);
     
     wallet->defaultGasPrice = AMOUNT_ETHER == type
     ? walletCreateDefaultGasPrice(wallet)
-    : tokenGetGasPrice (optionalToken);
+    : ethTokenGetGasPrice (optionalToken);
     
     array_new(wallet->transfers, DEFAULT_TRANSFER_CAPACITY);
     return wallet;
@@ -412,7 +412,7 @@ walletUpdateBalance (BREthereumWallet wallet) {
         wallet->balance = amountCreateEther (etherCreate(balance));
     }
     else
-        wallet->balance = amountCreateToken (createTokenQuantity(amountGetToken (wallet->balance), balance));
+        wallet->balance = amountCreateToken (ethTokenQuantityCreate(amountGetToken (wallet->balance), balance));
 }
 // Gas Limit
 
@@ -453,7 +453,7 @@ walletCreateDefaultGasPrice (BREthereumWallet wallet) {
                                   (DEFAULT_ETHER_GAS_PRICE_NUMBER,
                                    DEFAULT_ETHER_GAS_PRICE_UNIT));
         case AMOUNT_TOKEN:
-            return tokenGetGasPrice (wallet->token);
+            return ethTokenGetGasPrice (wallet->token);
     }
 }
 
@@ -644,7 +644,7 @@ walletStateCreate (const BREthereumWallet wallet) {
         state->amount  = etherGetValue (amountGetEther(balance), WEI);
     }
     else {
-        state->address = tokenGetAddressRaw(token);
+        state->address = ethTokenGetAddressRaw(token);
         state->amount  = amountGetTokenQuantity(balance).valueAsInteger;
     }
 

--- a/ethereum/ewm/BREthereumWallet.c
+++ b/ethereum/ewm/BREthereumWallet.c
@@ -141,8 +141,8 @@ walletCreateDetailed (BREthereumAccount account,
     
     wallet->token = optionalToken;
     wallet->balance = (AMOUNT_ETHER == type
-                       ? amountCreateEther(etherCreate(UINT256_ZERO))
-                       : amountCreateToken(ethTokenQuantityCreate (wallet->token, UINT256_ZERO)));
+                       ? ethAmountCreateEther(etherCreate(UINT256_ZERO))
+                       : ethAmountCreateToken(ethTokenQuantityCreate (wallet->token, UINT256_ZERO)));
     
     wallet->defaultGasLimit = AMOUNT_ETHER == type
     ? walletCreateDefaultGasLimit(wallet)
@@ -207,7 +207,7 @@ walletEstimateTransferFee (BREthereumWallet wallet,
     return walletEstimateTransferFeeDetailed (wallet,
                                               amount,
                                               wallet->defaultGasPrice,
-                                              amountGetGasEstimate(amount),
+                                              ethAmountGetGasEstimate(amount),
                                               overflow);
 }
 
@@ -384,10 +384,10 @@ walletUpdateBalance (BREthereumWallet wallet) {
     for (size_t index = 0; index < array_count (wallet->transfers); index++) {
         BREthereumTransfer transfer = wallet->transfers[index];
         BREthereumAmount   amount = transferGetAmount(transfer);
-        assert (amountGetType(wallet->balance) == amountGetType(amount));
-        UInt256 value = (AMOUNT_ETHER == amountGetType(amount)
-                         ? amountGetEther(amount).valueInWEI
-                         : amountGetTokenQuantity(amount).valueAsInteger);
+        assert (ethAmountGetType(wallet->balance) == ethAmountGetType(amount));
+        UInt256 value = (AMOUNT_ETHER == ethAmountGetType(amount)
+                         ? ethAmountGetEther(amount).valueInWEI
+                         : ethAmountGetTokenQuantity(amount).valueAsInteger);
 
         if (ETHEREUM_BOOLEAN_IS_TRUE(ethAddressEqual(wallet->address, transferGetSourceAddress(transfer)))) {
             sent = uint256Add_Overflow(sent, value, &overflow);
@@ -407,12 +407,12 @@ walletUpdateBalance (BREthereumWallet wallet) {
     // and shouldn't we also ensure that an event is generated (like all calls to
     // walletSetBalance() ensure)?
 
-    if (AMOUNT_ETHER == amountGetType(wallet->balance)) {
+    if (AMOUNT_ETHER == ethAmountGetType(wallet->balance)) {
         balance = uint256Sub_Negative(balance, fees, &negative);
-        wallet->balance = amountCreateEther (etherCreate(balance));
+        wallet->balance = ethAmountCreateEther (etherCreate(balance));
     }
     else
-        wallet->balance = amountCreateToken (ethTokenQuantityCreate(amountGetToken (wallet->balance), balance));
+        wallet->balance = ethAmountCreateToken (ethTokenQuantityCreate(ethAmountGetToken (wallet->balance), balance));
 }
 // Gas Limit
 
@@ -429,7 +429,7 @@ walletSetDefaultGasLimit(BREthereumWallet wallet,
 
 static BREthereumGas
 walletCreateDefaultGasLimit (BREthereumWallet wallet) {
-    return amountGetGasEstimate(wallet->balance);
+    return ethAmountGetGasEstimate(wallet->balance);
 }
 
 // Gas Price
@@ -447,7 +447,7 @@ walletSetDefaultGasPrice(BREthereumWallet wallet,
 
 static BREthereumGasPrice
 walletCreateDefaultGasPrice (BREthereumWallet wallet) {
-    switch (amountGetType(wallet->balance)) {
+    switch (ethAmountGetType(wallet->balance)) {
         case AMOUNT_ETHER:
             return ethGasPriceCreate(etherCreateNumber
                                   (DEFAULT_ETHER_GAS_PRICE_NUMBER,
@@ -641,11 +641,11 @@ walletStateCreate (const BREthereumWallet wallet) {
 
     if (NULL == token) {
         state->address = FAKE_ETHER_ADDRESS_INIT;
-        state->amount  = etherGetValue (amountGetEther(balance), WEI);
+        state->amount  = etherGetValue (ethAmountGetEther(balance), WEI);
     }
     else {
         state->address = ethTokenGetAddressRaw(token);
-        state->amount  = amountGetTokenQuantity(balance).valueAsInteger;
+        state->amount  = ethAmountGetTokenQuantity(balance).valueAsInteger;
     }
 
     return state;

--- a/ethereum/ewm/BREthereumWallet.c
+++ b/ethereum/ewm/BREthereumWallet.c
@@ -488,11 +488,11 @@ walletWalkTransfers (BREthereumWallet wallet,
 extern BREthereumTransfer
 walletGetTransferByIdentifier (BREthereumWallet wallet,
                                BREthereumHash hash) {
-    if (ETHEREUM_BOOLEAN_IS_TRUE (hashEqual (hash, EMPTY_HASH_INIT))) return NULL;
+    if (ETHEREUM_BOOLEAN_IS_TRUE (ethHashEqual (hash, EMPTY_HASH_INIT))) return NULL;
 
     for (int i = 0; i < array_count(wallet->transfers); i++) {
         BREthereumHash identifier = transferGetIdentifier (wallet->transfers[i]);
-        if (ETHEREUM_BOOLEAN_IS_TRUE (hashEqual (hash, identifier)))
+        if (ETHEREUM_BOOLEAN_IS_TRUE (ethHashEqual (hash, identifier)))
             return wallet->transfers[i];
     }
     return NULL;
@@ -503,7 +503,7 @@ walletGetTransferByOriginatingHash (BREthereumWallet wallet,
                                     BREthereumHash hash) {
     for (int i = 0; i < array_count(wallet->transfers); i++) {
         BREthereumTransaction transaction = transferGetOriginatingTransaction (wallet->transfers[i]);
-        if (NULL != transaction && ETHEREUM_BOOLEAN_IS_TRUE (hashEqual (hash, transactionGetHash (transaction))))
+        if (NULL != transaction && ETHEREUM_BOOLEAN_IS_TRUE (ethHashEqual (hash, transactionGetHash (transaction))))
             return wallet->transfers[i];
     }
     return NULL;

--- a/ethereum/ewm/BREthereumWallet.c
+++ b/ethereum/ewm/BREthereumWallet.c
@@ -220,8 +220,8 @@ walletEstimateTransferFeeDetailed (BREthereumWallet wallet,
                                    BREthereumGasPrice price,
                                    BREthereumGas gas,
                                    int *overflow) {
-    return etherCreate (mulUInt256_Overflow (price.etherPerGas.valueInWEI,
-                                             createUInt256(gas.amountOfGas),
+    return etherCreate (uint256Mul_Overflow (price.etherPerGas.valueInWEI,
+                                             uint256Create(gas.amountOfGas),
                                              overflow));
 }
 
@@ -390,25 +390,25 @@ walletUpdateBalance (BREthereumWallet wallet) {
                          : amountGetTokenQuantity(amount).valueAsInteger);
 
         if (ETHEREUM_BOOLEAN_IS_TRUE(addressEqual(wallet->address, transferGetSourceAddress(transfer)))) {
-            sent = addUInt256_Overflow(sent, value, &overflow);
+            sent = uint256Add_Overflow(sent, value, &overflow);
 
             BREthereumEther fee = transferGetFee(transfer, &fee_overflow);
-            fees = addUInt256_Overflow(fees, fee.valueInWEI, &fee_overflow);
+            fees = uint256Add_Overflow(fees, fee.valueInWEI, &fee_overflow);
         }
         else
-            recv = addUInt256_Overflow(recv, value, &overflow);
+            recv = uint256Add_Overflow(recv, value, &overflow);
 
         assert (!overflow);
     }
 
-    UInt256 balance = subUInt256_Negative(recv, sent, &negative);
+    UInt256 balance = uint256Sub_Negative(recv, sent, &negative);
 
     // If we are going to be changing the balance here then 1) shouldn't we call walletSetBalance()
     // and shouldn't we also ensure that an event is generated (like all calls to
     // walletSetBalance() ensure)?
 
     if (AMOUNT_ETHER == amountGetType(wallet->balance)) {
-        balance = subUInt256_Negative(balance, fees, &negative);
+        balance = uint256Sub_Negative(balance, fees, &negative);
         wallet->balance = amountCreateEther (etherCreate(balance));
     }
     else

--- a/ethereum/ewm/testEwm.c
+++ b/ethereum/ewm/testEwm.c
@@ -65,8 +65,8 @@ installTokensForTestOnNetwork (BREthereumNetwork network) {
 
     tokens = tokenSetCreate(10);
 
-    BREthereumGas defaultGasLimit = gasCreate(TOKEN_BRD_DEFAULT_GAS_LIMIT);
-    BREthereumGasPrice defaultGasPrice = gasPriceCreate(etherCreateNumber(TOKEN_BRD_DEFAULT_GAS_PRICE_IN_WEI_UINT64, WEI));
+    BREthereumGas defaultGasLimit = ethGasCreate(TOKEN_BRD_DEFAULT_GAS_LIMIT);
+    BREthereumGasPrice defaultGasPrice = ethGasPriceCreate(etherCreateNumber(TOKEN_BRD_DEFAULT_GAS_PRICE_IN_WEI_UINT64, WEI));
 
     BREthereumToken token;
 
@@ -678,8 +678,8 @@ void prepareTransaction (const char *paperKey,
     // END - One Time Code Block
     
     // Optional - will provide listNodeWalletCreateTransactionDetailed.
-    ewmWalletSetDefaultGasPrice(ewm, wallet, gasPriceCreate(etherCreateNumber(gasPrice, GWEI)));
-    ewmWalletSetDefaultGasLimit(ewm, wallet, gasCreate(gasLimit));
+    ewmWalletSetDefaultGasPrice(ewm, wallet, ethGasPriceCreate(etherCreateNumber(gasPrice, GWEI)));
+    ewmWalletSetDefaultGasLimit(ewm, wallet, ethGasCreate(gasLimit));
 
     BREthereumAmount amountAmountInEther =
     ewmCreateEtherAmountUnit(ewm, amount, WEI);
@@ -744,8 +744,8 @@ testReallySend (const char *storagePath) {
     accountSetAddressNonce(account, address, nonce, ETHEREUM_BOOLEAN_TRUE);
     
     // Optional - will provide listNodeWalletCreateTransactionDetailed.
-    ewmWalletSetDefaultGasPrice(ewm, wallet, gasPriceCreate(etherCreateNumber(gasPrice, GWEI)));
-    ewmWalletSetDefaultGasLimit(ewm, wallet, gasCreate(gasLimit));
+    ewmWalletSetDefaultGasPrice(ewm, wallet, ethGasPriceCreate(etherCreateNumber(gasPrice, GWEI)));
+    ewmWalletSetDefaultGasLimit(ewm, wallet, ethGasCreate(gasLimit));
     
     BRCoreParseStatus status;
     BREthereumAmount amountAmountInEther =

--- a/ethereum/ewm/testEwm.c
+++ b/ethereum/ewm/testEwm.c
@@ -35,7 +35,7 @@
 
 static const char *
 getTokenBRDAddress (BREthereumNetwork network) {
-    return (network == ethereumMainnet
+    return (network == ethNetworkMainnet
             ? "0x558ec3152e2eb2174905cd19aea4e34a23de9ad6"
             : "0x7108ca7c4718efa810457f228305c9c71390931a");
 }
@@ -43,7 +43,7 @@ getTokenBRDAddress (BREthereumNetwork network) {
 #if defined (BITCOIN_DEBUG)
 static const char *
 getTokenTSTAddress (BREthereumNetwork network) {
-    return (network == ethereumMainnet
+    return (network == ethNetworkMainnet
             ? "0x3efd578b271d034a69499e4a2d933c631d44b9ad"
             : "0x722dd3f80bac40c951b51bdd28dd19d435762180");
 }
@@ -596,7 +596,7 @@ runEWM_CONNECT_test (const char *paperKey,
     BREthereumEther expectedBalance = etherCreate(uint256CreateParse("0x123f", 16, &status));
     assert (CORE_PARSE_OK == status);
 
-    BREthereumEWM ewm = ewmCreateWithPaperKey (ethereumMainnet, paperKey, ETHEREUM_TIMESTAMP_UNKNOWN,
+    BREthereumEWM ewm = ewmCreateWithPaperKey (ethNetworkMainnet, paperKey, ETHEREUM_TIMESTAMP_UNKNOWN,
                                                CRYPTO_SYNC_MODE_API_ONLY,
                                                client,
                                                storagePath,
@@ -667,7 +667,7 @@ void prepareTransaction (const char *paperKey,
     // START - One Time Code Block
     client.context = (JsonRpcTestContext) calloc (1, sizeof (struct JsonRpcTestContextRecord));
     
-    BREthereumEWM ewm = ewmCreateWithPaperKey (ethereumMainnet, paperKey, ETHEREUM_TIMESTAMP_UNKNOWN,
+    BREthereumEWM ewm = ewmCreateWithPaperKey (ethNetworkMainnet, paperKey, ETHEREUM_TIMESTAMP_UNKNOWN,
                                                CRYPTO_SYNC_MODE_P2P_ONLY,
                                                client,
                                                storagePath,
@@ -729,7 +729,7 @@ testReallySend (const char *storagePath) {
     printf ("PaperKey: '%s'\nAddress: '%s'\nGasLimt: %" PRIu64 "\nGasPrice: %" PRIu64 " GWEI\n", paperKey, recvAddr, gasLimit, gasPrice);
     
     alarmClockCreateIfNecessary (1);
-    BREthereumEWM ewm = ewmCreateWithPaperKey (ethereumMainnet, paperKey, ETHEREUM_TIMESTAMP_UNKNOWN,
+    BREthereumEWM ewm = ewmCreateWithPaperKey (ethNetworkMainnet, paperKey, ETHEREUM_TIMESTAMP_UNKNOWN,
                                                CRYPTO_SYNC_MODE_P2P_ONLY,
                                                client,
                                                storagePath,
@@ -803,8 +803,8 @@ runEWM_TOKEN_test (const char *paperKey,
     
     BRCoreParseStatus status;
     
-    BREthereumToken token = tokenLookupTestX(getTokenBRDAddress(ethereumMainnet));
-    BREthereumEWM ewm = ewmCreateWithPaperKey (ethereumMainnet, paperKey, ETHEREUM_TIMESTAMP_UNKNOWN,
+    BREthereumToken token = tokenLookupTestX(getTokenBRDAddress(ethNetworkMainnet));
+    BREthereumEWM ewm = ewmCreateWithPaperKey (ethNetworkMainnet, paperKey, ETHEREUM_TIMESTAMP_UNKNOWN,
                                                CRYPTO_SYNC_MODE_P2P_ONLY,
                                                client,
                                                storagePath,
@@ -841,7 +841,7 @@ runEWM_PUBLIC_KEY_test (BREthereumNetwork network,
                         const char *storagePath) {
     printf ("====   PUBLIC KEY\n");
 
-    BREthereumEWM ewm1 = ewmCreateWithPaperKey (ethereumMainnet, paperKey, ETHEREUM_TIMESTAMP_UNKNOWN,
+    BREthereumEWM ewm1 = ewmCreateWithPaperKey (ethNetworkMainnet, paperKey, ETHEREUM_TIMESTAMP_UNKNOWN,
                                                 CRYPTO_SYNC_MODE_P2P_ONLY,
                                                 client,
                                                 storagePath,
@@ -850,7 +850,7 @@ runEWM_PUBLIC_KEY_test (BREthereumNetwork network,
     BRKey publicKey = ewmGetAccountPrimaryAddressPublicKey (ewm1);
     char *addr1 = ewmGetAccountPrimaryAddress (ewm1);
     
-    BREthereumEWM ewm2 = ewmCreateWithPublicKey (ethereumMainnet, publicKey, ETHEREUM_TIMESTAMP_UNKNOWN,
+    BREthereumEWM ewm2 = ewmCreateWithPublicKey (ethNetworkMainnet, publicKey, ETHEREUM_TIMESTAMP_UNKNOWN,
                                                  CRYPTO_SYNC_MODE_P2P_ONLY,
                                                  client,
                                                  storagePath,
@@ -884,7 +884,7 @@ runSyncTest (BREthereumNetwork network,
     
     alarmClockCreateIfNecessary (1);
 
-    ewm = ewmCreate (ethereumMainnet, account, accountTimestamp, mode, client, storagePath, 0, 6);
+    ewm = ewmCreate (ethNetworkMainnet, account, accountTimestamp, mode, client, storagePath, 0, 6);
 
     
     char *address = ewmGetAccountPrimaryAddress(ewm);
@@ -910,12 +910,12 @@ runSyncTest (BREthereumNetwork network,
 extern void
 runEWMTests (const char *paperKey,
              const char *storagePath) {
-    installTokensForTestOnNetwork(ethereumMainnet);
+    installTokensForTestOnNetwork(ethNetworkMainnet);
     printf ("==== EWM\n");
     // prepareTransaction(NODE_PAPER_KEY, NODE_RECV_ADDR, TEST_TRANS2_GAS_PRICE_VALUE, GAS_LIMIT_DEFAULT, NODE_ETHER_AMOUNT);
     if (NULL == paperKey) paperKey = NODE_PAPER_KEY;
 
 //    runEWM_CONNECT_test(paperKey, storagePath);
     runEWM_TOKEN_test (paperKey, storagePath);
-    runEWM_PUBLIC_KEY_test (ethereumMainnet, paperKey, storagePath);
+    runEWM_PUBLIC_KEY_test (ethNetworkMainnet, paperKey, storagePath);
 }

--- a/ethereum/ewm/testEwm.c
+++ b/ethereum/ewm/testEwm.c
@@ -609,7 +609,7 @@ runEWM_CONNECT_test (const char *paperKey,
 
     balance = ewmWalletGetBalance (ewm, wallet);
     assert (AMOUNT_ETHER == balance.type);
-    assert (ETHEREUM_BOOLEAN_TRUE == etherIsEQ (amountGetEther(balance), etherCreateZero()));
+    assert (ETHEREUM_BOOLEAN_TRUE == etherIsEQ (ethAmountGetEther(balance), etherCreateZero()));
 
     // Immediately dispatches callbacks for WalletManager and Wallet events. Notable, wallet
     // create and a wallet update balance events.
@@ -622,8 +622,8 @@ runEWM_CONNECT_test (const char *paperKey,
     waitForBalance(client.context);
     balance = ewmWalletGetBalance (ewm, wallet);
     assert (AMOUNT_ETHER == balance.type);
-    assert (ETHEREUM_BOOLEAN_TRUE == etherIsEQ (amountGetEther(balance), etherCreateZero()) ||
-            ETHEREUM_BOOLEAN_TRUE == etherIsEQ (amountGetEther(balance), expectedBalance));
+    assert (ETHEREUM_BOOLEAN_TRUE == etherIsEQ (ethAmountGetEther(balance), etherCreateZero()) ||
+            ETHEREUM_BOOLEAN_TRUE == etherIsEQ (ethAmountGetEther(balance), expectedBalance));
 
     ewmConnect(ewm);
 
@@ -637,8 +637,8 @@ runEWM_CONNECT_test (const char *paperKey,
     //    ewmUpdateWalletBalance (ewm, wallet, &status);
 
     balance = ewmWalletGetBalance (ewm, wallet);
-    assert (AMOUNT_ETHER == amountGetType(balance));
-    assert (ETHEREUM_BOOLEAN_TRUE == etherIsEQ (expectedBalance, amountGetEther(balance)));
+    assert (AMOUNT_ETHER == ethAmountGetType(balance));
+    assert (ETHEREUM_BOOLEAN_TRUE == etherIsEQ (expectedBalance, ethAmountGetEther(balance)));
 
     //    ewmUpdateTransactions(ewm);
 

--- a/ethereum/ewm/testEwm.c
+++ b/ethereum/ewm/testEwm.c
@@ -739,9 +739,9 @@ testReallySend (const char *storagePath) {
     
     // A wallet amount Ether
     BREthereumWallet wallet = ewmGetWallet(ewm);
-    BREthereumAddress address = accountGetPrimaryAddress (account);
+    BREthereumAddress address = ethAccountGetPrimaryAddress (account);
     
-    accountSetAddressNonce(account, address, nonce, ETHEREUM_BOOLEAN_TRUE);
+    ethAccountSetAddressNonce(account, address, nonce, ETHEREUM_BOOLEAN_TRUE);
     
     // Optional - will provide listNodeWalletCreateTransactionDetailed.
     ewmWalletSetDefaultGasPrice(ewm, wallet, ethGasPriceCreate(etherCreateNumber(gasPrice, GWEI)));

--- a/ethereum/ewm/testEwm.c
+++ b/ethereum/ewm/testEwm.c
@@ -53,7 +53,7 @@ static BRSetOf(BREthereumToken) tokens;
 
 static BREthereumToken
 tokenLookupTestX (const char *address) {
-    BREthereumAddress addr = addressCreate(address);
+    BREthereumAddress addr = ethAddressCreate(address);
     return BRSetGet (tokens, &addr);
 }
 
@@ -702,8 +702,8 @@ void prepareTransaction (const char *paperKey,
     assert (NULL != transfers && NULL != transfers[0]);
     
     BREthereumTransfer transfer = transfers[0];
-    assert (0 == strcmp (fromAddr, addressGetEncodedString (ewmTransferGetSource(ewm, transfer), 1)) &&
-            0 == strcmp (recvAddr, addressGetEncodedString (ewmTransferGetTarget(ewm, transfer), 1)));
+    assert (0 == strcmp (fromAddr, ethAddressGetEncodedString (ewmTransferGetSource(ewm, transfer), 1)) &&
+            0 == strcmp (recvAddr, ethAddressGetEncodedString (ewmTransferGetTarget(ewm, transfer), 1)));
     
     free (fromAddr);
     ewmDestroy(ewm);

--- a/ethereum/ewm/testEwm.c
+++ b/ethereum/ewm/testEwm.c
@@ -63,14 +63,14 @@ installTokensForTestOnNetwork (BREthereumNetwork network) {
     if (!needInstall) return;
     needInstall = 0;
 
-    tokens = tokenSetCreate(10);
+    tokens = ethTokenSetCreate(10);
 
     BREthereumGas defaultGasLimit = ethGasCreate(TOKEN_BRD_DEFAULT_GAS_LIMIT);
     BREthereumGasPrice defaultGasPrice = ethGasPriceCreate(etherCreateNumber(TOKEN_BRD_DEFAULT_GAS_PRICE_IN_WEI_UINT64, WEI));
 
     BREthereumToken token;
 
-    token = tokenCreate (getTokenBRDAddress(network),
+    token = ethTokenCreate (getTokenBRDAddress(network),
                          "BRD",
                          "BRD Token",
                          "",
@@ -80,7 +80,7 @@ installTokensForTestOnNetwork (BREthereumNetwork network) {
     BRSetAdd (tokens, token);
 
 #if defined (BITCOIN_DEBUG)
-    token = tokenCreate (getTokenTSTAddress(network),
+    token = ethTokenCreate (getTokenTSTAddress(network),
                          "TST",
                          "Test Standard Token",
                          "TeST Standard Token (TST) for TeSTing (TST)",
@@ -90,7 +90,7 @@ installTokensForTestOnNetwork (BREthereumNetwork network) {
     BRSetAdd (tokens, token);
 
 #endif
-    token = tokenCreate ("0x86fa049857e0209aa7d9e616f7eb3b3b78ecfdb0",
+    token = ethTokenCreate ("0x86fa049857e0209aa7d9e616f7eb3b3b78ecfdb0",
                          "EOS",
                          "EOS Token",
                          "",
@@ -99,7 +99,7 @@ installTokensForTestOnNetwork (BREthereumNetwork network) {
                          defaultGasPrice);
     BRSetAdd (tokens, token);
 
-    token = tokenCreate ("0xdd974d5c2e2928dea5f71b9825b8b646686bd200",
+    token = ethTokenCreate ("0xdd974d5c2e2928dea5f71b9825b8b646686bd200",
                          "KNC",
                          "KNC token",
                          "",

--- a/ethereum/ewm/testEwm.c
+++ b/ethereum/ewm/testEwm.c
@@ -593,7 +593,7 @@ runEWM_CONNECT_test (const char *paperKey,
     client.context = testContextCreate();
 
     BREthereumAmount balance;
-    BREthereumEther expectedBalance = etherCreate(createUInt256Parse("0x123f", 16, &status));
+    BREthereumEther expectedBalance = etherCreate(uint256CreateParse("0x123f", 16, &status));
     assert (CORE_PARSE_OK == status);
 
     BREthereumEWM ewm = ewmCreateWithPaperKey (ethereumMainnet, paperKey, ETHEREUM_TIMESTAMP_UNKNOWN,

--- a/ethereum/ewm/testEwm.c
+++ b/ethereum/ewm/testEwm.c
@@ -66,7 +66,7 @@ installTokensForTestOnNetwork (BREthereumNetwork network) {
     tokens = ethTokenSetCreate(10);
 
     BREthereumGas defaultGasLimit = ethGasCreate(TOKEN_BRD_DEFAULT_GAS_LIMIT);
-    BREthereumGasPrice defaultGasPrice = ethGasPriceCreate(etherCreateNumber(TOKEN_BRD_DEFAULT_GAS_PRICE_IN_WEI_UINT64, WEI));
+    BREthereumGasPrice defaultGasPrice = ethGasPriceCreate(ethEtherCreateNumber(TOKEN_BRD_DEFAULT_GAS_PRICE_IN_WEI_UINT64, WEI));
 
     BREthereumToken token;
 
@@ -593,7 +593,7 @@ runEWM_CONNECT_test (const char *paperKey,
     client.context = testContextCreate();
 
     BREthereumAmount balance;
-    BREthereumEther expectedBalance = etherCreate(uint256CreateParse("0x123f", 16, &status));
+    BREthereumEther expectedBalance = ethEtherCreate(uint256CreateParse("0x123f", 16, &status));
     assert (CORE_PARSE_OK == status);
 
     BREthereumEWM ewm = ewmCreateWithPaperKey (ethNetworkMainnet, paperKey, ETHEREUM_TIMESTAMP_UNKNOWN,
@@ -609,7 +609,7 @@ runEWM_CONNECT_test (const char *paperKey,
 
     balance = ewmWalletGetBalance (ewm, wallet);
     assert (AMOUNT_ETHER == balance.type);
-    assert (ETHEREUM_BOOLEAN_TRUE == etherIsEQ (ethAmountGetEther(balance), etherCreateZero()));
+    assert (ETHEREUM_BOOLEAN_TRUE == ethEtherIsEQ (ethAmountGetEther(balance), ethEtherCreateZero()));
 
     // Immediately dispatches callbacks for WalletManager and Wallet events. Notable, wallet
     // create and a wallet update balance events.
@@ -622,8 +622,8 @@ runEWM_CONNECT_test (const char *paperKey,
     waitForBalance(client.context);
     balance = ewmWalletGetBalance (ewm, wallet);
     assert (AMOUNT_ETHER == balance.type);
-    assert (ETHEREUM_BOOLEAN_TRUE == etherIsEQ (ethAmountGetEther(balance), etherCreateZero()) ||
-            ETHEREUM_BOOLEAN_TRUE == etherIsEQ (ethAmountGetEther(balance), expectedBalance));
+    assert (ETHEREUM_BOOLEAN_TRUE == ethEtherIsEQ (ethAmountGetEther(balance), ethEtherCreateZero()) ||
+            ETHEREUM_BOOLEAN_TRUE == ethEtherIsEQ (ethAmountGetEther(balance), expectedBalance));
 
     ewmConnect(ewm);
 
@@ -638,7 +638,7 @@ runEWM_CONNECT_test (const char *paperKey,
 
     balance = ewmWalletGetBalance (ewm, wallet);
     assert (AMOUNT_ETHER == ethAmountGetType(balance));
-    assert (ETHEREUM_BOOLEAN_TRUE == etherIsEQ (expectedBalance, ethAmountGetEther(balance)));
+    assert (ETHEREUM_BOOLEAN_TRUE == ethEtherIsEQ (expectedBalance, ethAmountGetEther(balance)));
 
     //    ewmUpdateTransactions(ewm);
 
@@ -678,7 +678,7 @@ void prepareTransaction (const char *paperKey,
     // END - One Time Code Block
     
     // Optional - will provide listNodeWalletCreateTransactionDetailed.
-    ewmWalletSetDefaultGasPrice(ewm, wallet, ethGasPriceCreate(etherCreateNumber(gasPrice, GWEI)));
+    ewmWalletSetDefaultGasPrice(ewm, wallet, ethGasPriceCreate(ethEtherCreateNumber(gasPrice, GWEI)));
     ewmWalletSetDefaultGasLimit(ewm, wallet, ethGasCreate(gasLimit));
 
     BREthereumAmount amountAmountInEther =
@@ -744,7 +744,7 @@ testReallySend (const char *storagePath) {
     ethAccountSetAddressNonce(account, address, nonce, ETHEREUM_BOOLEAN_TRUE);
     
     // Optional - will provide listNodeWalletCreateTransactionDetailed.
-    ewmWalletSetDefaultGasPrice(ewm, wallet, ethGasPriceCreate(etherCreateNumber(gasPrice, GWEI)));
+    ewmWalletSetDefaultGasPrice(ewm, wallet, ethGasPriceCreate(ethEtherCreateNumber(gasPrice, GWEI)));
     ewmWalletSetDefaultGasLimit(ewm, wallet, ethGasCreate(gasLimit));
     
     BRCoreParseStatus status;

--- a/ethereum/les/BREthereumLES.c
+++ b/ethereum/les/BREthereumLES.c
@@ -164,7 +164,7 @@ nodeConfigDecode (BRRlpItem item,
     config->state    = nodeStateDecode (items[2], coder);
     config->priority = (BREthereumNodePriority) rlpDecodeUInt64(coder, items[3], 0);
 
-    config->hash = hashCreateFromData((BRRlpData) { 64, &config->key.pubKey[1] });
+    config->hash = ethHashCreateFromData((BRRlpData) { 64, &config->key.pubKey[1] });
 
     return config;
 }
@@ -180,7 +180,7 @@ nodeConfigCreate (BREthereumNode node) {
     config->state = nodeGetState(node, NODE_ROUTE_TCP);
     config->priority = nodeGetPriority (node);
 
-    config->hash = hashCreateFromData((BRRlpData) { 64, &config->key.pubKey[1] });
+    config->hash = ethHashCreateFromData((BRRlpData) { 64, &config->key.pubKey[1] });
 
     return config;
 }
@@ -195,12 +195,12 @@ nodeConfigCreateEndpoint (BREthereumNodeConfig config) {
 extern size_t
 nodeConfigHashValue (const void *t)
 {
-    return hashSetValue(&((BREthereumNodeConfig) t)->hash);
+    return ethHashSetValue(&((BREthereumNodeConfig) t)->hash);
 }
 
 extern int
 nodeConfigHashEqual (const void *t1, const void *t2) {
-    return t1 == t2 || hashSetEqual (&((BREthereumNodeConfig) t1)->hash,
+    return t1 == t2 || ethHashSetEqual (&((BREthereumNodeConfig) t1)->hash,
                                      &((BREthereumNodeConfig) t2)->hash);
 }
 

--- a/ethereum/les/BREthereumLES.c
+++ b/ethereum/les/BREthereumLES.c
@@ -599,7 +599,7 @@ lesCreate (BREthereumNetwork network,
     // preserved.
     nodeEndpointSetStatus (les->localEndpoint,
                            messageP2PStatusCreate (0x00,  // ignored
-                                                   networkGetChainId(network),
+                                                   ethNetworkGetChainId(network),
                                                    les->head.number,
                                                    les->head.hash,
                                                    les->head.totalDifficulty,
@@ -1051,8 +1051,8 @@ lesHandleSelectError (BREthereumLES les,
 static void
 lesSeedQueryAll (BREthereumLES les) {
     // Create nodes from our network seeds.
-    const char **seeds = networkGetSeeds (les->network);
-    size_t seedsCount  = networkGetSeedsCount(les->network);
+    const char **seeds = ethNetworkGetSeeds (les->network);
+    size_t seedsCount  = ethNetworkGetSeedsCount(les->network);
 
     for (size_t i = 0; i < seedsCount; i++) {
         BREthereumLESSeedContext context = { les, seeds[i],
@@ -1096,7 +1096,7 @@ lesThreadBootstrapSeeds (BREthereumLES les) {
         { NODE_TYPE_PARITY,  NODE_PRIORITY_LCL, networkGetEnodesLocal (les->network, 1) },
         { NODE_TYPE_GETH,    NODE_PRIORITY_LCL, networkGetEnodesLocal (les->network, 0) },
 #elif defined (LES_BOOTSTRAP_BRD_ONLY)
-        { NODE_TYPE_UNKNOWN, NODE_PRIORITY_BRD, networkGetEnodesBRD (les->network) },
+        { NODE_TYPE_UNKNOWN, NODE_PRIORITY_BRD, ethNetworkGetEnodesBRD (les->network) },
 #else
         { NODE_TYPE_UNKNOWN, NODE_PRIORITY_DIS, networkGetEnodesCommunity (les->network) },
 #endif

--- a/ethereum/les/BREthereumLESFrameCoder.c
+++ b/ethereum/les/BREthereumLESFrameCoder.c
@@ -524,22 +524,22 @@ extern int testFrameCoderInitiator(BREthereumLESFrameCoder fCoder) {
 
     //Check to ensure AES_SECRET is valid
     uint8_t aesSecret[32];
-    decodeHex(aesSecret, 32, AES_SECRET, 64);
+    hexDecode(aesSecret, 32, AES_SECRET, 64);
     assert(memcmp(aesSecret, fCoder->aesDecryptKey, 32) == 0);
 
     
     //MAC_SECRET
     uint8_t macSecret[32];
-    decodeHex(macSecret, 32, MAC_SECRET, 64);
+    hexDecode(macSecret, 32, MAC_SECRET, 64);
     assert(memcmp(macSecret, fCoder->macSecretKey.u8, 32) == 0);
 
     //TOKEN
     //uint8_t token[32];
-    //decodeHex(token, 32, TOKEN, 64);
+    //hexDecode(token, 32, TOKEN, 64);
     
     //INITIAL_EGRESS_MAC
     uint8_t initialEgressMac[32];
-    decodeHex(initialEgressMac, 32, INITIAL_EGRESS_MAC, 64);
+    hexDecode(initialEgressMac, 32, INITIAL_EGRESS_MAC, 64);
     uint8_t egressDigest[32];
     
     keccak_digest(fCoder->egressMac, egressDigest);
@@ -548,7 +548,7 @@ extern int testFrameCoderInitiator(BREthereumLESFrameCoder fCoder) {
 
     //INITIAL_INGRESS_MAC
     uint8_t initialIngressMac[32];
-    decodeHex(initialIngressMac, 32, INITIAL_INGRESS_MAC, 64);
+    hexDecode(initialIngressMac, 32, INITIAL_INGRESS_MAC, 64);
     uint8_t ingressDigest[32];
     keccak_digest(fCoder->ingressMac, ingressDigest);
     
@@ -560,22 +560,22 @@ extern int testFrameCoderReceiver(BREthereumLESFrameCoder fCoder) {
 
     //Check to ensure AES_SECRET is valid
     uint8_t aesSecret[32];
-    decodeHex(aesSecret, 32, AES_SECRET, 64);
+    hexDecode(aesSecret, 32, AES_SECRET, 64);
     assert(memcmp(aesSecret, fCoder->aesDecryptKey, 32) == 0);
 
     
     //MAC_SECRET
     uint8_t macSecret[32];
-    decodeHex(macSecret, 32, MAC_SECRET, 64);
+    hexDecode(macSecret, 32, MAC_SECRET, 64);
     assert(memcmp(macSecret, fCoder->macSecretKey.u8, 32) == 0);
 
     //TOKEN
     //uint8_t token[32];
-    //decodeHex(token, 32, TOKEN, 64);
+    //hexDecode(token, 32, TOKEN, 64);
     
     //INITIAL_EGRESS_MAC
     uint8_t initialEgressMac[32];
-    decodeHex(initialEgressMac, 32, INITIAL_INGRESS_MAC, 64);
+    hexDecode(initialEgressMac, 32, INITIAL_INGRESS_MAC, 64);
     uint8_t egressDigest[32];
     keccak_digest(fCoder->egressMac, egressDigest);
     assert(memcmp(initialEgressMac,egressDigest, 32) == 0);
@@ -583,7 +583,7 @@ extern int testFrameCoderReceiver(BREthereumLESFrameCoder fCoder) {
 
     //INITIAL_INGRESS_MAC
     uint8_t initialIngressMac[32];
-    decodeHex(initialIngressMac, 32, INITIAL_EGRESS_MAC, 64);
+    hexDecode(initialIngressMac, 32, INITIAL_EGRESS_MAC, 64);
     uint8_t ingressDigest[32];
     keccak_digest(fCoder->ingressMac , ingressDigest);
     assert(memcmp(initialIngressMac,ingressDigest, 32) == 0);

--- a/ethereum/les/BREthereumNode.c
+++ b/ethereum/les/BREthereumNode.c
@@ -2021,7 +2021,7 @@ nodeSend (BREthereumNode node,
             if ((MESSAGE_PIP == message.identifier && PIP_MESSAGE_RELAY_TRANSACTIONS == message.u.pip.type) ||
                 (MESSAGE_LES == message.identifier && LES_MESSAGE_SEND_TX2 == message.u.les.identifier) ||
                 (MESSAGE_LES == message.identifier && LES_MESSAGE_SEND_TX  == message.u.les.identifier))
-                rlpShowItem (node->coder.rlp, item, "SEND");
+                rlpItemShow (node->coder.rlp, item, "SEND");
 #endif
             
             // Extract the `items` bytes w/o the RLP length prefix.  We *know* the `item` is an
@@ -2041,7 +2041,7 @@ nodeSend (BREthereumNode node,
             break;
         }
     }
-    rlpReleaseItem (node->coder.rlp, item);
+    rlpItemRelease (node->coder.rlp, item);
 
 #if defined (NEED_TO_PRINT_SEND_RECV_DATA)
     if (!error)
@@ -2091,7 +2091,7 @@ nodeRecv (BREthereumNode node,
             message = messageDecode (item, node->coder,
                                      MESSAGE_DIS,
                                      MESSAGE_DIS_IDENTIFIER_ANY);
-            rlpReleaseItem (node->coder.rlp, item);
+            rlpItemRelease (node->coder.rlp, item);
             break;
         }
 
@@ -2152,7 +2152,7 @@ nodeRecv (BREthereumNode node,
 
             // Identifier is at byte[0]
             BRRlpData identifierData = { 1, &bytes[0] };
-            BRRlpItem identifierItem = rlpGetItem (node->coder.rlp, identifierData);
+            BRRlpItem identifierItem = rlpDataGetItem (node->coder.rlp, identifierData);
             uint8_t value = (uint8_t) rlpDecodeUInt64 (node->coder.rlp, identifierItem, 1);
 
             BREthereumMessageIdentifier type;
@@ -2162,7 +2162,7 @@ nodeRecv (BREthereumNode node,
 
             // Actual body
             BRRlpData data = { headerCount - 1, &bytes[1] };
-            BRRlpItem item = rlpGetItem (node->coder.rlp, data);
+            BRRlpItem item = rlpDataGetItem (node->coder.rlp, data);
 
 #if defined (NEED_TO_PRINT_SEND_RECV_DATA)
             eth_log (LES_LOG_TOPIC, "Size: Recv: TCP: Type: %u, Subtype: %d", type, subtype);
@@ -2183,8 +2183,8 @@ nodeRecv (BREthereumNode node,
                 messageLESHasUse (&message.u.les, LES_MESSAGE_USE_RESPONSE))
                 node->credits = messageLESGetCredits (&message.u.les);
             
-            rlpReleaseItem (node->coder.rlp, item);
-            rlpReleaseItem (node->coder.rlp, identifierItem);
+            rlpItemRelease (node->coder.rlp, item);
+            rlpItemRelease (node->coder.rlp, identifierItem);
 
             break;
         }

--- a/ethereum/les/BREthereumNode.c
+++ b/ethereum/les/BREthereumNode.c
@@ -555,7 +555,7 @@ nodeGetLocalEndpoint (BREthereumNode node) {
 static BREthereumComparison
 nodeNeighborCompare (BREthereumNode n1,
                      BREthereumNode n2) {
-    switch (compareUInt256 (n1->distance, n2->distance)) {
+    switch (uint256Compare (n1->distance, n2->distance)) {
         case -1: return ETHEREUM_COMPARISON_LT;
         case  0: return ETHEREUM_COMPARISON_EQ;
         case +1: return ETHEREUM_COMPARISON_GT;

--- a/ethereum/les/BREthereumNode.c
+++ b/ethereum/les/BREthereumNode.c
@@ -628,13 +628,13 @@ nodeSetStateErrorProtocol (BREthereumNode node,
 // Support BRSet
 extern size_t
 nodeHashValue (const void *h) {
-    return hashSetValue(&((BREthereumNode) h)->hash);
+    return ethHashSetValue(&((BREthereumNode) h)->hash);
 }
 
 // Support BRSet
 extern int
 nodeHashEqual (const void *h1, const void *h2) {
-    return h1 == h2 || hashSetEqual (&((BREthereumNode) h1)->hash,
+    return h1 == h2 || ethHashSetEqual (&((BREthereumNode) h1)->hash,
                                      &((BREthereumNode) h2)->hash);
 }
 

--- a/ethereum/les/BREthereumNodeEndpoint.c
+++ b/ethereum/les/BREthereumNodeEndpoint.c
@@ -173,7 +173,7 @@ nodeEndpointCreateEnode (const char *enode) {
     memset (&key, 0, sizeof(BRKey));
     key.pubKey[0] = 0x04;
     key.compressed = 0;
-    decodeHex(&key.pubKey[1], 64, id, 128);
+    hexDecode(&key.pubKey[1], 64, id, 128);
 
     return nodeEndpointCreate((BREthereumDISNeighbor) { disEndpoint, key });
 }
@@ -464,7 +464,7 @@ nodeEndpointSendData (BREthereumNodeEndpoint endpoint,
 #if defined (NEED_TO_PRINT_SEND_DATA)
     {
         char hex[1 + 2 * bytesCount];
-        encodeHex(hex, 1 + 2 * bytesCount, bytes, bytesCount);
+        hexEncode(hex, 1 + 2 * bytesCount, bytes, bytesCount);
         printf ("Bytes: %s\n", hex);
     }
 #endif

--- a/ethereum/les/BREthereumNodeEndpoint.c
+++ b/ethereum/les/BREthereumNodeEndpoint.c
@@ -238,13 +238,13 @@ nodeEndpointGetNonce (BREthereumNodeEndpoint endpoint) {
 // Support BRSet
 extern size_t
 nodeEndpointHashValue (const void *h) {
-    return hashSetValue(&((BREthereumNodeEndpoint) h)->hash);
+    return ethHashSetValue(&((BREthereumNodeEndpoint) h)->hash);
 }
 
 // Support BRSet
 extern int
 nodeEndpointHashEqual (const void *h1, const void *h2) {
-    return h1 == h2 || hashSetEqual (&((BREthereumNodeEndpoint) h1)->hash,
+    return h1 == h2 || ethHashSetEqual (&((BREthereumNodeEndpoint) h1)->hash,
                                      &((BREthereumNodeEndpoint) h2)->hash);
 }
 

--- a/ethereum/les/BREthereumProvision.c
+++ b/ethereum/les/BREthereumProvision.c
@@ -350,7 +350,7 @@ provisionHandleMessageLES (BREthereumProvision *provisionMulti,
 
                     if (ETHEREUM_BOOLEAN_IS_TRUE (isValid)) {
                         // When valid extract [hash, totalDifficulty] from the MPT proof's value
-                        BRRlpItem item = rlpGetItem(coder, data);
+                        BRRlpItem item = rlpDataGetItem(coder, data);
 
                         size_t itemsCount = 0;
                         const BRRlpItem *items = rlpDecodeList (coder, item, &itemsCount);
@@ -359,7 +359,7 @@ provisionHandleMessageLES (BREthereumProvision *provisionMulti,
                         proof->hash = hashRlpDecode(items[0], coder);
                         proof->totalDifficulty = rlpDecodeUInt256 (coder, items[1], 1);
 
-                        rlpReleaseItem(coder, item);
+                        rlpItemRelease(coder, item);
                         rlpDataRelease(data);
                     }
                     else {
@@ -453,9 +453,9 @@ provisionHandleMessageLES (BREthereumProvision *provisionMulti,
                     BREthereumBoolean foundValue = ETHEREUM_BOOLEAN_FALSE;
                     BRRlpData data = mptNodePathGetValue (path, key, &foundValue);
                     if (ETHEREUM_BOOLEAN_IS_TRUE(foundValue)) {
-                        BRRlpItem item = rlpGetItem (coder, data);
+                        BRRlpItem item = rlpDataGetItem (coder, data);
                         provisionAccounts[offset + index] = accountStateRlpDecode (item, coder);
-                        rlpReleaseItem (coder, item);
+                        rlpItemRelease (coder, item);
                     }
                     else provisionAccounts[offset + index] = accountStateCreateEmpty();
                     rlpDataRelease(data);
@@ -805,7 +805,7 @@ provisionHandleMessagePIP (BREthereumProvision *provisionMulti,
 
                     // The MPT 'key' is the RLP encoding of the block number
                     BRRlpItem item = rlpEncodeUInt64(coder, provision->numbers[index], 0);
-                    BRRlpData data = rlpGetDataSharedDontRelease (coder, item);
+                    BRRlpData data = rlpItemGetDataSharedDontRelease (coder, item);
                     BREthereumData key = { data.bytesCount, data.bytes };
 
                     BREthereumMPTNodePath path; // = outputs[index].u.headerProof.path;
@@ -821,7 +821,7 @@ provisionHandleMessagePIP (BREthereumProvision *provisionMulti,
                         provisionProofs[offset + index].totalDifficulty = UINT256_ZERO;
                     }
 
-                    rlpReleaseItem (coder, item);
+                    rlpItemRelease (coder, item);
                     mptNodePathRelease (path);
                 }
                 rlpCoderRelease(coder);

--- a/ethereum/les/BREthereumProvision.c
+++ b/ethereum/les/BREthereumProvision.c
@@ -356,7 +356,7 @@ provisionHandleMessageLES (BREthereumProvision *provisionMulti,
                         const BRRlpItem *items = rlpDecodeList (coder, item, &itemsCount);
                         assert (2 == itemsCount);
 
-                        proof->hash = hashRlpDecode(items[0], coder);
+                        proof->hash = ethHashRlpDecode(items[0], coder);
                         proof->totalDifficulty = rlpDecodeUInt256 (coder, items[1], 1);
 
                         rlpItemRelease(coder, item);
@@ -1043,7 +1043,7 @@ provisionCopy (BREthereumProvision *provision,
                 provision->identifier,
                 provision->type,
                 { .bodies = {
-                    hashesCopy(provision->u.bodies.hashes),
+                    ethHashesCopy(provision->u.bodies.hashes),
                     NULL }}
             };
 
@@ -1052,7 +1052,7 @@ provisionCopy (BREthereumProvision *provision,
                 provision->identifier,
                 provision->type,
                 { .receipts = {
-                    hashesCopy(provision->u.receipts.hashes),
+                    ethHashesCopy(provision->u.receipts.hashes),
                     NULL }}
             };
 
@@ -1062,7 +1062,7 @@ provisionCopy (BREthereumProvision *provision,
                 provision->type,
                 { .accounts = {
                     provision->u.accounts.address,
-                    hashesCopy(provision->u.accounts.hashes),
+                    ethHashesCopy(provision->u.accounts.hashes),
                     NULL }}
             };
 
@@ -1071,7 +1071,7 @@ provisionCopy (BREthereumProvision *provision,
                 provision->identifier,
                 provision->type,
                 { .statuses = {
-                    hashesCopy(provision->u.statuses.hashes),
+                    ethHashesCopy(provision->u.statuses.hashes),
                     NULL }}
             };
 

--- a/ethereum/les/BREthereumProvision.c
+++ b/ethereum/les/BREthereumProvision.c
@@ -893,7 +893,7 @@ provisionHandleMessagePIP (BREthereumProvision *provisionMulti,
                     assert (PIP_REQUEST_ACCOUNT == outputs[index].identifier);
                     provisionAccounts[offset + index] =
                     accountStateCreate (outputs[index].u.account.nonce,
-                                        etherCreate(outputs[index].u.account.balance),
+                                        ethEtherCreate(outputs[index].u.account.balance),
                                         outputs[index].u.account.storageRootHash,
                                         outputs[index].u.account.codeHash);
                 }

--- a/ethereum/les/BREthereumProvision.c
+++ b/ethereum/les/BREthereumProvision.c
@@ -940,7 +940,7 @@ provisionHandleMessagePIP (BREthereumProvision *provisionMulti,
                                                      outputs[index].u.transactionIndex.blockNumber,
                                                      outputs[index].u.transactionIndex.transactionIndex,
                                                      TRANSACTION_STATUS_BLOCK_TIMESTAMP_UNKNOWN,
-                                                     gasCreate(0));
+                                                     ethGasCreate(0));
 
                 }
             }
@@ -966,7 +966,7 @@ provisionHandleMessagePIP (BREthereumProvision *provisionMulti,
                                                      outputs[0].u.transactionIndex.blockNumber,
                                                      outputs[0].u.transactionIndex.transactionIndex,
                                                      TRANSACTION_STATUS_BLOCK_TIMESTAMP_UNKNOWN,
-                                                     gasCreate (0));
+                                                     ethGasCreate (0));
                     break;
 
                 default:

--- a/ethereum/les/BREthereumProvision.c
+++ b/ethereum/les/BREthereumProvision.c
@@ -366,7 +366,7 @@ provisionHandleMessageLES (BREthereumProvision *provisionMulti,
                         proof->hash = EMPTY_HASH_INIT;
                         proof->totalDifficulty = UINT256_ZERO;
                     }
-                    dataRelease(key);
+                    ethDataRelease(key);
                 }
                 rlpCoderRelease(coder);
             }

--- a/ethereum/les/BREthereumProvision.c
+++ b/ethereum/les/BREthereumProvision.c
@@ -422,7 +422,7 @@ provisionHandleMessageLES (BREthereumProvision *provisionMulti,
         case PROVISION_ACCOUNTS: {
             assert (LES_MESSAGE_PROOFS == message.identifier);
             BREthereumProvisionAccounts *provision = &provisionMulti->u.accounts;
-            BREthereumHash hash = addressGetHash(provision->address);
+            BREthereumHash hash = ethAddressGetHash(provision->address);
             BREthereumData key  = { sizeof(BREthereumHash), hash.bytes };
 
             // We'll fill this - at the proper index if a multiple provision.
@@ -639,7 +639,7 @@ provisionCreateMessagePIP (BREthereumProvision *provisionMulti,
         case PROVISION_ACCOUNTS: {
             BREthereumProvisionAccounts *provision = &provisionMulti->u.accounts;
 
-            BREthereumHash addressHash = addressGetHash(provision->address);
+            BREthereumHash addressHash = ethAddressGetHash(provision->address);
             BRArrayOf(BREthereumHash) hashes = provision->hashes;
             size_t hashesCount = array_count(hashes);
 

--- a/ethereum/les/msg/BREthereumMessageDIS.c
+++ b/ethereum/les/msg/BREthereumMessageDIS.c
@@ -491,7 +491,7 @@ messageDISEncode (BREthereumDISMessage message,
     // Compute the signature over (identifier || data)
     size_t signatureSize = 65;
     BRRlpData signatureData = { 1 + data.bytesCount, (uint8_t *) &packet->identifier };
-    packet->signature = signatureCreate (SIGNATURE_TYPE_RECOVERABLE_RSV,
+    packet->signature = ethSignatureCreate (SIGNATURE_TYPE_RECOVERABLE_RSV,
                                          signatureData.bytes, signatureData.bytesCount,
                                          key).sig.rsv;
 

--- a/ethereum/les/msg/BREthereumMessageDIS.c
+++ b/ethereum/les/msg/BREthereumMessageDIS.c
@@ -196,7 +196,7 @@ neighborDISAsEnode (BREthereumDISNeighbor neighbor,
     BREthereumDISNeighborEnode enode = { '\0' };
 
     char nodeID [129];
-    encodeHex(nodeID, 129, &neighbor.key.pubKey[1], 64);
+    hexEncode(nodeID, 129, &neighbor.key.pubKey[1], 64);
 
     char IP [39];
     if (neighbor.node.domain == AF_INET)
@@ -502,12 +502,12 @@ messageDISEncode (BREthereumDISMessage message,
 #if defined (NEED_TO_PRINT_DIS_HEADER_DETAILS)
     {
         size_t ignore;
-        printf ("DATA     : %s\n", encodeHexCreate(&ignore, data.bytes, data.bytesCount));
-        printf ("SIG      : %s\n", encodeHexCreate(&ignore, (uint8_t*) &packet->signature, 65));
+        printf ("DATA     : %s\n", hexEncodeCreate(&ignore, data.bytes, data.bytesCount));
+        printf ("SIG      : %s\n", hexEncodeCreate(&ignore, (uint8_t*) &packet->signature, 65));
 
-        printf ("HASH DATA: %s\n", encodeHexCreate(&ignore, hashData.bytes, hashData.bytesCount));
+        printf ("HASH DATA: %s\n", hexEncodeCreate(&ignore, hashData.bytes, hashData.bytesCount));
         printf ("HASH RSLT: %s\n", hashAsString(packet->hash));
-        printf ("PACKET: %s\n", encodeHexCreate(&ignore, packetMemory, packetSize));
+        printf ("PACKET: %s\n", hexEncodeCreate(&ignore, packetMemory, packetSize));
     }
 #endif
     rlpReleaseItem(coder.rlp, bodyItem);

--- a/ethereum/les/msg/BREthereumMessageDIS.c
+++ b/ethereum/les/msg/BREthereumMessageDIS.c
@@ -165,7 +165,7 @@ neighborDISDecode (BRRlpItem item, BREthereumMessageCoder coder) {
 extern BREthereumHash
 neighborDISHash (BREthereumDISNeighbor neighbor) {
     BRRlpData data = { sizeof (BREthereumDISNeighbor), (uint8_t *) &neighbor };
-    return hashCreateFromData(data);
+    return ethHashCreateFromData(data);
 }
 
 extern UInt256
@@ -182,8 +182,8 @@ neighborDISDistance (BREthereumDISNeighbor n1,
     memcpy (val2.u8, &n2.key.pubKey[1], 64);
 
     // This hash is a 'Keccak256' hash.
-    BREthereumHash hash1 = hashCreateFromData((BRRlpData) { 64, val1.u8});
-    BREthereumHash hash2 = hashCreateFromData((BRRlpData) { 64, val2.u8});
+    BREthereumHash hash1 = ethHashCreateFromData((BRRlpData) { 64, val1.u8});
+    BREthereumHash hash2 = ethHashCreateFromData((BRRlpData) { 64, val2.u8});
 
     return uint256Bitwise (INT_BITWISE_XOR,
                            (UInt256*) hash1.bytes,
@@ -280,7 +280,7 @@ static BRRlpItem
 messageDISPongEncode (BREthereumDISMessagePong message, BREthereumMessageCoder coder) {
     return rlpEncodeList (coder.rlp, 3,
                           endpointDISEncode (&message.to, coder.rlp),
-                          hashRlpEncode (message.pingHash, coder.rlp),
+                          ethHashRlpEncode (message.pingHash, coder.rlp),
                           rlpEncodeUInt64 (coder.rlp, message.expiration, 1));
 }
 
@@ -293,7 +293,7 @@ messageDISPongDecode (BRRlpItem item, BREthereumMessageCoder coder, int releaseI
     if (3 != itemsCount) rlpCoderSetFailed(coder.rlp);
     else {
         pong.to = endpointDISDecode (items[0], coder.rlp);
-        pong.pingHash = hashRlpDecode (items[1], coder.rlp);
+        pong.pingHash = ethHashRlpDecode (items[1], coder.rlp);
         pong.expiration = rlpDecodeUInt64 (coder.rlp, items[2], 1);
     }
 
@@ -497,7 +497,7 @@ messageDISEncode (BREthereumDISMessage message,
 
     // Compute the hash over ( signature || identifier || data )
     BRRlpData hashData = { signatureSize + 1 + data.bytesCount, (uint8_t*) &packet->signature };
-    packet->hash = hashCreateFromData (hashData);
+    packet->hash = ethHashCreateFromData (hashData);
 
 #if defined (NEED_TO_PRINT_DIS_HEADER_DETAILS)
     {

--- a/ethereum/les/msg/BREthereumMessageDIS.c
+++ b/ethereum/les/msg/BREthereumMessageDIS.c
@@ -263,7 +263,7 @@ messageDISPingDecode (BRRlpItem item, BREthereumMessageCoder coder, BREthereumHa
 
         ping.hash = hash;
     }
-    if (releaseItem) rlpReleaseItem (coder.rlp, item);
+    if (releaseItem) rlpItemRelease (coder.rlp, item);
     return ping;
 }
 
@@ -297,7 +297,7 @@ messageDISPongDecode (BRRlpItem item, BREthereumMessageCoder coder, int releaseI
         pong.expiration = rlpDecodeUInt64 (coder.rlp, items[2], 1);
     }
 
-    if (releaseItem) rlpReleaseItem (coder.rlp, item);
+    if (releaseItem) rlpItemRelease (coder.rlp, item);
     return pong;
 }
 
@@ -354,7 +354,7 @@ messageDISNeighborsDecode (BRRlpItem item, BREthereumMessageCoder coder, int rel
         message.expiration = rlpDecodeUInt64 (coder.rlp, items[1], 1);
     }
 
-    if (releaseItem) rlpReleaseItem (coder.rlp, item);
+    if (releaseItem) rlpItemRelease (coder.rlp, item);
 
     return message;
 }
@@ -408,7 +408,7 @@ messageDISDecode (BRRlpItem item,
 
     // Get the rlpItem from packet->data
     BRRlpData messageData = { packetData.bytesCount - packetSize, &packetData.bytes[packetSize] };
-    BRRlpItem messageItem = rlpGetItem (coder.rlp, messageData);
+    BRRlpItem messageItem = rlpDataGetItem (coder.rlp, messageData);
 
     switch (identifier) {
         case DIS_MESSAGE_PONG:
@@ -461,7 +461,7 @@ messageDISEncode (BREthereumDISMessage message,
     }
     BRKey key = message.privateKeyForSigning;
 
-    BRRlpData data = rlpGetDataSharedDontRelease (coder.rlp, bodyItem);
+    BRRlpData data = rlpItemGetDataSharedDontRelease (coder.rlp, bodyItem);
 
     // We are producing a 'packet' which as described above is a concatenation of a header and
     // data where the header IS NOT rlp encoded but the data IS rlp encoded.  We will take the
@@ -510,7 +510,7 @@ messageDISEncode (BREthereumDISMessage message,
         printf ("PACKET: %s\n", hexEncodeCreate(&ignore, packetMemory, packetSize));
     }
 #endif
-    rlpReleaseItem(coder.rlp, bodyItem);
+    rlpItemRelease(coder.rlp, bodyItem);
 
     // Now, finally, `packet` and `packetMemory` are complete.
     return rlpEncodeBytes (coder.rlp, packetMemory, packetSize);

--- a/ethereum/les/msg/BREthereumMessageLES.c
+++ b/ethereum/les/msg/BREthereumMessageLES.c
@@ -183,7 +183,7 @@ messageLESAnnounceDecode (BRRlpItem item,
     const BRRlpItem *items = rlpDecodeList(coder.rlp, item, &itemsCount);
     assert (5 == itemsCount || 4 == itemsCount);
 
-    message.headHash = hashRlpDecode (items[0], coder.rlp);
+    message.headHash = ethHashRlpDecode (items[0], coder.rlp);
     message.headNumber = rlpDecodeUInt64 (coder.rlp, items[1], 1);
     message.headTotalDifficulty = rlpDecodeUInt256 (coder.rlp, items[2], 1);
     message.reorgDepth = rlpDecodeUInt64 (coder.rlp, items[3], 1);
@@ -228,7 +228,7 @@ messageLESGetBlockHeadersEncode (BREthereumLESMessageGetBlockHeaders message,
                            rlpEncodeList (coder.rlp, 4,
                                           (message.useBlockNumber
                                            ? rlpEncodeUInt64 (coder.rlp, message.block.number, 1)
-                                           : hashRlpEncode (message.block.hash, coder.rlp)),
+                                           : ethHashRlpEncode (message.block.hash, coder.rlp)),
                                           rlpEncodeUInt64 (coder.rlp, message.maxHeaders, 1),
                                           rlpEncodeUInt64 (coder.rlp, message.skip, 1),
                                           rlpEncodeUInt64 (coder.rlp, message.reverse, 1)));
@@ -279,7 +279,7 @@ static BRRlpItem
 messageLESGetBlockBodiesEncode (BREthereumLESMessageGetBlockBodies message, BREthereumMessageCoder coder) {
     return rlpEncodeList2 (coder.rlp,
                            rlpEncodeUInt64 (coder.rlp, message.reqId, 1),
-                           hashEncodeList (message.hashes, coder.rlp));
+                           ethHashEncodeList (message.hashes, coder.rlp));
 }
 
 /// MARK: LES BlockBodies
@@ -329,7 +329,7 @@ static BRRlpItem
 messageLESGetReceiptsEncode (BREthereumLESMessageGetReceipts message, BREthereumMessageCoder coder) {
     return rlpEncodeList2 (coder.rlp,
                            rlpEncodeUInt64 (coder.rlp, message.reqId, 1),
-                           hashEncodeList (message.hashes, coder.rlp));
+                           ethHashEncodeList (message.hashes, coder.rlp));
 }
 
 /// MARK: LES Receipts
@@ -374,9 +374,9 @@ static BRRlpItem
 proofsSpecEncode (BREthereumLESMessageGetProofsSpec spec,
                   BREthereumMessageCoder coder) {
     return rlpEncodeList (coder.rlp, 4,
-                          hashRlpEncode (spec.blockHash, coder.rlp),
+                          ethHashRlpEncode (spec.blockHash, coder.rlp),
                           rlpEncodeBytes(coder.rlp, NULL, 0),
-                          hashRlpEncode(addressGetHash(spec.address), coder.rlp),
+                          ethHashRlpEncode(addressGetHash(spec.address), coder.rlp),
                           rlpEncodeUInt64 (coder.rlp, spec.fromLevel, 1));
 }
 
@@ -596,7 +596,7 @@ static BRRlpItem
 messageLESGetTxStatusEncode (BREthereumLESMessageGetTxStatus message, BREthereumMessageCoder coder) {
     return rlpEncodeList2 (coder.rlp,
                            rlpEncodeUInt64 (coder.rlp, message.reqId, 1),
-                           hashEncodeList (message.hashes, coder.rlp));
+                           ethHashEncodeList (message.hashes, coder.rlp));
 }
 
 /// MARK: LES TxStatus

--- a/ethereum/les/msg/BREthereumMessageLES.c
+++ b/ethereum/les/msg/BREthereumMessageLES.c
@@ -376,7 +376,7 @@ proofsSpecEncode (BREthereumLESMessageGetProofsSpec spec,
     return rlpEncodeList (coder.rlp, 4,
                           ethHashRlpEncode (spec.blockHash, coder.rlp),
                           rlpEncodeBytes(coder.rlp, NULL, 0),
-                          ethHashRlpEncode(addressGetHash(spec.address), coder.rlp),
+                          ethHashRlpEncode(ethAddressGetHash(spec.address), coder.rlp),
                           rlpEncodeUInt64 (coder.rlp, spec.fromLevel, 1));
 }
 

--- a/ethereum/les/msg/BREthereumMessageP2P.c
+++ b/ethereum/les/msg/BREthereumMessageP2P.c
@@ -117,7 +117,7 @@ extern void
 messageP2PHelloShow (const BREthereumP2PMessageHello *hello) {
     size_t nodeIdLen = 2 * sizeof (hello->nodeId.u8) + 1;
     char nodeId[nodeIdLen];
-    encodeHex(nodeId, nodeIdLen, hello->nodeId.u8, sizeof (hello->nodeId.u8));
+    hexEncode(nodeId, nodeIdLen, hello->nodeId.u8, sizeof (hello->nodeId.u8));
 
     eth_log (LES_LOG_TOPIC, "Hello%s", "");
     eth_log (LES_LOG_TOPIC, "    Version     : %" PRIu64, hello->version);

--- a/ethereum/les/msg/BREthereumMessageP2P.c
+++ b/ethereum/les/msg/BREthereumMessageP2P.c
@@ -335,8 +335,8 @@ messageP2PStatusExtractValue (BREthereumP2PMessageStatus *status,
 extern void
 messageP2PStatusShow(BREthereumP2PMessageStatus *message) {
     BREthereumHashString headHashString, genesisHashString;
-    hashFillString (message->headHash, headHashString);
-    hashFillString (message->genesisHash, genesisHashString);
+    ethHashFillString (message->headHash, headHashString);
+    ethHashFillString (message->genesisHash, genesisHashString);
 
     char *headTotalDifficulty = uint256CoerceString (message->headTd, 10);
 
@@ -413,7 +413,7 @@ messageP2PStatusEncode (BREthereumP2PMessageStatus *status,
 
     items[index++] = rlpEncodeList2(coder.rlp,
                                     rlpEncodeString(coder.rlp, "headHash"),
-                                    hashRlpEncode(status->headHash, coder.rlp));
+                                    ethHashRlpEncode(status->headHash, coder.rlp));
 
     items[index++] = rlpEncodeList2(coder.rlp,
                                     rlpEncodeString(coder.rlp, "headNum"),
@@ -421,7 +421,7 @@ messageP2PStatusEncode (BREthereumP2PMessageStatus *status,
 
     items[index++] = rlpEncodeList2 (coder.rlp,
                                      rlpEncodeString(coder.rlp, "genesisHash"),
-                                     hashRlpEncode(status->genesisHash, coder.rlp));
+                                     ethHashRlpEncode(status->genesisHash, coder.rlp));
 
     for (size_t pi = 0; NULL != status->pairs && pi < array_count(status->pairs); pi++) { // Pair-Index
         BREthereumP2PMessageStatusKeyValuePair *pair = &status->pairs[pi];
@@ -523,13 +523,13 @@ messageP2PStatusDecode (BRRlpItem item,
                 status.headTd = rlpDecodeUInt256(coder.rlp, keyPairs[1], 1);
             }
             else if (strcmp(key, "headHash") == 0) {
-                status.headHash = hashRlpDecode(keyPairs[1], coder.rlp);
+                status.headHash = ethHashRlpDecode(keyPairs[1], coder.rlp);
             }
             else if (strcmp(key, "headNum") == 0) {
                 status.headNum = rlpDecodeUInt64(coder.rlp, keyPairs[1], 1);
             }
             else if (strcmp(key, "genesisHash") == 0) {
-                status.genesisHash = hashRlpDecode(keyPairs[1], coder.rlp);
+                status.genesisHash = ethHashRlpDecode(keyPairs[1], coder.rlp);
             }
             // Optional
 

--- a/ethereum/les/msg/BREthereumMessageP2P.c
+++ b/ethereum/les/msg/BREthereumMessageP2P.c
@@ -338,7 +338,7 @@ messageP2PStatusShow(BREthereumP2PMessageStatus *message) {
     hashFillString (message->headHash, headHashString);
     hashFillString (message->genesisHash, genesisHashString);
 
-    char *headTotalDifficulty = coerceString (message->headTd, 10);
+    char *headTotalDifficulty = uint256CoerceString (message->headTd, 10);
 
     BREthereumP2PMessageStatusValue value;
 

--- a/ethereum/les/msg/BREthereumMessagePIP.c
+++ b/ethereum/les/msg/BREthereumMessagePIP.c
@@ -109,7 +109,7 @@ messagePIPAnnounceDecode (BRRlpItem item,
     const BRRlpItem *items = rlpDecodeList(coder.rlp, item, &itemsCount);
     if (5 != itemsCount && 4 != itemsCount) rlpCoderSetFailed (coder.rlp);
     else {
-        message.headHash = hashRlpDecode (items[0], coder.rlp);
+        message.headHash = ethHashRlpDecode (items[0], coder.rlp);
         message.headNumber = rlpDecodeUInt64 (coder.rlp, items[1], 1);
         message.headTotalDifficulty = rlpDecodeUInt256 (coder.rlp, items[2], 1);
         message.reorgDepth = rlpDecodeUInt64 (coder.rlp, items[3], 1);
@@ -146,7 +146,7 @@ messagePIPRequestInputEncode (BREthereumPIPRequestInput input,
                                   loose(coder.rlp, 0,
                                         (input.u.headers.useBlockNumber
                                          ? rlpEncodeUInt64 (coder.rlp, input.u.headers.block.number, 1)
-                                         : hashRlpEncode (input.u.headers.block.hash, coder.rlp))),
+                                         : ethHashRlpEncode (input.u.headers.block.hash, coder.rlp))),
                                   rlpEncodeUInt64 (coder.rlp, input.u.headers.skip, 1),
                                   rlpEncodeUInt64 (coder.rlp, input.u.headers.max, 1),
                                   rlpEncodeUInt64 (coder.rlp, ETHEREUM_BOOLEAN_IS_TRUE (input.u.headers.reverse), 1));
@@ -159,36 +159,36 @@ messagePIPRequestInputEncode (BREthereumPIPRequestInput input,
             
         case PIP_REQUEST_TRANSACTION_INDEX:
             item = rlpEncodeList1 (coder.rlp,
-                                   loose (coder.rlp, 0, hashRlpEncode (input.u.transactionIndex.transactionHash, coder.rlp)));
+                                   loose (coder.rlp, 0, ethHashRlpEncode (input.u.transactionIndex.transactionHash, coder.rlp)));
             break;
             
         case PIP_REQUEST_BLOCK_RECEIPTS:
             item = rlpEncodeList1 (coder.rlp,
-                                   loose (coder.rlp, 0, hashRlpEncode (input.u.blockReceipt.blockHash, coder.rlp)));
+                                   loose (coder.rlp, 0, ethHashRlpEncode (input.u.blockReceipt.blockHash, coder.rlp)));
             break;
             
         case PIP_REQUEST_BLOCK_BODY:
             item = rlpEncodeList1 (coder.rlp,
-                                   loose (coder.rlp, 0, hashRlpEncode (input.u.blockBody.blockHash, coder.rlp)));
+                                   loose (coder.rlp, 0, ethHashRlpEncode (input.u.blockBody.blockHash, coder.rlp)));
             break;
             
         case PIP_REQUEST_ACCOUNT:
             item = rlpEncodeList2 (coder.rlp,
-                                   loose (coder.rlp, 0, hashRlpEncode (input.u.account.blockHash, coder.rlp)),
-                                   loose (coder.rlp, 0, hashRlpEncode (input.u.account.addressHash, coder.rlp)));
+                                   loose (coder.rlp, 0, ethHashRlpEncode (input.u.account.blockHash, coder.rlp)),
+                                   loose (coder.rlp, 0, ethHashRlpEncode (input.u.account.addressHash, coder.rlp)));
             break;
             
         case PIP_REQUEST_STORAGE:
             item = rlpEncodeList (coder.rlp, 3,
-                                  loose (coder.rlp, 0, hashRlpEncode (input.u.storage.blockHash, coder.rlp)),
-                                  loose (coder.rlp, 0, hashRlpEncode (input.u.storage.addressHash, coder.rlp)),
-                                  loose (coder.rlp, 0, hashRlpEncode (input.u.storage.storageRootHash, coder.rlp)));
+                                  loose (coder.rlp, 0, ethHashRlpEncode (input.u.storage.blockHash, coder.rlp)),
+                                  loose (coder.rlp, 0, ethHashRlpEncode (input.u.storage.addressHash, coder.rlp)),
+                                  loose (coder.rlp, 0, ethHashRlpEncode (input.u.storage.storageRootHash, coder.rlp)));
             break;
             
         case PIP_REQUEST_CODE:
             item = rlpEncodeList2 (coder.rlp,
-                                   loose (coder.rlp, 0, hashRlpEncode (input.u.code.blockHash, coder.rlp)),
-                                   loose (coder.rlp, 0, hashRlpEncode (input.u.code.codeHash, coder.rlp)));
+                                   loose (coder.rlp, 0, ethHashRlpEncode (input.u.code.blockHash, coder.rlp)),
+                                   loose (coder.rlp, 0, ethHashRlpEncode (input.u.code.codeHash, coder.rlp)));
             break;
             
         case PIP_REQUEST_EXECUTION:
@@ -288,7 +288,7 @@ messagePIPRequestOutputDecode (BRRlpItem item,
                 PIP_REQUEST_HEADER_PROOF,
                 { .headerProof = {
                     path,
-                    hashRlpDecode(outputItems[1], coder.rlp),
+                    ethHashRlpDecode(outputItems[1], coder.rlp),
                     rlpDecodeUInt256 (coder.rlp, outputItems[2], 1)
                 }}
             };
@@ -303,7 +303,7 @@ messagePIPRequestOutputDecode (BRRlpItem item,
                 PIP_REQUEST_TRANSACTION_INDEX,
                 { .transactionIndex = {
                     rlpDecodeUInt64 (coder.rlp, outputItems[0], 1),
-                    hashRlpDecode(outputItems[1], coder.rlp),
+                    ethHashRlpDecode(outputItems[1], coder.rlp),
                     rlpDecodeUInt64 (coder.rlp, outputItems[2], 1)
                 }}
             };
@@ -339,8 +339,8 @@ messagePIPRequestOutputDecode (BRRlpItem item,
                 { .account = {
                     rlpDecodeUInt64 (coder.rlp, outputItems[1], 1),
                     rlpDecodeUInt256 (coder.rlp, outputItems[2], 1),
-                    hashRlpDecode (outputItems[3], coder.rlp),
-                    hashRlpDecode (outputItems[4], coder.rlp) }}
+                    ethHashRlpDecode (outputItems[3], coder.rlp),
+                    ethHashRlpDecode (outputItems[4], coder.rlp) }}
             };
         }
 

--- a/ethereum/les/testLES.c
+++ b/ethereum/les/testLES.c
@@ -986,8 +986,8 @@ run_SendTransaction_Tests(BREthereumLES les, const char *paperKey) {
 
     _initTest(1);
 
-    BREthereumAccount account = createAccount (paperKey);
-    BREthereumAddress sourceAddr = accountGetPrimaryAddress (account);
+    BREthereumAccount account = ethAccountCreate (paperKey);
+    BREthereumAddress sourceAddr = ethAccountGetPrimaryAddress (account);
     BREthereumAddress targetAddr = ethAddressCreate("0x49f4C50d9BcC7AfdbCF77e0d6e364C29D5a660DF");
 
 
@@ -1016,7 +1016,7 @@ run_SendTransaction_Tests(BREthereumLES les, const char *paperKey) {
     BRRlpData data = rlpItemGetData(coder, item);
 
     // Sign the RLP Encoded bytes.
-    BREthereumSignature signature = accountSignBytes (account,
+    BREthereumSignature signature = ethAccountSignBytes (account,
                                                       sourceAddr,
                                                       SIGNATURE_TYPE_RECOVERABLE_VRS_EIP,
                                                       data.bytes,

--- a/ethereum/les/testLES.c
+++ b/ethereum/les/testLES.c
@@ -185,49 +185,49 @@ static BlockHeaderTestData _blockHeaderTestData[5];
 static void _initBlockHeaderTestData(void){
     
     //Block Number: 4732524
-    _blockHeaderTestData[0].hash = hashCreate("0x3a510c07862ebce419a14bfcd95620f924d188a935654c5ad0f4d5d7ee429193");
+    _blockHeaderTestData[0].hash = ethHashCreate("0x3a510c07862ebce419a14bfcd95620f924d188a935654c5ad0f4d5d7ee429193");
     _blockHeaderTestData[0].blockNum = 4732524;
     _blockHeaderTestData[0].difficulty = uint256Create(1645417372907632);
     _blockHeaderTestData[0].gasUsed = 7996865;
-    _blockHeaderTestData[0].parent = hashCreate("0x5463afdad9eb343096a6a6561d4fed4b478380d02721cdd8fab97fda058f9fa2");
+    _blockHeaderTestData[0].parent = ethHashCreate("0x5463afdad9eb343096a6a6561d4fed4b478380d02721cdd8fab97fda058f9fa2");
     _blockHeaderTestData[0].transactionCount = 331;
     _blockHeaderTestData[0].ommersCount = 0;
     
     //Block Number: 4732523
-    _blockHeaderTestData[1].hash = hashCreate("0x5463afdad9eb343096a6a6561d4fed4b478380d02721cdd8fab97fda058f9fa2");
+    _blockHeaderTestData[1].hash = ethHashCreate("0x5463afdad9eb343096a6a6561d4fed4b478380d02721cdd8fab97fda058f9fa2");
     _blockHeaderTestData[1].blockNum = 4732523;
     _blockHeaderTestData[1].difficulty = uint256Create(1645417372874864);
     _blockHeaderTestData[1].gasUsed = 7998505;
-    _blockHeaderTestData[1].parent = hashCreate("0xb812a7b4a96c87a3d7d572847b3dee352b395cc9cfe3b6f0d163bc54e7d8a78e");
+    _blockHeaderTestData[1].parent = ethHashCreate("0xb812a7b4a96c87a3d7d572847b3dee352b395cc9cfe3b6f0d163bc54e7d8a78e");
     _blockHeaderTestData[1].transactionCount = 193;
     _blockHeaderTestData[1].ommersCount = 0;
     
     //Block Number: 4732522
-    _blockHeaderTestData[2].hash = hashCreate("0xb812a7b4a96c87a3d7d572847b3dee352b395cc9cfe3b6f0d163bc54e7d8a78e");
+    _blockHeaderTestData[2].hash = ethHashCreate("0xb812a7b4a96c87a3d7d572847b3dee352b395cc9cfe3b6f0d163bc54e7d8a78e");
     _blockHeaderTestData[2].blockNum = 4732522;
     _blockHeaderTestData[2].difficulty = uint256Create(1646221191783396);
     _blockHeaderTestData[2].gasUsed = 8003540;
-    _blockHeaderTestData[2].parent = hashCreate("0x4b29fb30276713be22786a9bdd548d787e9a2ea10248669f189b3f57f86ebaf8");
+    _blockHeaderTestData[2].parent = ethHashCreate("0x4b29fb30276713be22786a9bdd548d787e9a2ea10248669f189b3f57f86ebaf8");
     _blockHeaderTestData[2].transactionCount = 186;
     _blockHeaderTestData[2].ommersCount = 0;
     
     
     //Block Number: 4732521
-    _blockHeaderTestData[3].hash = hashCreate("0x4b29fb30276713be22786a9bdd548d787e9a2ea10248669f189b3f57f86ebaf8");
+    _blockHeaderTestData[3].hash = ethHashCreate("0x4b29fb30276713be22786a9bdd548d787e9a2ea10248669f189b3f57f86ebaf8");
     _blockHeaderTestData[3].blockNum = 4732521;
     _blockHeaderTestData[3].difficulty = uint256Create(1647025403373368);
     _blockHeaderTestData[3].gasUsed = 7996801;
-    _blockHeaderTestData[3].parent = hashCreate("0x4abb508954ec5f827184fb0d8bc74b104094d4060a06cc2dd743e4bfeaf1d8af");
+    _blockHeaderTestData[3].parent = ethHashCreate("0x4abb508954ec5f827184fb0d8bc74b104094d4060a06cc2dd743e4bfeaf1d8af");
     _blockHeaderTestData[3].transactionCount = 316;
     _blockHeaderTestData[3].ommersCount = 0;
     
     
     //Block Number: 4732520
-    _blockHeaderTestData[4].hash = hashCreate("0x4abb508954ec5f827184fb0d8bc74b104094d4060a06cc2dd743e4bfeaf1d8af");
+    _blockHeaderTestData[4].hash = ethHashCreate("0x4abb508954ec5f827184fb0d8bc74b104094d4060a06cc2dd743e4bfeaf1d8af");
     _blockHeaderTestData[4].blockNum = 4732520;
     _blockHeaderTestData[4].difficulty = uint256Create(1647830007836613);
     _blockHeaderTestData[4].gasUsed = 7986707;
-    _blockHeaderTestData[4].parent = hashCreate("0xe8f5d7cd81ad8ae3a677f6df6d87438ee5c98ead11f8df1b90b788f059a7deab");
+    _blockHeaderTestData[4].parent = ethHashCreate("0xe8f5d7cd81ad8ae3a677f6df6d87438ee5c98ead11f8df1b90b788f059a7deab");
     _blockHeaderTestData[4].transactionCount = 169;
     _blockHeaderTestData[4].ommersCount = 0;
 }
@@ -246,9 +246,9 @@ static BREthereumBoolean _checkBlockHeader(BREthereumBlockHeader header,
     
     
     return (gotBlockNumber == expectedBlockNumber &&
-            hashSetEqual(&gotHash, &expectedHash)  &&
+            ethHashSetEqual(&gotHash, &expectedHash)  &&
             gotGasUsed == expectedGasUsed &&
-            (hashSetEqual(&gotParentHash, &expectedParenthash)
+            (ethHashSetEqual(&gotParentHash, &expectedParenthash)
              ? ETHEREUM_BOOLEAN_TRUE
              : ETHEREUM_BOOLEAN_FALSE));
     
@@ -425,7 +425,7 @@ void _GetBlockProofs_Calllback_Test1 (BREthereumLESProvisionContext context,
 
     if (*context1 == _GetBlockProofs_Context1) {  // 6000000
         BRCoreParseStatus status;
-        assert (ETHEREUM_BOOLEAN_IS_TRUE (hashEqual(hash, HASH_INIT("be847be2bceb74e660daf96b3f0669d58f59dc9101715689a00ef864a5408f43"))));
+        assert (ETHEREUM_BOOLEAN_IS_TRUE (ethHashEqual(hash, HASH_INIT("be847be2bceb74e660daf96b3f0669d58f59dc9101715689a00ef864a5408f43"))));
         assert (UInt256Eq (totalDifficulty, uint256CreateParse ("5484495551037046114587", 0, &status)));
     }
 
@@ -481,13 +481,13 @@ _GetTxStatus_Test2_Callback (BREthereumLESProvisionContext context,
     
     //Check to make sure we get back the right transaction
     BREthereumHash expectedTransactionHashes[] = {
-        hashCreate("0xc070b1e539e9a329b14c95ec960779359a65be193137779bf2860dc239248d7c"),
-        hashCreate("0x78453edd2955e6ef6b200f5f9b98b3940d0d3f1528f902e7e855df56bf934cc5")
+        ethHashCreate("0xc070b1e539e9a329b14c95ec960779359a65be193137779bf2860dc239248d7c"),
+        ethHashCreate("0x78453edd2955e6ef6b200f5f9b98b3940d0d3f1528f902e7e855df56bf934cc5")
     };
 
     BREthereumHash expectedBlockHashes[] = {
-        hashCreate("0xf16becb908162df51c3789fab0e6ba52568fa7ee7d0127eb51bfaa0bcd40fb1b"),
-        hashCreate("0x0a4b16bac21b6dfeb51ccb522d8c34840844ae78ed0bc177670c501c18d35ff2")
+        ethHashCreate("0xf16becb908162df51c3789fab0e6ba52568fa7ee7d0127eb51bfaa0bcd40fb1b"),
+        ethHashCreate("0x0a4b16bac21b6dfeb51ccb522d8c34840844ae78ed0bc177670c501c18d35ff2")
     };
 
     uint64_t expectedBlockNumbers[] = {
@@ -501,12 +501,12 @@ _GetTxStatus_Test2_Callback (BREthereumLESProvisionContext context,
     };
 
     for (size_t index = 0; index < 2; index++) {
-        assert(hashSetEqual(&hashes[index], &expectedTransactionHashes[index]));
+        assert(ethHashSetEqual(&hashes[index], &expectedTransactionHashes[index]));
 
         assert (TRANSACTION_STATUS_INCLUDED == statusesByHash[index].type);
 
 
-        assert(hashSetEqual(&statusesByHash[index].u.included.blockHash, &expectedBlockHashes[index]));
+        assert(ethHashSetEqual(&statusesByHash[index].u.included.blockHash, &expectedBlockHashes[index]));
 
         assert(statusesByHash[index].u.included.blockNumber == expectedBlockNumbers[index]);
         assert(statusesByHash[index].u.included.transactionIndex == expectedTransactionIndexes[index]);
@@ -540,11 +540,11 @@ _GetTxStatus_Test1_Callback (BREthereumLESProvisionContext context,
     assert(*context1 == _GetTxStatus_Context1); //Check to make sure the context is correct
 
     BREthereumHash expectedTransactionHashes[] = {
-        hashCreate("0xc070b1e539e9a329b14c95ec960779359a65be193137779bf2860dc239248d7c"),
+        ethHashCreate("0xc070b1e539e9a329b14c95ec960779359a65be193137779bf2860dc239248d7c"),
     };
 
     BREthereumHash expectedBlockHashes[] = {
-        hashCreate("0xf16becb908162df51c3789fab0e6ba52568fa7ee7d0127eb51bfaa0bcd40fb1b"),
+        ethHashCreate("0xf16becb908162df51c3789fab0e6ba52568fa7ee7d0127eb51bfaa0bcd40fb1b"),
     };
 
     uint64_t expectedBlockNumbers[] = {
@@ -556,12 +556,12 @@ _GetTxStatus_Test1_Callback (BREthereumLESProvisionContext context,
     };
 
     for (size_t index = 0; index < 1; index++) {
-        assert(hashSetEqual(&hashes[index], &expectedTransactionHashes[index]));
+        assert(ethHashSetEqual(&hashes[index], &expectedTransactionHashes[index]));
 
         assert (TRANSACTION_STATUS_INCLUDED == statusesByHash[index].type);
 
 
-        assert(hashSetEqual(&statusesByHash[index].u.included.blockHash, &expectedBlockHashes[index]));
+        assert(ethHashSetEqual(&statusesByHash[index].u.included.blockHash, &expectedBlockHashes[index]));
 
         assert(statusesByHash[index].u.included.blockNumber == expectedBlockNumbers[index]);
         assert(statusesByHash[index].u.included.transactionIndex == expectedTransactionIndexes[index]);
@@ -575,8 +575,8 @@ static void
 run_GetTxStatus_Tests (BREthereumLES les) {
     
     // Prepare values to be given to a send tranactions status message
-    BREthereumHash transaction1Hash = hashCreate("0xc070b1e539e9a329b14c95ec960779359a65be193137779bf2860dc239248d7c");
-    BREthereumHash transaction2Hash = hashCreate("0x78453edd2955e6ef6b200f5f9b98b3940d0d3f1528f902e7e855df56bf934cc5");
+    BREthereumHash transaction1Hash = ethHashCreate("0xc070b1e539e9a329b14c95ec960779359a65be193137779bf2860dc239248d7c");
+    BREthereumHash transaction2Hash = ethHashCreate("0x78453edd2955e6ef6b200f5f9b98b3940d0d3f1528f902e7e855df56bf934cc5");
     
     //Initilize testing state
     _initTest(2);
@@ -628,7 +628,7 @@ _GetBlockBodies_Callback_Test1 (BREthereumLESProvisionContext context,
     assert(*context1 == _GetBlockBodies_Context1); //Check to make sure the context is correct
     
     //Check Block Hash
-    assert(hashSetEqual(&hashes[0], &_blockHeaderTestData[_GetBlockBodies_Context1].hash));
+    assert(ethHashSetEqual(&hashes[0], &_blockHeaderTestData[_GetBlockBodies_Context1].hash));
     
     //Check to make sure we got back the right number of transactions and ommers
     assert(array_count(pairs[0].transactions) == _blockHeaderTestData[_GetBlockBodies_Context1].transactionCount);
@@ -659,7 +659,7 @@ _GetBlockBodies_Callback_Test2 (BREthereumLESProvisionContext context,
 
     for (size_t index = 0; index < 2; index++) {
         //Check Block Hash
-        assert(hashSetEqual(&hashes[index], &_blockHeaderTestData[_GetBlockBodies_Context2 + index].hash));
+        assert(ethHashSetEqual(&hashes[index], &_blockHeaderTestData[_GetBlockBodies_Context2 + index].hash));
     
         //Check to make sure we got back the right number of transactions and ommers
         assert(array_count(pairs[index].transactions) == _blockHeaderTestData[_GetBlockBodies_Context2 + index].transactionCount);
@@ -727,7 +727,7 @@ _GetReceipts_Callback_Test1 (BREthereumLESProvisionContext context,
     assert(*context1 == _GetReceipts_Context1); //Check to make sure the context is correct
     
     //Check Block Hash
-    assert(hashSetEqual(&hashes[0], &_blockHeaderTestData[_GetReceipts_Context1].hash));
+    assert(ethHashSetEqual(&hashes[0], &_blockHeaderTestData[_GetReceipts_Context1].hash));
     
     //Check to make sure we got back the right number of transactions and ommers
     assert(array_count(receiptsByHash[0]) == _blockHeaderTestData[_GetReceipts_Context1].transactionCount);
@@ -758,7 +758,7 @@ _GetReceipts_Callback_Test2 (BREthereumLESProvisionContext context,
 
     for (size_t index = 0; index < 2; index++) {
         //Check Block Hash
-        assert(hashSetEqual(&hashes[index], &_blockHeaderTestData[_GetReceipts_Context2 + index].hash));
+        assert(ethHashSetEqual(&hashes[index], &_blockHeaderTestData[_GetReceipts_Context2 + index].hash));
     
         //Check to make sure we got back the right number of receipts
         assert(array_count(receiptsByHash[index]) == _blockHeaderTestData[_GetReceipts_Context2 + index].transactionCount);
@@ -1177,12 +1177,12 @@ runLESTests (const char *paperKey) {
     
     //Prepare values to be given to a LES context
     char headHashStr[] = "0xd4e56740f876aef8c010b86a40d5f56745a118d0906a34e69aec8c0db1cb8fa3";
-    BREthereumHash headHash = hashCreate(headHashStr);
+    BREthereumHash headHash = ethHashCreate(headHashStr);
     
     uint64_t headNumber = 0;
     UInt256 headTD = uint256Create (0x400000000);
     
-    BREthereumHash genesisHash = hashCreate(headHashStr);
+    BREthereumHash genesisHash = ethHashCreate(headHashStr);
     
     // Create an LES context
     BREthereumLES les = lesCreate (ethereumMainnet,

--- a/ethereum/les/testLES.c
+++ b/ethereum/les/testLES.c
@@ -1075,7 +1075,7 @@ void _GetBlockHeaders_0_1 (BREthereumLESProvisionContext context,
 
     item = blockHeaderRlpEncode (header_0, ETHEREUM_BOOLEAN_TRUE, RLP_TYPE_NETWORK, coder);
     data = rlpGetDataSharedDontRelease(coder, item);
-    hex = encodeHexCreate(NULL, data.bytes, data.bytesCount);
+    hex = hexEncodeCreate(NULL, data.bytes, data.bytesCount);
     rlpShowItem(coder, item, "BLOCK_0");
     printf ("Block_0: %s\n", hex);
 
@@ -1083,7 +1083,7 @@ void _GetBlockHeaders_0_1 (BREthereumLESProvisionContext context,
 
     item = blockHeaderRlpEncode (header_1, ETHEREUM_BOOLEAN_TRUE, RLP_TYPE_NETWORK, coder);
     data = rlpGetDataSharedDontRelease(coder, item);
-    hex = encodeHexCreate(NULL, data.bytes, data.bytesCount);
+    hex = hexEncodeCreate(NULL, data.bytes, data.bytesCount);
     rlpShowItem(coder, item, "BLOCK_1");
     printf ("Block_1: %s\n", hex);
 
@@ -1164,7 +1164,7 @@ run_GetSomeBlocks (BREthereumLES les) {
     BRRlpCoder coder = rlpCoderCreate();
     BRRlpItem item = blockRlpEncode (block, ethereumMainnet, RLP_TYPE_NETWORK, coder);
     BRRlpData data = rlpGetDataSharedDontRelease(coder, item);
-    char      *hex = encodeHexCreate(NULL, data.bytes, data.bytesCount);
+    char      *hex = hexEncodeCreate(NULL, data.bytes, data.bytesCount);
     printf ("Block: %s\n", hex);
     rlpShowItem(coder, item, "BLOCK");
 

--- a/ethereum/les/testLES.c
+++ b/ethereum/les/testLES.c
@@ -1013,7 +1013,7 @@ run_SendTransaction_Tests(BREthereumLES les, const char *paperKey) {
                                            ethereumMainnet,
                                            RLP_TYPE_TRANSACTION_UNSIGNED,
                                            coder);
-    BRRlpData data = rlpGetData(coder, item);
+    BRRlpData data = rlpItemGetData(coder, item);
 
     // Sign the RLP Encoded bytes.
     BREthereumSignature signature = accountSignBytes (account,
@@ -1024,14 +1024,14 @@ run_SendTransaction_Tests(BREthereumLES les, const char *paperKey) {
                                                       paperKey);
 
     transactionSign (transaction, signature);
-    rlpReleaseItem(coder, item);
+    rlpItemRelease(coder, item);
     rlpDataRelease(data);
 
     item = transactionRlpEncode (transaction,
                                            ethereumMainnet,
                                            RLP_TYPE_TRANSACTION_SIGNED,
                                            coder);
-    rlpReleaseItem(coder, item);
+    rlpItemRelease(coder, item);
 
     //Request block headers 4732522, 4732523, 4732524
     lesSubmitTransaction (les, NODE_REFERENCE_ANY,
@@ -1074,20 +1074,20 @@ void _GetBlockHeaders_0_1 (BREthereumLESProvisionContext context,
     char *hex;
 
     item = blockHeaderRlpEncode (header_0, ETHEREUM_BOOLEAN_TRUE, RLP_TYPE_NETWORK, coder);
-    data = rlpGetDataSharedDontRelease(coder, item);
+    data = rlpItemGetDataSharedDontRelease(coder, item);
     hex = hexEncodeCreate(NULL, data.bytes, data.bytesCount);
-    rlpShowItem(coder, item, "BLOCK_0");
+    rlpItemShow(coder, item, "BLOCK_0");
     printf ("Block_0: %s\n", hex);
 
-    free (hex); rlpReleaseItem (coder, item);
+    free (hex); rlpItemRelease (coder, item);
 
     item = blockHeaderRlpEncode (header_1, ETHEREUM_BOOLEAN_TRUE, RLP_TYPE_NETWORK, coder);
-    data = rlpGetDataSharedDontRelease(coder, item);
+    data = rlpItemGetDataSharedDontRelease(coder, item);
     hex = hexEncodeCreate(NULL, data.bytes, data.bytesCount);
-    rlpShowItem(coder, item, "BLOCK_1");
+    rlpItemShow(coder, item, "BLOCK_1");
     printf ("Block_1: %s\n", hex);
 
-    free (hex); rlpReleaseItem (coder, item);
+    free (hex); rlpItemRelease (coder, item);
 
     _signalTestComplete();
 }

--- a/ethereum/les/testLES.c
+++ b/ethereum/les/testLES.c
@@ -187,7 +187,7 @@ static void _initBlockHeaderTestData(void){
     //Block Number: 4732524
     _blockHeaderTestData[0].hash = hashCreate("0x3a510c07862ebce419a14bfcd95620f924d188a935654c5ad0f4d5d7ee429193");
     _blockHeaderTestData[0].blockNum = 4732524;
-    _blockHeaderTestData[0].difficulty = createUInt256(1645417372907632);
+    _blockHeaderTestData[0].difficulty = uint256Create(1645417372907632);
     _blockHeaderTestData[0].gasUsed = 7996865;
     _blockHeaderTestData[0].parent = hashCreate("0x5463afdad9eb343096a6a6561d4fed4b478380d02721cdd8fab97fda058f9fa2");
     _blockHeaderTestData[0].transactionCount = 331;
@@ -196,7 +196,7 @@ static void _initBlockHeaderTestData(void){
     //Block Number: 4732523
     _blockHeaderTestData[1].hash = hashCreate("0x5463afdad9eb343096a6a6561d4fed4b478380d02721cdd8fab97fda058f9fa2");
     _blockHeaderTestData[1].blockNum = 4732523;
-    _blockHeaderTestData[1].difficulty = createUInt256(1645417372874864);
+    _blockHeaderTestData[1].difficulty = uint256Create(1645417372874864);
     _blockHeaderTestData[1].gasUsed = 7998505;
     _blockHeaderTestData[1].parent = hashCreate("0xb812a7b4a96c87a3d7d572847b3dee352b395cc9cfe3b6f0d163bc54e7d8a78e");
     _blockHeaderTestData[1].transactionCount = 193;
@@ -205,7 +205,7 @@ static void _initBlockHeaderTestData(void){
     //Block Number: 4732522
     _blockHeaderTestData[2].hash = hashCreate("0xb812a7b4a96c87a3d7d572847b3dee352b395cc9cfe3b6f0d163bc54e7d8a78e");
     _blockHeaderTestData[2].blockNum = 4732522;
-    _blockHeaderTestData[2].difficulty = createUInt256(1646221191783396);
+    _blockHeaderTestData[2].difficulty = uint256Create(1646221191783396);
     _blockHeaderTestData[2].gasUsed = 8003540;
     _blockHeaderTestData[2].parent = hashCreate("0x4b29fb30276713be22786a9bdd548d787e9a2ea10248669f189b3f57f86ebaf8");
     _blockHeaderTestData[2].transactionCount = 186;
@@ -215,7 +215,7 @@ static void _initBlockHeaderTestData(void){
     //Block Number: 4732521
     _blockHeaderTestData[3].hash = hashCreate("0x4b29fb30276713be22786a9bdd548d787e9a2ea10248669f189b3f57f86ebaf8");
     _blockHeaderTestData[3].blockNum = 4732521;
-    _blockHeaderTestData[3].difficulty = createUInt256(1647025403373368);
+    _blockHeaderTestData[3].difficulty = uint256Create(1647025403373368);
     _blockHeaderTestData[3].gasUsed = 7996801;
     _blockHeaderTestData[3].parent = hashCreate("0x4abb508954ec5f827184fb0d8bc74b104094d4060a06cc2dd743e4bfeaf1d8af");
     _blockHeaderTestData[3].transactionCount = 316;
@@ -225,7 +225,7 @@ static void _initBlockHeaderTestData(void){
     //Block Number: 4732520
     _blockHeaderTestData[4].hash = hashCreate("0x4abb508954ec5f827184fb0d8bc74b104094d4060a06cc2dd743e4bfeaf1d8af");
     _blockHeaderTestData[4].blockNum = 4732520;
-    _blockHeaderTestData[4].difficulty = createUInt256(1647830007836613);
+    _blockHeaderTestData[4].difficulty = uint256Create(1647830007836613);
     _blockHeaderTestData[4].gasUsed = 7986707;
     _blockHeaderTestData[4].parent = hashCreate("0xe8f5d7cd81ad8ae3a677f6df6d87438ee5c98ead11f8df1b90b788f059a7deab");
     _blockHeaderTestData[4].transactionCount = 169;
@@ -426,7 +426,7 @@ void _GetBlockProofs_Calllback_Test1 (BREthereumLESProvisionContext context,
     if (*context1 == _GetBlockProofs_Context1) {  // 6000000
         BRCoreParseStatus status;
         assert (ETHEREUM_BOOLEAN_IS_TRUE (hashEqual(hash, HASH_INIT("be847be2bceb74e660daf96b3f0669d58f59dc9101715689a00ef864a5408f43"))));
-        assert (UInt256Eq (totalDifficulty, createUInt256Parse ("5484495551037046114587", 0, &status)));
+        assert (UInt256Eq (totalDifficulty, uint256CreateParse ("5484495551037046114587", 0, &status)));
     }
 
     //    assert(context1 == &_GetBlockHeaders_Context1); //Check to make sure the context is correct
@@ -1180,7 +1180,7 @@ runLESTests (const char *paperKey) {
     BREthereumHash headHash = hashCreate(headHashStr);
     
     uint64_t headNumber = 0;
-    UInt256 headTD = createUInt256 (0x400000000);
+    UInt256 headTD = uint256Create (0x400000000);
     
     BREthereumHash genesisHash = hashCreate(headHashStr);
     

--- a/ethereum/les/testLES.c
+++ b/ethereum/les/testLES.c
@@ -1010,7 +1010,7 @@ run_SendTransaction_Tests(BREthereumLES les, const char *paperKey) {
 
     BRRlpCoder coder = rlpCoderCreate();
     BRRlpItem item = transactionRlpEncode (transaction,
-                                           ethereumMainnet,
+                                           ethNetworkMainnet,
                                            RLP_TYPE_TRANSACTION_UNSIGNED,
                                            coder);
     BRRlpData data = rlpItemGetData(coder, item);
@@ -1028,7 +1028,7 @@ run_SendTransaction_Tests(BREthereumLES les, const char *paperKey) {
     rlpDataRelease(data);
 
     item = transactionRlpEncode (transaction,
-                                           ethereumMainnet,
+                                           ethNetworkMainnet,
                                            RLP_TYPE_TRANSACTION_SIGNED,
                                            coder);
     rlpItemRelease(coder, item);
@@ -1185,7 +1185,7 @@ runLESTests (const char *paperKey) {
     BREthereumHash genesisHash = ethHashCreate(headHashStr);
     
     // Create an LES context
-    BREthereumLES les = lesCreate (ethereumMainnet,
+    BREthereumLES les = lesCreate (ethNetworkMainnet,
                                    NULL, _announceCallback, _statusCallback, _saveNodesCallback,
                                    headHash, headNumber, headTD, genesisHash,
                                    NULL,

--- a/ethereum/les/testLES.c
+++ b/ethereum/les/testLES.c
@@ -992,8 +992,8 @@ run_SendTransaction_Tests(BREthereumLES les, const char *paperKey) {
 
 
     BRCoreParseStatus status;
-    BREthereumEther amount = etherCreateString("0.001", ETHER, &status);
-    BREthereumGasPrice gasPrice = ethGasPriceCreate (etherCreateString("5.0", GWEI, &status));
+    BREthereumEther amount = ethEtherCreateString("0.001", ETHER, &status);
+    BREthereumGasPrice gasPrice = ethGasPriceCreate (ethEtherCreateString("5.0", GWEI, &status));
     BREthereumGas gasLimit = ethGasCreate(21000);
 
     uint64_t nonce = 9;

--- a/ethereum/les/testLES.c
+++ b/ethereum/les/testLES.c
@@ -988,7 +988,7 @@ run_SendTransaction_Tests(BREthereumLES les, const char *paperKey) {
 
     BREthereumAccount account = createAccount (paperKey);
     BREthereumAddress sourceAddr = accountGetPrimaryAddress (account);
-    BREthereumAddress targetAddr = addressCreate("0x49f4C50d9BcC7AfdbCF77e0d6e364C29D5a660DF");
+    BREthereumAddress targetAddr = ethAddressCreate("0x49f4C50d9BcC7AfdbCF77e0d6e364C29D5a660DF");
 
 
     BRCoreParseStatus status;

--- a/ethereum/les/testLES.c
+++ b/ethereum/les/testLES.c
@@ -993,8 +993,8 @@ run_SendTransaction_Tests(BREthereumLES les, const char *paperKey) {
 
     BRCoreParseStatus status;
     BREthereumEther amount = etherCreateString("0.001", ETHER, &status);
-    BREthereumGasPrice gasPrice = gasPriceCreate (etherCreateString("5.0", GWEI, &status));
-    BREthereumGas gasLimit = gasCreate(21000);
+    BREthereumGasPrice gasPrice = ethGasPriceCreate (etherCreateString("5.0", GWEI, &status));
+    BREthereumGas gasLimit = ethGasCreate(21000);
 
     uint64_t nonce = 9;
 

--- a/ethereum/mpt/BREthereumMPT.c
+++ b/ethereum/mpt/BREthereumMPT.c
@@ -188,13 +188,13 @@ mptNodeDecode (BRRlpItem item,
         case 17: {
             node = mptNodeCreate(MPT_NODE_BRANCH);
             for (size_t index = 0; index < 16; index++) {
-                BRRlpData data = rlpGetDataSharedDontRelease (coder, items[index]);
+                BRRlpData data = rlpItemGetDataSharedDontRelease (coder, items[index]);
                 // Either a hash (0x<32 bytes>) or empty (0x)
                 node->u.branch.keys[index] = (0 == data.bytesCount || 1 == data.bytesCount
                                               ? EMPTY_HASH_INIT
                                               : hashRlpDecode(items[index], coder));
             }
-            node->u.branch.value = rlpGetData (coder, items[16]);
+            node->u.branch.value = rlpItemGetData (coder, items[16]);
             break;
         }
     }
@@ -258,12 +258,12 @@ mptNodePathDecodeFromBytes (BRRlpItem item,
         // items[index] holds bytes as the RLP encoding of MPT nodes.  We'll decode the bytes
         // and then RLP encode the bytes (but this time as RLP items.... got it??).
         BRRlpData data = rlpDecodeBytesSharedDontRelease (coder, items[index]);
-        BRRlpItem item = rlpGetItem(coder, data);
+        BRRlpItem item = rlpDataGetItem(coder, data);
         array_add (nodes, mptNodeDecode (item, coder));
 #if defined (MPT_SHOW_PROOF_NODES)
         rlpShowItem (coder, item, "MPTN");
 #endif
-        rlpReleaseItem (coder, item);
+        rlpItemRelease (coder, item);
     }
 
     // TODO: If any above item is decoded improperly, then `nodes` will have NULL values.

--- a/ethereum/mpt/BREthereumMPT.c
+++ b/ethereum/mpt/BREthereumMPT.c
@@ -49,12 +49,12 @@ mptNodeRelease (BREthereumMPTNode node) {
     if (NULL == node) return;  // On RLP coding error during 'nodes' processing
     switch (node->type) {
         case MPT_NODE_LEAF:
-            dataRelease(node->u.leaf.path);
+            ethDataRelease(node->u.leaf.path);
             rlpDataRelease(node->u.leaf.value);
             break;
 
         case MPT_NODE_EXTENSION:
-            dataRelease (node->u.extension.path);
+            ethDataRelease (node->u.extension.path);
             break;
 
         case MPT_NODE_BRANCH:

--- a/ethereum/mpt/BREthereumMPT.c
+++ b/ethereum/mpt/BREthereumMPT.c
@@ -105,7 +105,7 @@ mptNodeConsume (BREthereumMPTNode node, uint8_t *key) {
 
         case MPT_NODE_BRANCH: {
             // We'll consume one byte if the node's key is not an empty hash
-            return (ETHEREUM_BOOLEAN_IS_TRUE (hashEqual (node->u.branch.keys[key[0]],
+            return (ETHEREUM_BOOLEAN_IS_TRUE (ethHashEqual (node->u.branch.keys[key[0]],
                                                          EMPTY_HASH_INIT))
                     ? 0
                     : 1);
@@ -176,7 +176,7 @@ mptNodeDecode (BRRlpItem item,
 
                 case MPT_NODE_EXTENSION:
                     node->u.extension.path = path;
-                    node->u.extension.key = hashRlpDecode (items[1], coder);
+                    node->u.extension.key = ethHashRlpDecode (items[1], coder);
                     break;
 
                 case MPT_NODE_BRANCH:
@@ -192,7 +192,7 @@ mptNodeDecode (BRRlpItem item,
                 // Either a hash (0x<32 bytes>) or empty (0x)
                 node->u.branch.keys[index] = (0 == data.bytesCount || 1 == data.bytesCount
                                               ? EMPTY_HASH_INIT
-                                              : hashRlpDecode(items[index], coder));
+                                              : ethHashRlpDecode(items[index], coder));
             }
             node->u.branch.value = rlpItemGetData (coder, items[16]);
             break;

--- a/ethereum/rlp/BRRlpCoder.c
+++ b/ethereum/rlp/BRRlpCoder.c
@@ -865,14 +865,14 @@ rlpDataExtract (BRRlpCoder coder, BRRlpItem item, uint8_t **bytes, size_t *bytes
 }
 
 extern BRRlpData
-rlpGetData (BRRlpCoder coder, BRRlpItem item) {
+rlpItemGetData (BRRlpCoder coder, BRRlpItem item) {
     BRRlpData data;
     rlpDataExtract(coder, item, &data.bytes, &data.bytesCount);
     return data;
 }
 
 extern BRRlpData
-rlpGetDataSharedDontRelease (BRRlpCoder coder, BRRlpItem item) {
+rlpItemGetDataSharedDontRelease (BRRlpCoder coder, BRRlpItem item) {
     assert (itemIsValid(coder, item));
     BRRlpData result = { item->bytesCount, item->bytes };
     return result;
@@ -905,7 +905,7 @@ rlpGetItem_FillData (BRRlpCoder coder, uint8_t *bytes) {
  * represent a list.
  */
 extern BRRlpItem
-rlpGetItem (BRRlpCoder coder, BRRlpData data) {
+rlpDataGetItem (BRRlpCoder coder, BRRlpData data) {
     assert (0 != data.bytesCount);
 
     BRRlpItem result = rlpCoderAcquireItem (coder);
@@ -946,7 +946,7 @@ rlpGetItem (BRRlpCoder coder, BRRlpData data) {
         while (bytes < bytesLimit) {
             // Get the `data` for this sub-item and then recurse
             BRRlpData d = rlpGetItem_FillData(coder, bytes);
-            items[itemsIndex++] = rlpGetItem (coder, d);
+            items[itemsIndex++] = rlpDataGetItem (coder, d);
 
             // Move to the next sub-item
             bytes += d.bytesCount;
@@ -976,7 +976,7 @@ rlpGetItem (BRRlpCoder coder, BRRlpData data) {
 #define RLP_SHOW_INDENT_INCREMENT  2
 
 static void
-rlpShowItemInternal (BRRlpCoder coder, BRRlpItem context, const char *topic, int indent) {
+rlpItemShowInternal (BRRlpCoder coder, BRRlpItem context, const char *topic, int indent) {
     if (indent > 256) indent = 256;
     char spaces [257];
     memset (spaces, ' ', indent);
@@ -989,7 +989,7 @@ rlpShowItemInternal (BRRlpCoder coder, BRRlpItem context, const char *topic, int
             else {
                 eth_log(topic, "%sL%3zu: [", spaces, context->itemsCount);
                 for (int i = 0; i < context->itemsCount; i++)
-                    rlpShowItemInternal(coder,
+                    rlpItemShowInternal(coder,
                                         context->items[i],
                                         topic,
                                         indent + RLP_SHOW_INDENT_INCREMENT);
@@ -1015,22 +1015,22 @@ rlpShowItemInternal (BRRlpCoder coder, BRRlpItem context, const char *topic, int
 }
 
 extern void
-rlpReleaseItem (BRRlpCoder coder, BRRlpItem item) {
+rlpItemRelease (BRRlpCoder coder, BRRlpItem item) {
     assert (itemIsValid(coder, item));
     rlpCoderReleaseItem (coder, item);
 }
 
 extern void
-rlpShowItem (BRRlpCoder coder, BRRlpItem item, const char *topic) {
-    rlpShowItemInternal(coder, item, topic, 0);
+rlpItemShow (BRRlpCoder coder, BRRlpItem item, const char *topic) {
+    rlpItemShowInternal(coder, item, topic, 0);
 }
 
 extern void
-rlpShow (BRRlpData data, const char *topic) {
+rlpDataShow (BRRlpData data, const char *topic) {
     BRRlpCoder coder = rlpCoderCreate();
-    BRRlpItem item = rlpGetItem(coder, data);
-    rlpShowItem (coder, item, topic);
-    rlpReleaseItem(coder, item);
+    BRRlpItem item = rlpDataGetItem(coder, data);
+    rlpItemShow (coder, item, topic);
+    rlpItemRelease(coder, item);
 }
 
 /*

--- a/ethereum/rlp/BRRlpCoder.c
+++ b/ethereum/rlp/BRRlpCoder.c
@@ -598,7 +598,7 @@ rlpDecodeUInt64(BRRlpCoder coder, BRRlpItem item, int zeroAsEmptyString) {
 //
 extern BRRlpItem
 rlpEncodeUInt256(BRRlpCoder coder, UInt256 value, int zeroAsEmptyString) {
-    return (1 == zeroAsEmptyString && 0 == compareUInt256 (value, UINT256_ZERO)
+    return (1 == zeroAsEmptyString && 0 == uint256Compare (value, UINT256_ZERO)
             ? rlpEncodeString(coder, "")
             : coderEncodeUInt256(coder, value));
 }

--- a/ethereum/rlp/BRRlpCoder.c
+++ b/ethereum/rlp/BRRlpCoder.c
@@ -750,12 +750,12 @@ rlpEncodeHexString (BRRlpCoder coder, const char *string) {
     else if (stringLen < (16 * 1024)) {
         size_t bytesCount = stringLen / 2;
         uint8_t bytes[bytesCount];
-        decodeHex(bytes, bytesCount, string, stringLen);
+        hexDecode(bytes, bytesCount, string, stringLen);
         return rlpEncodeBytes(coder, bytes, bytesCount);
     }
     else {
         size_t bytesCount = 0;
-        uint8_t *bytes = decodeHexCreate(&bytesCount, string, strlen(string));
+        uint8_t *bytes = hexDecodeCreate(&bytesCount, string, strlen(string));
         BRRlpItem item = rlpEncodeBytes(coder, bytes, bytesCount);
         free (bytes);
         return item;
@@ -769,7 +769,7 @@ rlpDecodeHexString (BRRlpCoder coder, BRRlpItem item, const char *prefix) {
 
     char *result = malloc (strlen(prefix) + 2 * data.bytesCount + 1);
     strcpy (result, prefix);
-    encodeHex(&result[strlen(prefix)], 2 * data.bytesCount + 1, data.bytes, data.bytesCount);
+    hexEncode(&result[strlen(prefix)], 2 * data.bytesCount + 1, data.bytes, data.bytesCount);
 
     rlpDataRelease (data);
     return result;
@@ -1005,7 +1005,7 @@ rlpShowItemInternal (BRRlpCoder coder, BRRlpItem context, const char *topic, int
             // We'll limit the display to a string of 1024 characters.
             size_t bytesCount = length > 512 ? 512 : length;
             char string[1024 + 1];
-            encodeHex(string, 2 * bytesCount + 1, &context->bytes[offset], bytesCount);
+            hexEncode(string, 2 * bytesCount + 1, &context->bytes[offset], bytesCount);
 
             eth_log(topic, "%sI%3zu: 0x%s%s", spaces, length, string,
                     (bytesCount == length ? "" : "..."));

--- a/ethereum/rlp/BRRlpCoder.h
+++ b/ethereum/rlp/BRRlpCoder.h
@@ -66,21 +66,21 @@ rlpDataRelease (BRRlpData data);
 typedef struct BRRlpItemRecord *BRRlpItem;
 
 extern void
-rlpReleaseItem (BRRlpCoder coder, BRRlpItem item);
+rlpItemRelease (BRRlpCoder coder, BRRlpItem item);
 
 /**
  * Convet the bytes in `data` into an `item`.  If `data` represents a RLP list, then `item` will
  * represent a list (thus `data` is 'walked' to identify subitems, including sublists).
  */
 extern BRRlpItem
-rlpGetItem (BRRlpCoder coder, BRRlpData data);
+rlpDataGetItem (BRRlpCoder coder, BRRlpData data);
 
 /**
  * Return the RLP data associated with `item`.  You own this data and must call
  * rlpDataRelese().
  */
 extern BRRlpData
-rlpGetData (BRRlpCoder coder, BRRlpItem item);
+rlpItemGetData (BRRlpCoder coder, BRRlpItem item);
 
 /**
  * Return the RLP data associated with `item`.  You DO NOT own this data; you must not
@@ -88,7 +88,7 @@ rlpGetData (BRRlpCoder coder, BRRlpItem item);
  * pointer into the `coder` memory and will become invalid on coder release.
  */
 extern BRRlpData
-rlpGetDataSharedDontRelease (BRRlpCoder coder, BRRlpItem item);
+rlpItemGetDataSharedDontRelease (BRRlpCoder coder, BRRlpItem item);
 
 /**
  * Extract the `bytes` and `bytesCount` for `item`.  The returns `bytes` will be the complete
@@ -195,10 +195,10 @@ rlpDecodeList (BRRlpCoder coder, BRRlpItem item, size_t *itemsCount);
 // Show
 //
 extern void
-rlpShowItem (BRRlpCoder coder, BRRlpItem item, const char *topic);
+rlpItemShow (BRRlpCoder coder, BRRlpItem item, const char *topic);
 
 extern void
-rlpShow (BRRlpData data, const char *topic);
+rlpDataShow (BRRlpData data, const char *topic);
 
 //
 // Decode RLPData directly to numbers

--- a/ethereum/rlp/testRlp.c
+++ b/ethereum/rlp/testRlp.c
@@ -59,7 +59,7 @@ int equalBytes (uint8_t *a, size_t aLen, uint8_t *b, size_t bLen) {
 }
 
 void rlpCheck (BRRlpCoder coder, BRRlpItem item, uint8_t *result, size_t resultSize) {
-    BRRlpData data = rlpGetData(coder, item);
+    BRRlpData data = rlpItemGetData(coder, item);
     assert (equalBytes(data.bytes, data.bytesCount, result, resultSize));
     printf (" => "); showHex (data.bytes, data.bytesCount);
 
@@ -70,14 +70,14 @@ void rlpCheckString (BRRlpCoder coder, const char *string, uint8_t *result, size
     printf ("  \"%s\"", string);
     BRRlpItem item = rlpEncodeString(coder, (char*) string);
     rlpCheck(coder, item, result, resultSize);
-    rlpReleaseItem(coder, item);
+    rlpItemRelease(coder, item);
 }
 
 void rlpCheckInt (BRRlpCoder coder, uint64_t value, uint8_t *result, size_t resultSize) {
     printf ("  %" PRIu64, value);
     BRRlpItem item = rlpEncodeUInt64(coder, value, 0);
     rlpCheck(coder, item, result, resultSize);
-    rlpReleaseItem(coder, item);
+    rlpItemRelease(coder, item);
 }
 
 void runRlpEncodeTest () {
@@ -109,14 +109,14 @@ void runRlpEncodeTest () {
     uint8_t resCatDog[] = RLP_L1_RES;
     printf ("  \"%s\"", "[\"cat\" \"dog\"]");
     rlpCheck(coder, listCatDog, resCatDog, 9);
-    rlpReleaseItem(coder, listCatDog);
+    rlpItemRelease(coder, listCatDog);
 
     BRCoreParseStatus status = CORE_PARSE_OK;
     char *value = "5968770000000000000000";
     UInt256 r = uint256CreateParse(value, 10, &status);
     BRRlpItem item = rlpEncodeUInt256(coder, r, 0);
-    BRRlpData data = rlpGetData(coder, item);
-    rlpReleaseItem(coder, item);
+    BRRlpData data = rlpItemGetData(coder, item);
+    rlpItemRelease(coder, item);
     printf ("  %s\n    => ", value); showHex (data.bytes, data.bytesCount);
     char *dataHex = hexEncodeCreate(NULL, data.bytes, data.bytesCount);
     printf ("    => %s\n", dataHex);
@@ -138,7 +138,7 @@ void runRlpDecodeTest () {
     l1d.bytes = l1b;
     l1d.bytesCount = 9;
 
-    BRRlpItem l1i = rlpGetItem(coder, l1d);
+    BRRlpItem l1i = rlpDataGetItem(coder, l1d);
     const BRRlpItem *l1is = rlpDecodeList (coder, l1i, &c);
     assert (2 == c);
 
@@ -146,7 +146,7 @@ void runRlpDecodeTest () {
     char *liDog = rlpDecodeString(coder, l1is[1]);
     assert (0 == strcmp (liCat, "cat"));
     assert (0 == strcmp (liDog, "dog"));
-    rlpReleaseItem(coder, l1i);
+    rlpItemRelease(coder, l1i);
     free (liCat);
     free (liDog);
 
@@ -155,10 +155,10 @@ void runRlpDecodeTest () {
     s3d.bytes = s3b;
     s3d.bytesCount = 58;
 
-    BRRlpItem s3i = rlpGetItem(coder, s3d);
+    BRRlpItem s3i = rlpDataGetItem(coder, s3d);
     char *s3Lorem = rlpDecodeString(coder, s3i);
     assert (0 == strcmp (s3Lorem, RLP_S3));
-    rlpReleaseItem(coder, s3i);
+    rlpItemRelease(coder, s3i);
    free (s3Lorem);
 
     //
@@ -167,10 +167,10 @@ void runRlpDecodeTest () {
     v3d.bytes = v3b;
     v3d.bytesCount = 3;
 
-    BRRlpItem v3i = rlpGetItem(coder, v3d);
+    BRRlpItem v3i = rlpDataGetItem(coder, v3d);
     uint64_t v3v = rlpDecodeUInt64(coder, v3i, 0);
     assert (1024 == v3v);
-    rlpReleaseItem(coder, v3i);
+    rlpItemRelease(coder, v3i);
 
     rlpCoderRelease(coder);
 }

--- a/ethereum/rlp/testRlp.c
+++ b/ethereum/rlp/testRlp.c
@@ -113,7 +113,7 @@ void runRlpEncodeTest () {
 
     BRCoreParseStatus status = CORE_PARSE_OK;
     char *value = "5968770000000000000000";
-    UInt256 r = createUInt256Parse(value, 10, &status);
+    UInt256 r = uint256CreateParse(value, 10, &status);
     BRRlpItem item = rlpEncodeUInt256(coder, r, 0);
     BRRlpData data = rlpGetData(coder, item);
     rlpReleaseItem(coder, item);

--- a/ethereum/rlp/testRlp.c
+++ b/ethereum/rlp/testRlp.c
@@ -118,7 +118,7 @@ void runRlpEncodeTest () {
     BRRlpData data = rlpGetData(coder, item);
     rlpReleaseItem(coder, item);
     printf ("  %s\n    => ", value); showHex (data.bytes, data.bytesCount);
-    char *dataHex = encodeHexCreate(NULL, data.bytes, data.bytesCount);
+    char *dataHex = hexEncodeCreate(NULL, data.bytes, data.bytesCount);
     printf ("    => %s\n", dataHex);
     assert (0 == strcasecmp (dataHex, "8a01439152d319e84d0000"));
     free (dataHex);

--- a/ethereum/test.c
+++ b/ethereum/test.c
@@ -123,8 +123,8 @@ void runTransactionTests1 (BREthereumAccount account, BREthereumNetwork network)
     printf ("     TEST 1\n");
     
     BREthereumWallet  wallet = walletCreate(account, network);
-    walletSetDefaultGasLimit(wallet, gasCreate(TEST_TRANS1_GAS_LIMIT));
-    walletSetDefaultGasPrice(wallet, gasPriceCreate(etherCreateNumber(TEST_TRANS1_GAS_PRICE_VALUE, TEST_TRANS1_GAS_PRICE_UNIT)));
+    walletSetDefaultGasLimit(wallet, ethGasCreate(TEST_TRANS1_GAS_LIMIT));
+    walletSetDefaultGasPrice(wallet, ethGasPriceCreate(etherCreateNumber(TEST_TRANS1_GAS_PRICE_VALUE, TEST_TRANS1_GAS_PRICE_UNIT)));
 
     BREthereumTransfer transfer = walletCreateTransfer(wallet,
                                                        addressCreate(TEST_TRANS1_TARGET_ADDRESS),
@@ -188,8 +188,8 @@ void runTransactionTests2 (BREthereumAccount account, BREthereumNetwork network)
     printf ("     TEST 2\n");
     
     BREthereumWallet  wallet = walletCreate(account, network);
-    walletSetDefaultGasLimit(wallet, gasCreate(TEST_TRANS2_GAS_LIMIT));
-    walletSetDefaultGasPrice(wallet, gasPriceCreate(etherCreateNumber(TEST_TRANS2_GAS_PRICE_VALUE, TEST_TRANS2_GAS_PRICE_UNIT)));
+    walletSetDefaultGasLimit(wallet, ethGasCreate(TEST_TRANS2_GAS_LIMIT));
+    walletSetDefaultGasPrice(wallet, ethGasPriceCreate(etherCreateNumber(TEST_TRANS2_GAS_PRICE_VALUE, TEST_TRANS2_GAS_PRICE_UNIT)));
 
     BREthereumTransfer transfer = walletCreateTransfer(wallet,
                                                        addressCreate(TEST_TRANS2_TARGET_ADDRESS),
@@ -268,8 +268,8 @@ void runTransactionTests3 (BREthereumAccount account, BREthereumNetwork network)
     UInt256 value = uint256CreateParse ("5968770000000000000000", 10, &status);
     BREthereumAmount amount = amountCreateToken(createTokenQuantity (token, value));
     
-    walletSetDefaultGasLimit(wallet, gasCreate(TEST_TRANS3_GAS_LIMIT));
-    walletSetDefaultGasPrice(wallet, gasPriceCreate(etherCreateNumber(TEST_TRANS3_GAS_PRICE_VALUE, TEST_TRANS3_GAS_PRICE_UNIT)));
+    walletSetDefaultGasLimit(wallet, ethGasCreate(TEST_TRANS3_GAS_LIMIT));
+    walletSetDefaultGasPrice(wallet, ethGasPriceCreate(etherCreateNumber(TEST_TRANS3_GAS_PRICE_VALUE, TEST_TRANS3_GAS_PRICE_UNIT)));
 
     BREthereumTransfer transfer = walletCreateTransfer(wallet,
                                                        addressCreate(TEST_TRANS3_TARGET_ADDRESS),
@@ -369,8 +369,8 @@ void testTransactionCodingEther () {
 
     BREthereumAddress txRecvAddr = addressCreate(NODE_RECV_ADDR);
     BREthereumAmount txAmount = amountCreateEther(etherCreate(uint256Create(NODE_ETHER_AMOUNT)));
-    BREthereumGasPrice txGasPrice = gasPriceCreate(etherCreate(uint256Create(NODE_GAS_PRICE_VALUE)));
-    BREthereumGas txGas = gasCreate(NODE_GAS_LIMIT);
+    BREthereumGasPrice txGasPrice = ethGasPriceCreate(etherCreate(uint256Create(NODE_GAS_PRICE_VALUE)));
+    BREthereumGas txGas = ethGasCreate(NODE_GAS_LIMIT);
 
     walletSetDefaultGasPrice(wallet, txGasPrice);
     walletSetDefaultGasLimit(wallet, txGas);
@@ -395,9 +395,9 @@ void testTransactionCodingEther () {
     rlpItemRelease(coder, item);
 
     assert (transactionGetNonce(transaction) == transactionGetNonce(decodedTransaction));
-    assert (ETHEREUM_COMPARISON_EQ == gasPriceCompare(transactionGetGasPrice(transaction),
+    assert (ETHEREUM_COMPARISON_EQ == ethGasPriceCompare(transactionGetGasPrice(transaction),
                                                       transactionGetGasPrice(decodedTransaction)));
-    assert (ETHEREUM_COMPARISON_EQ == gasCompare(transactionGetGasLimit(transaction),
+    assert (ETHEREUM_COMPARISON_EQ == ethGasCompare(transactionGetGasLimit(transaction),
                                                  transactionGetGasLimit(decodedTransaction)));
     assert (ETHEREUM_COMPARISON_EQ == etherCompare(transactionGetAmount(transaction),
                                                    transactionGetAmount(decodedTransaction)));
@@ -422,7 +422,7 @@ void testTransactionCodingEther () {
                                                                          11592,
                                                                          21,
                                                                          0,
-                                                                         gasCreate(0));
+                                                                         ethGasCreate(0));
     transactionSetStatus(transaction, status);
     item = transactionRlpEncode(transaction, ethereumMainnet, RLP_TYPE_ARCHIVE, coder);
     BREthereumTransaction archivedTransaction = transactionRlpDecode(item, ethereumMainnet, RLP_TYPE_ARCHIVE, coder);
@@ -448,8 +448,8 @@ void testTransactionCodingToken () {
 
     BREthereumAddress txRecvAddr = addressCreate(NODE_RECV_ADDR);
     BREthereumAmount txAmount = amountCreateToken(createTokenQuantity(token, uint256Create(NODE_ETHER_AMOUNT)));
-    BREthereumGasPrice txGasPrice = gasPriceCreate(etherCreate(uint256Create(NODE_GAS_PRICE_VALUE)));
-    BREthereumGas txGas = gasCreate(NODE_GAS_LIMIT);
+    BREthereumGasPrice txGasPrice = ethGasPriceCreate(etherCreate(uint256Create(NODE_GAS_PRICE_VALUE)));
+    BREthereumGas txGas = ethGasCreate(NODE_GAS_LIMIT);
 
     walletSetDefaultGasPrice(wallet, txGasPrice);
     walletSetDefaultGasLimit(wallet, txGas);
@@ -474,9 +474,9 @@ void testTransactionCodingToken () {
     rlpItemRelease(coder, item);
     
     assert (transactionGetNonce(transaction) == transactionGetNonce(decodedTransaction));
-    assert (ETHEREUM_COMPARISON_EQ == gasPriceCompare(transactionGetGasPrice(transaction),
+    assert (ETHEREUM_COMPARISON_EQ == ethGasPriceCompare(transactionGetGasPrice(transaction),
                                                       transactionGetGasPrice(decodedTransaction)));
-    assert (ETHEREUM_COMPARISON_EQ == gasCompare(transactionGetGasLimit(transaction),
+    assert (ETHEREUM_COMPARISON_EQ == ethGasCompare(transactionGetGasLimit(transaction),
                                                  transactionGetGasLimit(decodedTransaction)));
 //    int typeMismatch = 0;
 #if defined (TRANSACTION_ENCODE_TOKEN)

--- a/ethereum/test.c
+++ b/ethereum/test.c
@@ -124,11 +124,11 @@ void runTransactionTests1 (BREthereumAccount account, BREthereumNetwork network)
     
     BREthereumWallet  wallet = walletCreate(account, network);
     walletSetDefaultGasLimit(wallet, ethGasCreate(TEST_TRANS1_GAS_LIMIT));
-    walletSetDefaultGasPrice(wallet, ethGasPriceCreate(etherCreateNumber(TEST_TRANS1_GAS_PRICE_VALUE, TEST_TRANS1_GAS_PRICE_UNIT)));
+    walletSetDefaultGasPrice(wallet, ethGasPriceCreate(ethEtherCreateNumber(TEST_TRANS1_GAS_PRICE_VALUE, TEST_TRANS1_GAS_PRICE_UNIT)));
 
     BREthereumTransfer transfer = walletCreateTransfer(wallet,
                                                        ethAddressCreate(TEST_TRANS1_TARGET_ADDRESS),
-                                                       ethAmountCreateEther(etherCreateNumber(TEST_TRANS1_ETHER_AMOUNT, TEST_TRANS1_ETHER_AMOUNT_UNIT)));
+                                                       ethAmountCreateEther(ethEtherCreateNumber(TEST_TRANS1_ETHER_AMOUNT, TEST_TRANS1_ETHER_AMOUNT_UNIT)));
     BREthereumTransaction transaction = transferGetOriginatingTransaction(transfer);
     transactionSetNonce(transaction, TEST_TRANS1_NONCE);
 
@@ -189,11 +189,11 @@ void runTransactionTests2 (BREthereumAccount account, BREthereumNetwork network)
     
     BREthereumWallet  wallet = walletCreate(account, network);
     walletSetDefaultGasLimit(wallet, ethGasCreate(TEST_TRANS2_GAS_LIMIT));
-    walletSetDefaultGasPrice(wallet, ethGasPriceCreate(etherCreateNumber(TEST_TRANS2_GAS_PRICE_VALUE, TEST_TRANS2_GAS_PRICE_UNIT)));
+    walletSetDefaultGasPrice(wallet, ethGasPriceCreate(ethEtherCreateNumber(TEST_TRANS2_GAS_PRICE_VALUE, TEST_TRANS2_GAS_PRICE_UNIT)));
 
     BREthereumTransfer transfer = walletCreateTransfer(wallet,
                                                        ethAddressCreate(TEST_TRANS2_TARGET_ADDRESS),
-                                                       ethAmountCreateEther(etherCreateNumber(TEST_TRANS2_ETHER_AMOUNT,
+                                                       ethAmountCreateEther(ethEtherCreateNumber(TEST_TRANS2_ETHER_AMOUNT,
                                                                                            TEST_TRANS2_ETHER_AMOUNT_UNIT)));
     BREthereumTransaction transaction = transferGetOriginatingTransaction(transfer);
     transactionSetNonce(transaction, TEST_TRANS2_NONCE);
@@ -269,7 +269,7 @@ void runTransactionTests3 (BREthereumAccount account, BREthereumNetwork network)
     BREthereumAmount amount = ethAmountCreateToken(ethTokenQuantityCreate (token, value));
     
     walletSetDefaultGasLimit(wallet, ethGasCreate(TEST_TRANS3_GAS_LIMIT));
-    walletSetDefaultGasPrice(wallet, ethGasPriceCreate(etherCreateNumber(TEST_TRANS3_GAS_PRICE_VALUE, TEST_TRANS3_GAS_PRICE_UNIT)));
+    walletSetDefaultGasPrice(wallet, ethGasPriceCreate(ethEtherCreateNumber(TEST_TRANS3_GAS_PRICE_VALUE, TEST_TRANS3_GAS_PRICE_UNIT)));
 
     BREthereumTransfer transfer = walletCreateTransfer(wallet,
                                                        ethAddressCreate(TEST_TRANS3_TARGET_ADDRESS),
@@ -368,8 +368,8 @@ void testTransactionCodingEther () {
     BREthereumWallet wallet = walletCreate(account, ethNetworkMainnet);
 
     BREthereumAddress txRecvAddr = ethAddressCreate(NODE_RECV_ADDR);
-    BREthereumAmount txAmount = ethAmountCreateEther(etherCreate(uint256Create(NODE_ETHER_AMOUNT)));
-    BREthereumGasPrice txGasPrice = ethGasPriceCreate(etherCreate(uint256Create(NODE_GAS_PRICE_VALUE)));
+    BREthereumAmount txAmount = ethAmountCreateEther(ethEtherCreate(uint256Create(NODE_ETHER_AMOUNT)));
+    BREthereumGasPrice txGasPrice = ethGasPriceCreate(ethEtherCreate(uint256Create(NODE_GAS_PRICE_VALUE)));
     BREthereumGas txGas = ethGasCreate(NODE_GAS_LIMIT);
 
     walletSetDefaultGasPrice(wallet, txGasPrice);
@@ -399,7 +399,7 @@ void testTransactionCodingEther () {
                                                       transactionGetGasPrice(decodedTransaction)));
     assert (ETHEREUM_COMPARISON_EQ == ethGasCompare(transactionGetGasLimit(transaction),
                                                  transactionGetGasLimit(decodedTransaction)));
-    assert (ETHEREUM_COMPARISON_EQ == etherCompare(transactionGetAmount(transaction),
+    assert (ETHEREUM_COMPARISON_EQ == ethEtherCompare(transactionGetAmount(transaction),
                                                    transactionGetAmount(decodedTransaction)));
 
     assert (ETHEREUM_BOOLEAN_TRUE == ethAddressEqual(transactionGetTargetAddress(transaction),
@@ -448,7 +448,7 @@ void testTransactionCodingToken () {
 
     BREthereumAddress txRecvAddr = ethAddressCreate(NODE_RECV_ADDR);
     BREthereumAmount txAmount = ethAmountCreateToken(ethTokenQuantityCreate(token, uint256Create(NODE_ETHER_AMOUNT)));
-    BREthereumGasPrice txGasPrice = ethGasPriceCreate(etherCreate(uint256Create(NODE_GAS_PRICE_VALUE)));
+    BREthereumGasPrice txGasPrice = ethGasPriceCreate(ethEtherCreate(uint256Create(NODE_GAS_PRICE_VALUE)));
     BREthereumGas txGas = ethGasCreate(NODE_GAS_LIMIT);
 
     walletSetDefaultGasPrice(wallet, txGasPrice);

--- a/ethereum/test.c
+++ b/ethereum/test.c
@@ -406,7 +406,7 @@ void testTransactionCodingEther () {
                                                   transactionGetTargetAddress(decodedTransaction)));
 
     // Signature
-    assert (ETHEREUM_BOOLEAN_TRUE == signatureEqual(transactionGetSignature (transaction),
+    assert (ETHEREUM_BOOLEAN_TRUE == ethSignatureEqual(transactionGetSignature (transaction),
                                                     transactionGetSignature (decodedTransaction)));
 
     // Address recovery
@@ -487,7 +487,7 @@ void testTransactionCodingToken () {
                                                      transactionGetTargetAddress(decodedTransaction)));
 #endif
     // Signature
-    assert (ETHEREUM_BOOLEAN_TRUE == signatureEqual(transactionGetSignature (transaction),
+    assert (ETHEREUM_BOOLEAN_TRUE == ethSignatureEqual(transactionGetSignature (transaction),
                                                     transactionGetSignature (decodedTransaction)));
 
     walletUnhandleTransfer(wallet, transfer);

--- a/ethereum/test.c
+++ b/ethereum/test.c
@@ -59,14 +59,14 @@ tokenLookupTest (const char *address);
 #define TEST_ETH_PRIKEY   "0x73bf21bf06769f98dabcfac16c2f74e852da823effed12794e56876ede02d45d"
 
 void runAddressTests (BREthereumAccount account) {
-    BREthereumAddress address = accountGetPrimaryAddress(account);
+    BREthereumAddress address = ethAccountGetPrimaryAddress(account);
     
     printf ("== Address\n");
     printf ("        String: %p\n", &address);
     printf ("      PaperKey: %p, %s\n", TEST_PAPER_KEY, TEST_PAPER_KEY);
 
 #if defined (DEBUG)
-    const char *publicKeyString = accountGetPrimaryAddressPublicKeyString(account, 1);
+    const char *publicKeyString = ethAccountGetPrimaryAddressPublicKeyString(account, 1);
     printf ("    Public Key: %p, %s\n", publicKeyString, publicKeyString);
     assert (0 == strcmp (TEST_ETH_PUBKEY, publicKeyString));
     free ((void *) publicKeyString);
@@ -77,15 +77,15 @@ void runAddressTests (BREthereumAccount account) {
     assert (0 == strcmp (TEST_ETH_ADDR, addressString) ||
             0 == strcmp (TEST_ETH_ADDR_CHK, addressString));
 
-    assert (0 == accountGetAddressNonce(account, address));
-    assert (0 == accountGetThenIncrementAddressNonce(account, address));
-    assert (1 == accountGetAddressNonce(account, address));
-    accountSetAddressNonce(account, address, 0, ETHEREUM_BOOLEAN_FALSE);
-    assert (1 == accountGetAddressNonce(account, address));
-    accountSetAddressNonce(account, address, 0, ETHEREUM_BOOLEAN_TRUE);
-    assert (0 == accountGetAddressNonce(account, address));
-    accountSetAddressNonce(account, address, 2, ETHEREUM_BOOLEAN_FALSE);
-    assert (2 == accountGetAddressNonce(account, address));
+    assert (0 == ethAccountGetAddressNonce(account, address));
+    assert (0 == ethAccountGetThenIncrementAddressNonce(account, address));
+    assert (1 == ethAccountGetAddressNonce(account, address));
+    ethAccountSetAddressNonce(account, address, 0, ETHEREUM_BOOLEAN_FALSE);
+    assert (1 == ethAccountGetAddressNonce(account, address));
+    ethAccountSetAddressNonce(account, address, 0, ETHEREUM_BOOLEAN_TRUE);
+    assert (0 == ethAccountGetAddressNonce(account, address));
+    ethAccountSetAddressNonce(account, address, 2, ETHEREUM_BOOLEAN_FALSE);
+    assert (2 == ethAccountGetAddressNonce(account, address));
 
     free ((void *) addressString);
 }
@@ -328,14 +328,14 @@ void runTransactionTests (BREthereumAccount account, BREthereumNetwork network) 
 //
 void runAccountTests () {
     
-    BREthereumAccount account = createAccount(TEST_PAPER_KEY);
+    BREthereumAccount account = ethAccountCreate (TEST_PAPER_KEY);
     BREthereumNetwork network = ethereumMainnet;
     
     printf ("==== Account: %p\n", account);
     runAddressTests(account);
     runTransactionTests(account, network);
     
-    accountFree (account);
+    ethAccountRelease (account);
     printf ("\n\n");
 }
 
@@ -364,7 +364,7 @@ void runAccountTests () {
 void testTransactionCodingEther () {
     printf ("     Coding Transaction\n");
 
-    BREthereumAccount account = createAccount (NODE_PAPER_KEY);
+    BREthereumAccount account = ethAccountCreate (NODE_PAPER_KEY);
     BREthereumWallet wallet = walletCreate(account, ethereumMainnet);
 
     BREthereumAddress txRecvAddr = ethAddressCreate(NODE_RECV_ADDR);
@@ -414,7 +414,7 @@ void testTransactionCodingEther () {
     BREthereumAddress decodedTransactionSourceAddress = transactionGetSourceAddress(decodedTransaction);
     assert (ETHEREUM_BOOLEAN_IS_TRUE(ethAddressEqual(transactionSourceAddress, decodedTransactionSourceAddress)));
 
-    assert (ETHEREUM_BOOLEAN_IS_TRUE(accountHasAddress(account, transactionSourceAddress)));
+    assert (ETHEREUM_BOOLEAN_IS_TRUE(ethAccountHasAddress(account, transactionSourceAddress)));
 
     // Archive
     BREthereumHash someBlockHash = HASH_INIT("fc45a8c5ebb5f920931e3d5f48992f3a89b544b4e21dc2c11c5bf8165a7245d6");
@@ -443,7 +443,7 @@ void testTransactionCodingToken () {
     printf ("     Coding Transaction\n");
 
     BREthereumToken token = tokenLookupTest(tokenBRDAddress);
-    BREthereumAccount account = createAccount (NODE_PAPER_KEY);
+    BREthereumAccount account = ethAccountCreate (NODE_PAPER_KEY);
     BREthereumWallet wallet = walletCreateHoldingToken(account, ethereumMainnet, token);
 
     BREthereumAddress txRecvAddr = ethAddressCreate(NODE_RECV_ADDR);

--- a/ethereum/test.c
+++ b/ethereum/test.c
@@ -138,7 +138,7 @@ void runTransactionTests1 (BREthereumAccount account, BREthereumNetwork network)
     BRRlpData dataUnsignedTransaction = rlpGetData(coder, item);
 
     char result[2 * dataUnsignedTransaction.bytesCount + 1];
-    encodeHex(result, 2 * dataUnsignedTransaction.bytesCount + 1, dataUnsignedTransaction.bytes, dataUnsignedTransaction.bytesCount);
+    hexEncode(result, 2 * dataUnsignedTransaction.bytesCount + 1, dataUnsignedTransaction.bytes, dataUnsignedTransaction.bytesCount);
     printf ("       Tx1 Raw (unsigned): %s\n", result);
     assert (0 == strcmp (result, TEST_TRANS1_RESULT));
     rlpDataRelease(dataUnsignedTransaction);
@@ -205,12 +205,12 @@ void runTransactionTests2 (BREthereumAccount account, BREthereumNetwork network)
     BRRlpData data = rlpGetData(coder, item);
 
     char result[2 * data.bytesCount + 1];
-    encodeHex(result, 2 * data.bytesCount + 1, data.bytes, data.bytesCount);
+    hexEncode(result, 2 * data.bytesCount + 1, data.bytes, data.bytesCount);
     printf ("       Tx2 Raw (unsigned): %s\n", result);
     assert (0 == strcmp (result, TEST_TRANS2_RESULT_UNSIGNED));
     rlpDataRelease(data);
 
-    data.bytes = decodeHexCreate(&data.bytesCount, TEST_TRANS2_RESULT_SIGNED, strlen (TEST_TRANS2_RESULT_SIGNED));
+    data.bytes = hexDecodeCreate(&data.bytesCount, TEST_TRANS2_RESULT_SIGNED, strlen (TEST_TRANS2_RESULT_SIGNED));
     rlpShow(data, "Trans2Test");
     rlpDataRelease(data);
 
@@ -282,7 +282,7 @@ void runTransactionTests3 (BREthereumAccount account, BREthereumNetwork network)
     BRRlpItem item = transactionRlpEncode(transaction, network, RLP_TYPE_TRANSACTION_UNSIGNED, coder);
     BRRlpData dataUnsignedTransaction = rlpGetData (coder, item);
     
-    char *rawTx = encodeHexCreate(NULL, dataUnsignedTransaction.bytes, dataUnsignedTransaction.bytesCount);
+    char *rawTx = hexEncodeCreate(NULL, dataUnsignedTransaction.bytes, dataUnsignedTransaction.bytesCount);
     printf ("       Tx3 Raw (unsigned): %s\n", rawTx);
     assert (0 == strcasecmp(rawTx, (0 == strcmp (tokenBRDAddress, "0x558ec3152e2eb2174905cd19aea4e34a23de9ad6") ? TEST_TRANS3_UNSIGNED_TX_MAINNET : TEST_TRANS3_UNSIGNED_TX_TESTNET)));
     free (rawTx);
@@ -301,7 +301,7 @@ void runTransactionTests4 (BREthereumAccount account, BREthereumNetwork network)
     printf ("     TEST 4\n");
 
     BRRlpData data;
-    data.bytes = decodeHexCreate(&data.bytesCount, TEST_TRANS4_SIGNED_TX, strlen (TEST_TRANS4_SIGNED_TX));
+    data.bytes = hexDecodeCreate(&data.bytesCount, TEST_TRANS4_SIGNED_TX, strlen (TEST_TRANS4_SIGNED_TX));
 
     BRRlpCoder coder = rlpCoderCreate();
     BRRlpItem item = rlpGetItem(coder, data);
@@ -388,7 +388,7 @@ void testTransactionCodingEther () {
                                           RLP_TYPE_TRANSACTION_SIGNED,
                                           coder);
     BRRlpData data = rlpGetData (coder, item);
-    char *rawTx = encodeHexCreate(NULL, data.bytes, data.bytesCount);
+    char *rawTx = hexEncodeCreate(NULL, data.bytes, data.bytesCount);
     printf ("        Raw Transaction: 0x%s\n", rawTx);
 
     BREthereumTransaction decodedTransaction = transactionRlpDecode(item, ethereumMainnet, RLP_TYPE_TRANSACTION_SIGNED, coder);
@@ -467,7 +467,7 @@ void testTransactionCodingToken () {
                                           RLP_TYPE_TRANSACTION_SIGNED,
                                           coder);
     BRRlpData data = rlpGetData (coder, item);
-    char *rawTx = encodeHexCreate(NULL, data.bytes, data.bytesCount);
+    char *rawTx = hexEncodeCreate(NULL, data.bytes, data.bytesCount);
     printf ("        Raw Transaction: 0x%s\n", rawTx);
 
     BREthereumTransaction decodedTransaction = transactionRlpDecode(item, ethereumMainnet, RLP_TYPE_TRANSACTION_SIGNED, coder);
@@ -507,7 +507,7 @@ runPerfTestsCoder (int repeat, int many) {
     BRRlpCoder coderSaved = coder;
 
     BRRlpData data;
-    data.bytes = decodeHexCreate(&data.bytesCount, TEST_TRANS4_SIGNED_TX, strlen (TEST_TRANS4_SIGNED_TX));
+    data.bytes = hexDecodeCreate(&data.bytesCount, TEST_TRANS4_SIGNED_TX, strlen (TEST_TRANS4_SIGNED_TX));
 
     BRRlpItem item = rlpGetItem(coder, data);
     BREthereumTransaction transaction = transactionRlpDecode(item, ethereumMainnet, RLP_TYPE_TRANSACTION_SIGNED, coder);

--- a/ethereum/test.c
+++ b/ethereum/test.c
@@ -128,7 +128,7 @@ void runTransactionTests1 (BREthereumAccount account, BREthereumNetwork network)
 
     BREthereumTransfer transfer = walletCreateTransfer(wallet,
                                                        ethAddressCreate(TEST_TRANS1_TARGET_ADDRESS),
-                                                       amountCreateEther(etherCreateNumber(TEST_TRANS1_ETHER_AMOUNT, TEST_TRANS1_ETHER_AMOUNT_UNIT)));
+                                                       ethAmountCreateEther(etherCreateNumber(TEST_TRANS1_ETHER_AMOUNT, TEST_TRANS1_ETHER_AMOUNT_UNIT)));
     BREthereumTransaction transaction = transferGetOriginatingTransaction(transfer);
     transactionSetNonce(transaction, TEST_TRANS1_NONCE);
 
@@ -193,7 +193,7 @@ void runTransactionTests2 (BREthereumAccount account, BREthereumNetwork network)
 
     BREthereumTransfer transfer = walletCreateTransfer(wallet,
                                                        ethAddressCreate(TEST_TRANS2_TARGET_ADDRESS),
-                                                       amountCreateEther(etherCreateNumber(TEST_TRANS2_ETHER_AMOUNT,
+                                                       ethAmountCreateEther(etherCreateNumber(TEST_TRANS2_ETHER_AMOUNT,
                                                                                            TEST_TRANS2_ETHER_AMOUNT_UNIT)));
     BREthereumTransaction transaction = transferGetOriginatingTransaction(transfer);
     transactionSetNonce(transaction, TEST_TRANS2_NONCE);
@@ -266,7 +266,7 @@ void runTransactionTests3 (BREthereumAccount account, BREthereumNetwork network)
     BREthereumToken token = tokenLookupTest (tokenBRDAddress);
     BREthereumWallet wallet = walletCreateHoldingToken (account, network, token);
     UInt256 value = uint256CreateParse ("5968770000000000000000", 10, &status);
-    BREthereumAmount amount = amountCreateToken(ethTokenQuantityCreate (token, value));
+    BREthereumAmount amount = ethAmountCreateToken(ethTokenQuantityCreate (token, value));
     
     walletSetDefaultGasLimit(wallet, ethGasCreate(TEST_TRANS3_GAS_LIMIT));
     walletSetDefaultGasPrice(wallet, ethGasPriceCreate(etherCreateNumber(TEST_TRANS3_GAS_PRICE_VALUE, TEST_TRANS3_GAS_PRICE_UNIT)));
@@ -368,7 +368,7 @@ void testTransactionCodingEther () {
     BREthereumWallet wallet = walletCreate(account, ethNetworkMainnet);
 
     BREthereumAddress txRecvAddr = ethAddressCreate(NODE_RECV_ADDR);
-    BREthereumAmount txAmount = amountCreateEther(etherCreate(uint256Create(NODE_ETHER_AMOUNT)));
+    BREthereumAmount txAmount = ethAmountCreateEther(etherCreate(uint256Create(NODE_ETHER_AMOUNT)));
     BREthereumGasPrice txGasPrice = ethGasPriceCreate(etherCreate(uint256Create(NODE_GAS_PRICE_VALUE)));
     BREthereumGas txGas = ethGasCreate(NODE_GAS_LIMIT);
 
@@ -447,7 +447,7 @@ void testTransactionCodingToken () {
     BREthereumWallet wallet = walletCreateHoldingToken(account, ethNetworkMainnet, token);
 
     BREthereumAddress txRecvAddr = ethAddressCreate(NODE_RECV_ADDR);
-    BREthereumAmount txAmount = amountCreateToken(ethTokenQuantityCreate(token, uint256Create(NODE_ETHER_AMOUNT)));
+    BREthereumAmount txAmount = ethAmountCreateToken(ethTokenQuantityCreate(token, uint256Create(NODE_ETHER_AMOUNT)));
     BREthereumGasPrice txGasPrice = ethGasPriceCreate(etherCreate(uint256Create(NODE_GAS_PRICE_VALUE)));
     BREthereumGas txGas = ethGasCreate(NODE_GAS_LIMIT);
 

--- a/ethereum/test.c
+++ b/ethereum/test.c
@@ -132,7 +132,7 @@ void runTransactionTests1 (BREthereumAccount account, BREthereumNetwork network)
     BREthereumTransaction transaction = transferGetOriginatingTransaction(transfer);
     transactionSetNonce(transaction, TEST_TRANS1_NONCE);
 
-    assert (1 == networkGetChainId(network));
+    assert (1 == ethNetworkGetChainId(network));
     BRRlpCoder coder = rlpCoderCreate();
     BRRlpItem item = transactionRlpEncode(transaction, network, RLP_TYPE_TRANSACTION_UNSIGNED, coder);
     BRRlpData dataUnsignedTransaction = rlpItemGetData(coder, item);
@@ -198,7 +198,7 @@ void runTransactionTests2 (BREthereumAccount account, BREthereumNetwork network)
     BREthereumTransaction transaction = transferGetOriginatingTransaction(transfer);
     transactionSetNonce(transaction, TEST_TRANS2_NONCE);
 
-    assert (1 == networkGetChainId(network));
+    assert (1 == ethNetworkGetChainId(network));
 
     BRRlpCoder coder = rlpCoderCreate();
     BRRlpItem item = transactionRlpEncode(transaction, network, RLP_TYPE_TRANSACTION_UNSIGNED, coder);
@@ -277,7 +277,7 @@ void runTransactionTests3 (BREthereumAccount account, BREthereumNetwork network)
     BREthereumTransaction transaction = transferGetOriginatingTransaction(transfer);
     transactionSetNonce(transaction, TEST_TRANS3_NONCE);
 
-    assert (1 == networkGetChainId(network));
+    assert (1 == ethNetworkGetChainId(network));
     BRRlpCoder coder = rlpCoderCreate();
     BRRlpItem item = transactionRlpEncode(transaction, network, RLP_TYPE_TRANSACTION_UNSIGNED, coder);
     BRRlpData dataUnsignedTransaction = rlpItemGetData (coder, item);
@@ -329,7 +329,7 @@ void runTransactionTests (BREthereumAccount account, BREthereumNetwork network) 
 void runAccountTests () {
     
     BREthereumAccount account = ethAccountCreate (TEST_PAPER_KEY);
-    BREthereumNetwork network = ethereumMainnet;
+    BREthereumNetwork network = ethNetworkMainnet;
     
     printf ("==== Account: %p\n", account);
     runAddressTests(account);
@@ -365,7 +365,7 @@ void testTransactionCodingEther () {
     printf ("     Coding Transaction\n");
 
     BREthereumAccount account = ethAccountCreate (NODE_PAPER_KEY);
-    BREthereumWallet wallet = walletCreate(account, ethereumMainnet);
+    BREthereumWallet wallet = walletCreate(account, ethNetworkMainnet);
 
     BREthereumAddress txRecvAddr = ethAddressCreate(NODE_RECV_ADDR);
     BREthereumAmount txAmount = amountCreateEther(etherCreate(uint256Create(NODE_ETHER_AMOUNT)));
@@ -384,14 +384,14 @@ void testTransactionCodingEther () {
 
     BRRlpCoder coder = rlpCoderCreate();
     BRRlpItem item = transactionRlpEncode(transaction,
-                                          ethereumMainnet,
+                                          ethNetworkMainnet,
                                           RLP_TYPE_TRANSACTION_SIGNED,
                                           coder);
     BRRlpData data = rlpItemGetData (coder, item);
     char *rawTx = hexEncodeCreate(NULL, data.bytes, data.bytesCount);
     printf ("        Raw Transaction: 0x%s\n", rawTx);
 
-    BREthereumTransaction decodedTransaction = transactionRlpDecode(item, ethereumMainnet, RLP_TYPE_TRANSACTION_SIGNED, coder);
+    BREthereumTransaction decodedTransaction = transactionRlpDecode(item, ethNetworkMainnet, RLP_TYPE_TRANSACTION_SIGNED, coder);
     rlpItemRelease(coder, item);
 
     assert (transactionGetNonce(transaction) == transactionGetNonce(decodedTransaction));
@@ -424,8 +424,8 @@ void testTransactionCodingEther () {
                                                                          0,
                                                                          ethGasCreate(0));
     transactionSetStatus(transaction, status);
-    item = transactionRlpEncode(transaction, ethereumMainnet, RLP_TYPE_ARCHIVE, coder);
-    BREthereumTransaction archivedTransaction = transactionRlpDecode(item, ethereumMainnet, RLP_TYPE_ARCHIVE, coder);
+    item = transactionRlpEncode(transaction, ethNetworkMainnet, RLP_TYPE_ARCHIVE, coder);
+    BREthereumTransaction archivedTransaction = transactionRlpDecode(item, ethNetworkMainnet, RLP_TYPE_ARCHIVE, coder);
     rlpItemRelease(coder, item);
     BREthereumTransactionStatus archivedStatus = transactionGetStatus(archivedTransaction);
     assert (ETHEREUM_BOOLEAN_IS_TRUE(transactionStatusEqual(status, archivedStatus)));
@@ -444,7 +444,7 @@ void testTransactionCodingToken () {
 
     BREthereumToken token = tokenLookupTest(tokenBRDAddress);
     BREthereumAccount account = ethAccountCreate (NODE_PAPER_KEY);
-    BREthereumWallet wallet = walletCreateHoldingToken(account, ethereumMainnet, token);
+    BREthereumWallet wallet = walletCreateHoldingToken(account, ethNetworkMainnet, token);
 
     BREthereumAddress txRecvAddr = ethAddressCreate(NODE_RECV_ADDR);
     BREthereumAmount txAmount = amountCreateToken(createTokenQuantity(token, uint256Create(NODE_ETHER_AMOUNT)));
@@ -463,14 +463,14 @@ void testTransactionCodingToken () {
 
     BRRlpCoder coder = rlpCoderCreate();
     BRRlpItem item = transactionRlpEncode(transaction,
-                                          ethereumMainnet,
+                                          ethNetworkMainnet,
                                           RLP_TYPE_TRANSACTION_SIGNED,
                                           coder);
     BRRlpData data = rlpItemGetData (coder, item);
     char *rawTx = hexEncodeCreate(NULL, data.bytes, data.bytesCount);
     printf ("        Raw Transaction: 0x%s\n", rawTx);
 
-    BREthereumTransaction decodedTransaction = transactionRlpDecode(item, ethereumMainnet, RLP_TYPE_TRANSACTION_SIGNED, coder);
+    BREthereumTransaction decodedTransaction = transactionRlpDecode(item, ethNetworkMainnet, RLP_TYPE_TRANSACTION_SIGNED, coder);
     rlpItemRelease(coder, item);
     
     assert (transactionGetNonce(transaction) == transactionGetNonce(decodedTransaction));
@@ -510,17 +510,17 @@ runPerfTestsCoder (int repeat, int many) {
     data.bytes = hexDecodeCreate(&data.bytesCount, TEST_TRANS4_SIGNED_TX, strlen (TEST_TRANS4_SIGNED_TX));
 
     BRRlpItem item = rlpDataGetItem(coder, data);
-    BREthereumTransaction transaction = transactionRlpDecode(item, ethereumMainnet, RLP_TYPE_TRANSACTION_SIGNED, coder);
+    BREthereumTransaction transaction = transactionRlpDecode(item, ethNetworkMainnet, RLP_TYPE_TRANSACTION_SIGNED, coder);
 
     BRRlpItem items [100];
 
     while (repeat-- > 0) {
         if (many) coder = rlpCoderCreate();
         for (int i = 0; i < 100; i++)
-            items[i] = transactionRlpEncode(transaction, ethereumMainnet, RLP_TYPE_TRANSACTION_SIGNED, coder);
+            items[i] = transactionRlpEncode(transaction, ethNetworkMainnet, RLP_TYPE_TRANSACTION_SIGNED, coder);
 
         for (int i = 0; i < 100; i++)
-            transactionRelease(transactionRlpDecode(item, ethereumMainnet, RLP_TYPE_TRANSACTION_SIGNED, coder));
+            transactionRelease(transactionRlpDecode(item, ethNetworkMainnet, RLP_TYPE_TRANSACTION_SIGNED, coder));
 
         for (int i = 0; i < 100; i++)
             rlpItemRelease(coder, items[i]);

--- a/ethereum/test.c
+++ b/ethereum/test.c
@@ -307,7 +307,7 @@ void runTransactionTests4 (BREthereumAccount account, BREthereumNetwork network)
     BRRlpItem item = rlpDataGetItem(coder, data);
     BREthereumTransaction tx = transactionRlpDecode(item, network, RLP_TYPE_TRANSACTION_SIGNED, coder);
 
-    assert (ETHEREUM_BOOLEAN_IS_TRUE (hashEqual(transactionGetHash(tx), hashCreate(TEST_TRANS4_HASH))));
+    assert (ETHEREUM_BOOLEAN_IS_TRUE (ethHashEqual(transactionGetHash(tx), ethHashCreate(TEST_TRANS4_HASH))));
     rlpDataRelease(data);
     transactionRelease(tx);
     rlpItemRelease(coder, item);
@@ -431,7 +431,7 @@ void testTransactionCodingEther () {
     assert (ETHEREUM_BOOLEAN_IS_TRUE(transactionStatusEqual(status, archivedStatus)));
     assert (ETHEREUM_BOOLEAN_IS_TRUE(addressEqual(transactionGetTargetAddress(transaction),
                                                   transactionGetTargetAddress(archivedTransaction))));
-    assert (ETHEREUM_BOOLEAN_IS_TRUE(hashEqual(status.u.included.blockHash, someBlockHash)));
+    assert (ETHEREUM_BOOLEAN_IS_TRUE(ethHashEqual(status.u.included.blockHash, someBlockHash)));
 
     walletUnhandleTransfer(wallet, transfer);
     transferRelease(transfer);

--- a/ethereum/test.c
+++ b/ethereum/test.c
@@ -266,7 +266,7 @@ void runTransactionTests3 (BREthereumAccount account, BREthereumNetwork network)
     BREthereumToken token = tokenLookupTest (tokenBRDAddress);
     BREthereumWallet wallet = walletCreateHoldingToken (account, network, token);
     UInt256 value = uint256CreateParse ("5968770000000000000000", 10, &status);
-    BREthereumAmount amount = amountCreateToken(createTokenQuantity (token, value));
+    BREthereumAmount amount = amountCreateToken(ethTokenQuantityCreate (token, value));
     
     walletSetDefaultGasLimit(wallet, ethGasCreate(TEST_TRANS3_GAS_LIMIT));
     walletSetDefaultGasPrice(wallet, ethGasPriceCreate(etherCreateNumber(TEST_TRANS3_GAS_PRICE_VALUE, TEST_TRANS3_GAS_PRICE_UNIT)));
@@ -447,7 +447,7 @@ void testTransactionCodingToken () {
     BREthereumWallet wallet = walletCreateHoldingToken(account, ethNetworkMainnet, token);
 
     BREthereumAddress txRecvAddr = ethAddressCreate(NODE_RECV_ADDR);
-    BREthereumAmount txAmount = amountCreateToken(createTokenQuantity(token, uint256Create(NODE_ETHER_AMOUNT)));
+    BREthereumAmount txAmount = amountCreateToken(ethTokenQuantityCreate(token, uint256Create(NODE_ETHER_AMOUNT)));
     BREthereumGasPrice txGasPrice = ethGasPriceCreate(etherCreate(uint256Create(NODE_GAS_PRICE_VALUE)));
     BREthereumGas txGas = ethGasCreate(NODE_GAS_LIMIT);
 

--- a/ethereum/test.c
+++ b/ethereum/test.c
@@ -265,7 +265,7 @@ void runTransactionTests3 (BREthereumAccount account, BREthereumNetwork network)
     BRCoreParseStatus status;
     BREthereumToken token = tokenLookupTest (tokenBRDAddress);
     BREthereumWallet wallet = walletCreateHoldingToken (account, network, token);
-    UInt256 value = createUInt256Parse ("5968770000000000000000", 10, &status);
+    UInt256 value = uint256CreateParse ("5968770000000000000000", 10, &status);
     BREthereumAmount amount = amountCreateToken(createTokenQuantity (token, value));
     
     walletSetDefaultGasLimit(wallet, gasCreate(TEST_TRANS3_GAS_LIMIT));
@@ -368,8 +368,8 @@ void testTransactionCodingEther () {
     BREthereumWallet wallet = walletCreate(account, ethereumMainnet);
 
     BREthereumAddress txRecvAddr = addressCreate(NODE_RECV_ADDR);
-    BREthereumAmount txAmount = amountCreateEther(etherCreate(createUInt256(NODE_ETHER_AMOUNT)));
-    BREthereumGasPrice txGasPrice = gasPriceCreate(etherCreate(createUInt256(NODE_GAS_PRICE_VALUE)));
+    BREthereumAmount txAmount = amountCreateEther(etherCreate(uint256Create(NODE_ETHER_AMOUNT)));
+    BREthereumGasPrice txGasPrice = gasPriceCreate(etherCreate(uint256Create(NODE_GAS_PRICE_VALUE)));
     BREthereumGas txGas = gasCreate(NODE_GAS_LIMIT);
 
     walletSetDefaultGasPrice(wallet, txGasPrice);
@@ -447,8 +447,8 @@ void testTransactionCodingToken () {
     BREthereumWallet wallet = walletCreateHoldingToken(account, ethereumMainnet, token);
 
     BREthereumAddress txRecvAddr = addressCreate(NODE_RECV_ADDR);
-    BREthereumAmount txAmount = amountCreateToken(createTokenQuantity(token, createUInt256(NODE_ETHER_AMOUNT)));
-    BREthereumGasPrice txGasPrice = gasPriceCreate(etherCreate(createUInt256(NODE_GAS_PRICE_VALUE)));
+    BREthereumAmount txAmount = amountCreateToken(createTokenQuantity(token, uint256Create(NODE_ETHER_AMOUNT)));
+    BREthereumGasPrice txGasPrice = gasPriceCreate(etherCreate(uint256Create(NODE_GAS_PRICE_VALUE)));
     BREthereumGas txGas = gasCreate(NODE_GAS_LIMIT);
 
     walletSetDefaultGasPrice(wallet, txGasPrice);

--- a/ethereum/test.c
+++ b/ethereum/test.c
@@ -72,7 +72,7 @@ void runAddressTests (BREthereumAccount account) {
     free ((void *) publicKeyString);
 #endif
     
-    const char *addressString = addressGetEncodedString(address, 1);
+    const char *addressString = ethAddressGetEncodedString(address, 1);
     printf ("       Address: %s\n", addressString);
     assert (0 == strcmp (TEST_ETH_ADDR, addressString) ||
             0 == strcmp (TEST_ETH_ADDR_CHK, addressString));
@@ -127,7 +127,7 @@ void runTransactionTests1 (BREthereumAccount account, BREthereumNetwork network)
     walletSetDefaultGasPrice(wallet, ethGasPriceCreate(etherCreateNumber(TEST_TRANS1_GAS_PRICE_VALUE, TEST_TRANS1_GAS_PRICE_UNIT)));
 
     BREthereumTransfer transfer = walletCreateTransfer(wallet,
-                                                       addressCreate(TEST_TRANS1_TARGET_ADDRESS),
+                                                       ethAddressCreate(TEST_TRANS1_TARGET_ADDRESS),
                                                        amountCreateEther(etherCreateNumber(TEST_TRANS1_ETHER_AMOUNT, TEST_TRANS1_ETHER_AMOUNT_UNIT)));
     BREthereumTransaction transaction = transferGetOriginatingTransaction(transfer);
     transactionSetNonce(transaction, TEST_TRANS1_NONCE);
@@ -192,7 +192,7 @@ void runTransactionTests2 (BREthereumAccount account, BREthereumNetwork network)
     walletSetDefaultGasPrice(wallet, ethGasPriceCreate(etherCreateNumber(TEST_TRANS2_GAS_PRICE_VALUE, TEST_TRANS2_GAS_PRICE_UNIT)));
 
     BREthereumTransfer transfer = walletCreateTransfer(wallet,
-                                                       addressCreate(TEST_TRANS2_TARGET_ADDRESS),
+                                                       ethAddressCreate(TEST_TRANS2_TARGET_ADDRESS),
                                                        amountCreateEther(etherCreateNumber(TEST_TRANS2_ETHER_AMOUNT,
                                                                                            TEST_TRANS2_ETHER_AMOUNT_UNIT)));
     BREthereumTransaction transaction = transferGetOriginatingTransaction(transfer);
@@ -272,7 +272,7 @@ void runTransactionTests3 (BREthereumAccount account, BREthereumNetwork network)
     walletSetDefaultGasPrice(wallet, ethGasPriceCreate(etherCreateNumber(TEST_TRANS3_GAS_PRICE_VALUE, TEST_TRANS3_GAS_PRICE_UNIT)));
 
     BREthereumTransfer transfer = walletCreateTransfer(wallet,
-                                                       addressCreate(TEST_TRANS3_TARGET_ADDRESS),
+                                                       ethAddressCreate(TEST_TRANS3_TARGET_ADDRESS),
                                                        amount);
     BREthereumTransaction transaction = transferGetOriginatingTransaction(transfer);
     transactionSetNonce(transaction, TEST_TRANS3_NONCE);
@@ -367,7 +367,7 @@ void testTransactionCodingEther () {
     BREthereumAccount account = createAccount (NODE_PAPER_KEY);
     BREthereumWallet wallet = walletCreate(account, ethereumMainnet);
 
-    BREthereumAddress txRecvAddr = addressCreate(NODE_RECV_ADDR);
+    BREthereumAddress txRecvAddr = ethAddressCreate(NODE_RECV_ADDR);
     BREthereumAmount txAmount = amountCreateEther(etherCreate(uint256Create(NODE_ETHER_AMOUNT)));
     BREthereumGasPrice txGasPrice = ethGasPriceCreate(etherCreate(uint256Create(NODE_GAS_PRICE_VALUE)));
     BREthereumGas txGas = ethGasCreate(NODE_GAS_LIMIT);
@@ -402,7 +402,7 @@ void testTransactionCodingEther () {
     assert (ETHEREUM_COMPARISON_EQ == etherCompare(transactionGetAmount(transaction),
                                                    transactionGetAmount(decodedTransaction)));
 
-    assert (ETHEREUM_BOOLEAN_TRUE == addressEqual(transactionGetTargetAddress(transaction),
+    assert (ETHEREUM_BOOLEAN_TRUE == ethAddressEqual(transactionGetTargetAddress(transaction),
                                                   transactionGetTargetAddress(decodedTransaction)));
 
     // Signature
@@ -412,7 +412,7 @@ void testTransactionCodingEther () {
     // Address recovery
     BREthereumAddress transactionSourceAddress = transactionGetSourceAddress(transaction);
     BREthereumAddress decodedTransactionSourceAddress = transactionGetSourceAddress(decodedTransaction);
-    assert (ETHEREUM_BOOLEAN_IS_TRUE(addressEqual(transactionSourceAddress, decodedTransactionSourceAddress)));
+    assert (ETHEREUM_BOOLEAN_IS_TRUE(ethAddressEqual(transactionSourceAddress, decodedTransactionSourceAddress)));
 
     assert (ETHEREUM_BOOLEAN_IS_TRUE(accountHasAddress(account, transactionSourceAddress)));
 
@@ -429,7 +429,7 @@ void testTransactionCodingEther () {
     rlpItemRelease(coder, item);
     BREthereumTransactionStatus archivedStatus = transactionGetStatus(archivedTransaction);
     assert (ETHEREUM_BOOLEAN_IS_TRUE(transactionStatusEqual(status, archivedStatus)));
-    assert (ETHEREUM_BOOLEAN_IS_TRUE(addressEqual(transactionGetTargetAddress(transaction),
+    assert (ETHEREUM_BOOLEAN_IS_TRUE(ethAddressEqual(transactionGetTargetAddress(transaction),
                                                   transactionGetTargetAddress(archivedTransaction))));
     assert (ETHEREUM_BOOLEAN_IS_TRUE(ethHashEqual(status.u.included.blockHash, someBlockHash)));
 
@@ -446,7 +446,7 @@ void testTransactionCodingToken () {
     BREthereumAccount account = createAccount (NODE_PAPER_KEY);
     BREthereumWallet wallet = walletCreateHoldingToken(account, ethereumMainnet, token);
 
-    BREthereumAddress txRecvAddr = addressCreate(NODE_RECV_ADDR);
+    BREthereumAddress txRecvAddr = ethAddressCreate(NODE_RECV_ADDR);
     BREthereumAmount txAmount = amountCreateToken(createTokenQuantity(token, uint256Create(NODE_ETHER_AMOUNT)));
     BREthereumGasPrice txGasPrice = ethGasPriceCreate(etherCreate(uint256Create(NODE_GAS_PRICE_VALUE)));
     BREthereumGas txGas = ethGasCreate(NODE_GAS_LIMIT);

--- a/ethereum/test.c
+++ b/ethereum/test.c
@@ -135,7 +135,7 @@ void runTransactionTests1 (BREthereumAccount account, BREthereumNetwork network)
     assert (1 == networkGetChainId(network));
     BRRlpCoder coder = rlpCoderCreate();
     BRRlpItem item = transactionRlpEncode(transaction, network, RLP_TYPE_TRANSACTION_UNSIGNED, coder);
-    BRRlpData dataUnsignedTransaction = rlpGetData(coder, item);
+    BRRlpData dataUnsignedTransaction = rlpItemGetData(coder, item);
 
     char result[2 * dataUnsignedTransaction.bytesCount + 1];
     hexEncode(result, 2 * dataUnsignedTransaction.bytesCount + 1, dataUnsignedTransaction.bytes, dataUnsignedTransaction.bytesCount);
@@ -154,7 +154,7 @@ void runTransactionTests1 (BREthereumAccount account, BREthereumNetwork network)
 
     walletUnhandleTransfer(wallet, transfer);
     transferRelease(transfer);
-    rlpReleaseItem(coder, item);
+    rlpItemRelease(coder, item);
     rlpCoderRelease(coder);
 }
 
@@ -202,7 +202,7 @@ void runTransactionTests2 (BREthereumAccount account, BREthereumNetwork network)
 
     BRRlpCoder coder = rlpCoderCreate();
     BRRlpItem item = transactionRlpEncode(transaction, network, RLP_TYPE_TRANSACTION_UNSIGNED, coder);
-    BRRlpData data = rlpGetData(coder, item);
+    BRRlpData data = rlpItemGetData(coder, item);
 
     char result[2 * data.bytesCount + 1];
     hexEncode(result, 2 * data.bytesCount + 1, data.bytes, data.bytesCount);
@@ -211,12 +211,12 @@ void runTransactionTests2 (BREthereumAccount account, BREthereumNetwork network)
     rlpDataRelease(data);
 
     data.bytes = hexDecodeCreate(&data.bytesCount, TEST_TRANS2_RESULT_SIGNED, strlen (TEST_TRANS2_RESULT_SIGNED));
-    rlpShow(data, "Trans2Test");
+    rlpDataShow(data, "Trans2Test");
     rlpDataRelease(data);
 
     walletUnhandleTransfer(wallet, transfer);
     transferRelease(transfer);
-    rlpReleaseItem(coder, item);
+    rlpItemRelease(coder, item);
     rlpCoderRelease(coder);
 }
 
@@ -280,7 +280,7 @@ void runTransactionTests3 (BREthereumAccount account, BREthereumNetwork network)
     assert (1 == networkGetChainId(network));
     BRRlpCoder coder = rlpCoderCreate();
     BRRlpItem item = transactionRlpEncode(transaction, network, RLP_TYPE_TRANSACTION_UNSIGNED, coder);
-    BRRlpData dataUnsignedTransaction = rlpGetData (coder, item);
+    BRRlpData dataUnsignedTransaction = rlpItemGetData (coder, item);
     
     char *rawTx = hexEncodeCreate(NULL, dataUnsignedTransaction.bytes, dataUnsignedTransaction.bytesCount);
     printf ("       Tx3 Raw (unsigned): %s\n", rawTx);
@@ -290,7 +290,7 @@ void runTransactionTests3 (BREthereumAccount account, BREthereumNetwork network)
 
     walletUnhandleTransfer(wallet, transfer);
     transferRelease(transfer);
-    rlpReleaseItem(coder, item);
+    rlpItemRelease(coder, item);
     rlpCoderRelease(coder);
 }
 
@@ -304,13 +304,13 @@ void runTransactionTests4 (BREthereumAccount account, BREthereumNetwork network)
     data.bytes = hexDecodeCreate(&data.bytesCount, TEST_TRANS4_SIGNED_TX, strlen (TEST_TRANS4_SIGNED_TX));
 
     BRRlpCoder coder = rlpCoderCreate();
-    BRRlpItem item = rlpGetItem(coder, data);
+    BRRlpItem item = rlpDataGetItem(coder, data);
     BREthereumTransaction tx = transactionRlpDecode(item, network, RLP_TYPE_TRANSACTION_SIGNED, coder);
 
     assert (ETHEREUM_BOOLEAN_IS_TRUE (hashEqual(transactionGetHash(tx), hashCreate(TEST_TRANS4_HASH))));
     rlpDataRelease(data);
     transactionRelease(tx);
-    rlpReleaseItem(coder, item);
+    rlpItemRelease(coder, item);
     rlpCoderRelease(coder);
 }
 
@@ -387,12 +387,12 @@ void testTransactionCodingEther () {
                                           ethereumMainnet,
                                           RLP_TYPE_TRANSACTION_SIGNED,
                                           coder);
-    BRRlpData data = rlpGetData (coder, item);
+    BRRlpData data = rlpItemGetData (coder, item);
     char *rawTx = hexEncodeCreate(NULL, data.bytes, data.bytesCount);
     printf ("        Raw Transaction: 0x%s\n", rawTx);
 
     BREthereumTransaction decodedTransaction = transactionRlpDecode(item, ethereumMainnet, RLP_TYPE_TRANSACTION_SIGNED, coder);
-    rlpReleaseItem(coder, item);
+    rlpItemRelease(coder, item);
 
     assert (transactionGetNonce(transaction) == transactionGetNonce(decodedTransaction));
     assert (ETHEREUM_COMPARISON_EQ == gasPriceCompare(transactionGetGasPrice(transaction),
@@ -426,7 +426,7 @@ void testTransactionCodingEther () {
     transactionSetStatus(transaction, status);
     item = transactionRlpEncode(transaction, ethereumMainnet, RLP_TYPE_ARCHIVE, coder);
     BREthereumTransaction archivedTransaction = transactionRlpDecode(item, ethereumMainnet, RLP_TYPE_ARCHIVE, coder);
-    rlpReleaseItem(coder, item);
+    rlpItemRelease(coder, item);
     BREthereumTransactionStatus archivedStatus = transactionGetStatus(archivedTransaction);
     assert (ETHEREUM_BOOLEAN_IS_TRUE(transactionStatusEqual(status, archivedStatus)));
     assert (ETHEREUM_BOOLEAN_IS_TRUE(addressEqual(transactionGetTargetAddress(transaction),
@@ -466,12 +466,12 @@ void testTransactionCodingToken () {
                                           ethereumMainnet,
                                           RLP_TYPE_TRANSACTION_SIGNED,
                                           coder);
-    BRRlpData data = rlpGetData (coder, item);
+    BRRlpData data = rlpItemGetData (coder, item);
     char *rawTx = hexEncodeCreate(NULL, data.bytes, data.bytesCount);
     printf ("        Raw Transaction: 0x%s\n", rawTx);
 
     BREthereumTransaction decodedTransaction = transactionRlpDecode(item, ethereumMainnet, RLP_TYPE_TRANSACTION_SIGNED, coder);
-    rlpReleaseItem(coder, item);
+    rlpItemRelease(coder, item);
     
     assert (transactionGetNonce(transaction) == transactionGetNonce(decodedTransaction));
     assert (ETHEREUM_COMPARISON_EQ == gasPriceCompare(transactionGetGasPrice(transaction),
@@ -509,7 +509,7 @@ runPerfTestsCoder (int repeat, int many) {
     BRRlpData data;
     data.bytes = hexDecodeCreate(&data.bytesCount, TEST_TRANS4_SIGNED_TX, strlen (TEST_TRANS4_SIGNED_TX));
 
-    BRRlpItem item = rlpGetItem(coder, data);
+    BRRlpItem item = rlpDataGetItem(coder, data);
     BREthereumTransaction transaction = transactionRlpDecode(item, ethereumMainnet, RLP_TYPE_TRANSACTION_SIGNED, coder);
 
     BRRlpItem items [100];
@@ -523,11 +523,11 @@ runPerfTestsCoder (int repeat, int many) {
             transactionRelease(transactionRlpDecode(item, ethereumMainnet, RLP_TYPE_TRANSACTION_SIGNED, coder));
 
         for (int i = 0; i < 100; i++)
-            rlpReleaseItem(coder, items[i]);
+            rlpItemRelease(coder, items[i]);
         if (many) rlpCoderRelease(coder);
     }
 
-    rlpReleaseItem(coderSaved, item);
+    rlpItemRelease(coderSaved, item);
     rlpCoderRelease(coderSaved);
 }
 

--- a/ethereum/util/BRUtilHex.c
+++ b/ethereum/util/BRUtilHex.c
@@ -22,7 +22,7 @@
 #define encodeChar(u)           ((char)    _hexc(u))
 
 extern void
-decodeHex (uint8_t *target, size_t targetLen, const char *source, size_t sourceLen) {
+hexDecode (uint8_t *target, size_t targetLen, const char *source, size_t sourceLen) {
     //
     assert (0 == sourceLen % 2);
     assert (2 * targetLen == sourceLen);
@@ -33,22 +33,22 @@ decodeHex (uint8_t *target, size_t targetLen, const char *source, size_t sourceL
 }
 
 extern size_t
-decodeHexLength (size_t stringLen) {
+hexDecodeLength (size_t stringLen) {
     assert (0 == stringLen % 2);
     return stringLen/2;
 }
 
 extern uint8_t *
-decodeHexCreate (size_t *targetLen, const char *source, size_t sourceLen) {
-    size_t length = decodeHexLength(sourceLen);
+hexDecodeCreate (size_t *targetLen, const char *source, size_t sourceLen) {
+    size_t length = hexDecodeLength(sourceLen);
     if (NULL != targetLen) *targetLen = length;
     uint8_t *target = malloc (length);
-    decodeHex (target, length, source, sourceLen);
+    hexDecode (target, length, source, sourceLen);
     return target;
 }
 
 extern void
-encodeHex (char *target, size_t targetLen, const uint8_t *source, size_t sourceLen) {
+hexEncode (char *target, size_t targetLen, const uint8_t *source, size_t sourceLen) {
     assert (targetLen == 2 * sourceLen  + 1);
     
     for (int i = 0; i < sourceLen; i++) {
@@ -59,21 +59,21 @@ encodeHex (char *target, size_t targetLen, const uint8_t *source, size_t sourceL
 }
 
 extern size_t
-encodeHexLength(size_t byteArrayLen) {
+hexEncodeLength(size_t byteArrayLen) {
     return 2 * byteArrayLen + 1;
 }
 
 extern char *
-encodeHexCreate (size_t *targetLen, const uint8_t *source, size_t sourceLen) {
-    size_t length = encodeHexLength(sourceLen);
+hexEncodeCreate (size_t *targetLen, const uint8_t *source, size_t sourceLen) {
+    size_t length = hexEncodeLength(sourceLen);
     if (NULL != targetLen) *targetLen = length;
     char *target = malloc (length);
-    encodeHex(target, length, source, sourceLen);
+    hexEncode(target, length, source, sourceLen);
     return target;
 }
 
 extern int
-encodeHexValidate (const char *number) {
+hexEncodeValidate (const char *number) {
     // Number contains only hex digits, has an even number and has at least two.
     if (NULL == number || '\0' == *number || 0 != strlen(number) % 2) return 0;
 

--- a/ethereum/util/BRUtilHex.h
+++ b/ethereum/util/BRUtilHex.h
@@ -20,7 +20,7 @@ extern "C" {
 /**
  * Convert a 'char *' string into a 'uint8_t *' byte array.  Two characters are consumed for each
  * byte.  The conversion is only valid for a source string this was derived by encoding a
- * byte array (with encodeHex).  Thus this method *WILL FATAL* if the sourceLen is not an even
+ * byte array (with hexEncode).  Thus this method *WILL FATAL* if the sourceLen is not an even
  * number.
  *
  * @param target
@@ -29,7 +29,7 @@ extern "C" {
  * @param sourceLen Must be even and 2*targetLen
  */
 extern void
-decodeHex (uint8_t *target, size_t targetLen, const char *source, size_t sourceLen);
+hexDecode (uint8_t *target, size_t targetLen, const char *source, size_t sourceLen);
 
 /**
  * Return the number `uint8_t *' elements needed to decode stringLen characters.  The provided
@@ -40,10 +40,10 @@ decodeHex (uint8_t *target, size_t targetLen, const char *source, size_t sourceL
  * @return
  */
 extern size_t
-decodeHexLength (size_t stringLen);
+hexDecodeLength (size_t stringLen);
 
 extern uint8_t *
-decodeHexCreate (size_t *targetLen, const char *source, size_t sourceLen);
+hexDecodeCreate (size_t *targetLen, const char *source, size_t sourceLen);
 
 /**
  * Convert a 'uint8_t *' byte array into a 'char *' string.  Two characters are produced for each
@@ -58,7 +58,7 @@ decodeHexCreate (size_t *targetLen, const char *source, size_t sourceLen);
  * @param sourceLen
  */
 extern void
-encodeHex (char *target, size_t targetLen, const uint8_t *source, size_t sourceLen);
+hexEncode (char *target, size_t targetLen, const uint8_t *source, size_t sourceLen);
 
 /**
  * Return the number of 'char *' elements needs to encode byteArrayLen bytes.  The return value
@@ -69,10 +69,10 @@ encodeHex (char *target, size_t targetLen, const uint8_t *source, size_t sourceL
  * @return
  */
 extern size_t
-encodeHexLength(size_t byteArrayLen);
+hexEncodeLength(size_t byteArrayLen);
 
 extern char *
-encodeHexCreate (size_t *targetLen, const uint8_t *source, size_t sourceLen);
+hexEncodeCreate (size_t *targetLen, const uint8_t *source, size_t sourceLen);
 
 /**
  * Return TRUE/1 if `string` is an encoded-hex string.
@@ -81,7 +81,7 @@ encodeHexCreate (size_t *targetLen, const uint8_t *source, size_t sourceLen);
  * @return
  */
 extern int
-encodeHexValidate (const char *string);
+hexEncodeValidate (const char *string);
 
 #ifdef __cplusplus
 }

--- a/ethereum/util/BRUtilMath.c
+++ b/ethereum/util/BRUtilMath.c
@@ -17,13 +17,13 @@
 #define AS_UINT64(x)  ((uint64_t) (x))
 
 extern UInt256
-createUInt256 (uint64_t value) {
+uint256Create (uint64_t value) {
     UInt256 result = { .u64 = { value, 0, 0, 0}};
     return result;
 }
 
 extern UInt256
-createUInt256Double (double value, int decimals, int *overflow) {
+uint256CreateDouble (double value, int decimals, int *overflow) {
     assert (NULL != overflow);
 
     UInt256 result = UINT256_ZERO;
@@ -39,13 +39,13 @@ createUInt256Double (double value, int decimals, int *overflow) {
 }
 
 extern UInt256
-createUInt256Power (uint8_t digits, int *overflow) {
+uint256CreatePower (uint8_t digits, int *overflow) {
     if (digits < 20) {    // 10^19 fits in uint64_t
         uint64_t value = 1;
         while (digits-- > 0)
             value *= 10;      // slowest possible integer algorithm... still fast enough.
         *overflow = 0;
-        return createUInt256(value);
+        return uint256Create(value);
     }
     else {
         *overflow = 1;
@@ -54,7 +54,7 @@ createUInt256Power (uint8_t digits, int *overflow) {
 }
 
 extern UInt256
-createUInt256Power2 (uint8_t power) {  // always power < 256, as it must be.
+uint256CreatePower2 (uint8_t power) {  // always power < 256, as it must be.
     uint8_t word  = power / 64;
     uint8_t shift = power % 64;
 
@@ -65,7 +65,7 @@ createUInt256Power2 (uint8_t power) {  // always power < 256, as it must be.
 }
 
 extern UInt256
-addUInt256_Overflow (const UInt256 y, const UInt256 x, int *overflow) {
+uint256Add_Overflow (const UInt256 y, const UInt256 x, int *overflow) {
     assert (overflow != NULL);
     
     UInt256 z = UINT256_ZERO;
@@ -88,7 +88,7 @@ addUInt256_Overflow (const UInt256 y, const UInt256 x, int *overflow) {
 }
 
 extern UInt512
-addUInt256 (UInt256 x, UInt256 y) {
+uint256Add (UInt256 x, UInt256 y) {
     UInt512 z = UINT512_ZERO;
     unsigned int count = sizeof (UInt256) / sizeof(uint32_t);
     
@@ -106,7 +106,7 @@ addUInt256 (UInt256 x, UInt256 y) {
 }
 
 static UInt256
-subUInt256_x_gt_y (UInt256 x, UInt256 y) {
+uint256Sub_x_gt_y (UInt256 x, UInt256 y) {
     UInt256 z = UINT256_ZERO;
     unsigned int count = sizeof (UInt256) / sizeof(uint32_t);
     
@@ -127,25 +127,25 @@ subUInt256_x_gt_y (UInt256 x, UInt256 y) {
 }
 
 extern UInt256
-subUInt256_Negative (UInt256 x, UInt256 y, int *negative) {
+uint256Sub_Negative (UInt256 x, UInt256 y, int *negative) {
     assert (negative != NULL);
-    if (eqUInt256(x, y)) {
+    if (uint256EQL(x, y)) {
         *negative = 0;
         return UINT256_ZERO;
     }
-    else if (gtUInt256(x, y)) {
+    else if (uint256GT(x, y)) {
         *negative = 0;
-        return subUInt256_x_gt_y(x, y);
+        return uint256Sub_x_gt_y(x, y);
     }
     else {
         *negative = 1;
-        return subUInt256_x_gt_y(y, x);
+        return uint256Sub_x_gt_y(y, x);
     }
 }
 
 
 extern UInt512
-mulUInt256 (const UInt256 x, const UInt256 y) {
+uint256Mul (const UInt256 x, const UInt256 y) {
     //  assert (__LITTLE_ENDIAN__ == BYTE_ORDER);
     UInt512 z = UINT512_ZERO;
     
@@ -169,17 +169,17 @@ mulUInt256 (const UInt256 x, const UInt256 y) {
 }
 
 extern UInt256
-mulUInt256_Overflow (UInt256 x, UInt256 y, int *overflow) {
-    return coerceUInt256 (mulUInt256 (x, y), overflow);
+uint256Mul_Overflow (UInt256 x, UInt256 y, int *overflow) {
+    return uint256Coerce (uint256Mul (x, y), overflow);
 }
 
 extern UInt256
-mulUInt256_Small (UInt256 x, uint32_t y, int *overflow) {
-    return mulUInt256_Overflow(x, createUInt256 (y), overflow);
+uint256Mul_Small (UInt256 x, uint32_t y, int *overflow) {
+    return uint256Mul_Overflow(x, uint256Create (y), overflow);
 }
 
 extern UInt256
-mulUInt256_Double (UInt256 x, double y, int *overflow, int *negative, double *rem) {
+uint256Mul_Double (UInt256 x, double y, int *overflow, int *negative, double *rem) {
     assert (NULL != overflow && NULL != negative);
 
     *negative = (y < 0.0);
@@ -237,7 +237,7 @@ mulUInt256_Double (UInt256 x, double y, int *overflow, int *negative, double *re
 }
 
 extern UInt256
-divUInt256_Small (UInt256 x, uint32_t y, uint32_t *rem) {
+uint256Div_Small (UInt256 x, uint32_t y, uint32_t *rem) {
     assert (NULL != rem);
     UInt256 z = UINT256_ZERO;
     uint64_t remainder = 0;
@@ -259,7 +259,7 @@ tooBigUInt256 (UInt512 x) {
 }
 
 extern UInt256
-coerceUInt256 (UInt512  x, int *overflow) {
+uint256Coerce (UInt512  x, int *overflow) {
     assert (NULL != overflow);
     
     *overflow = tooBigUInt256(x);
@@ -274,16 +274,16 @@ coerceUInt256 (UInt512  x, int *overflow) {
 }
 
 extern int
-compareUInt256 (UInt256 x, UInt256 y) {
-    return (eqUInt256(x, y)
+uint256Compare (UInt256 x, UInt256 y) {
+    return (uint256EQL(x, y)
             ? 0
-            : (gtUInt256(x, y)
+            : (uint256GT(x, y)
                ? +1
                : -1));
 }
 
 extern uint64_t
-coerceUInt64 (UInt256 value, int *overflow) {
+uint64Coerce (UInt256 value, int *overflow) {
     *overflow = (0 != value.u64[3] ||
                  0 != value.u64[2] ||
                  0 != value.u64[1]);
@@ -291,15 +291,15 @@ coerceUInt64 (UInt256 value, int *overflow) {
 }
 
 extern double
-coerceDouble (UInt256 value, int *overflow) {
-    long double result = coerceLongDouble (value, overflow);
+uint256CoerceDouble (UInt256 value, int *overflow) {
+    long double result = uint256CoerceLongDouble (value, overflow);
     if (!*overflow)
         *overflow = !isfinite ((double) result);
     return (double) result;
 }
 
 extern long double
-coerceLongDouble (UInt256 value, int *overflow) {
+uint256CoerceLongDouble (UInt256 value, int *overflow) {
     long double scale = powl ((long double) 2.0, (long double) 64.0);
     long double result = 0;
     for (ssize_t index = 3; index >= 0; index--)

--- a/ethereum/util/BRUtilMath.h
+++ b/ethereum/util/BRUtilMath.h
@@ -34,22 +34,22 @@ typedef enum {
  * Create from a single uint64_t value.
  */
 extern UInt256
-createUInt256 (uint64_t value);
+uint256Create (uint64_t value);
 
 extern UInt256
-createUInt256Double (double value, int decimals, int *overflow);
+uint256CreateDouble (double value, int decimals, int *overflow);
 
 /**
  * Create as `(expt 10 power)` where power < 20 is required.
  */
 extern UInt256
-createUInt256Power (uint8_t power, int *overflow);
+uint256CreatePower (uint8_t power, int *overflow);
 
 /**
  * Create as (expt 2 power) where power < 256
  */
 extern UInt256
-createUInt256Power2 (uint8_t power);
+uint256CreatePower2 (uint8_t power);
 
 /**
  * Create from a string in the provided base.  The string must consist of only characters
@@ -65,7 +65,7 @@ createUInt256Power2 (uint8_t power);
  * @param pointer to a boolean error
  */
 extern UInt256
-createUInt256Parse (const char *number, int base, BRCoreParseStatus *status);
+uint256CreateParse (const char *number, int base, BRCoreParseStatus *status);
 
 /**
  * Create from a string with the specificed number of decimals (values after a decimal point).
@@ -83,46 +83,46 @@ createUInt256Parse (const char *number, int base, BRCoreParseStatus *status);
  * @warn Requires stack size of at least 3 * (strlen(number) + digits). [We are sloppy]
  */
 extern UInt256
-createUInt256ParseDecimal (const char *number, int decimals, BRCoreParseStatus *status);
+uint256CreateParseDecimal (const char *number, int decimals, BRCoreParseStatus *status);
   
   /**
  * Return `x + y`
  */
 extern UInt512
-addUInt256 (UInt256 x, UInt256 y);
+uint256Add (UInt256 x, UInt256 y);
 
 /**
  * Return `x + y`.  If the result is too big then overflow is set to 1 and zero is returned.
  */
 extern UInt256
-addUInt256_Overflow (UInt256 x, UInt256 y, int *overflow);
+uint256Add_Overflow (UInt256 x, UInt256 y, int *overflow);
 
 /**
  * If `x >= y` return `x - y` and set `negative` to 0; otherwise, return `y - x` and set
  * `negative` to 1.
  */
 extern UInt256
-subUInt256_Negative (UInt256 x, UInt256 y, int *negative);
+uint256Sub_Negative (UInt256 x, UInt256 y, int *negative);
 
 /**
  * Return `x * y`
  */
 extern UInt512
-mulUInt256 (UInt256 x, UInt256 y);
+uint256Mul (UInt256 x, UInt256 y);
 
 /**
  * Multiply as `x * y`.  If the result is too big then overflow is set to 1 and
  * zero is returned.
  */
 extern UInt256
-mulUInt256_Overflow (UInt256 x, UInt256 y, int *overflow);
+uint256Mul_Overflow (UInt256 x, UInt256 y, int *overflow);
 
 /**
  * Multiply as `x * y` where `y` is a small (aka uint32) number.  If the result is too big
  * then overflow is set to 1 and zero is returned
  */
 extern UInt256
-mulUInt256_Small (UInt256 x, uint32_t y, int *overflow);
+uint256Mul_Small (UInt256 x, uint32_t y, int *overflow);
 
 /**
  * Multiply as `x * y` where `y` is a postive double.  If `y` is negative, then this function
@@ -133,34 +133,34 @@ mulUInt256_Small (UInt256 x, uint32_t y, int *overflow);
  * for example, 1 * 0.123, rem will be 0.123.
  */
 extern UInt256
-mulUInt256_Double (UInt256 x, double y, int *overflow, int *negative, double *rem);
+uint256Mul_Double (UInt256 x, double y, int *overflow, int *negative, double *rem);
 
 extern UInt256
-divUInt256_Small (UInt256 x, uint32_t y, uint32_t *rem);
+uint256Div_Small (UInt256 x, uint32_t y, uint32_t *rem);
 
 /**
  * Coerce `x`, a UInt512, to a UInt256.  If `x` is too big then overflow is set to 1 and
  * zero is returned.
  */
 extern UInt256
-coerceUInt256 (UInt512  x, int *overflow);
+uint256Coerce (UInt512  x, int *overflow);
 
 /**
  * Coerce `x`, a UInt256, to a uint64_t.  If `x` is too big then overflow is set to 1 and
  * zero is returned.
  */
 extern uint64_t
-coerceUInt64 (UInt256 x, int *overflow);
+uint64Coerce (UInt256 x, int *overflow);
 
 /**
  * Coerce `x`, a UInt256, to a double.  If `x` is too big then overflow is set to 1 and
  * zero is returned.
  */
 extern double
-coerceDouble (UInt256 value, int *overflow);
+uint256CoerceDouble (UInt256 value, int *overflow);
 
 extern long double
-coerceLongDouble (UInt256 value, int *overflow);
+uint256CoerceLongDouble (UInt256 value, int *overflow);
 
 /**
  * Returns the string representation of `x` in `base`.  No matter the base, the returned string
@@ -171,10 +171,10 @@ coerceLongDouble (UInt256 value, int *overflow);
  * @warn YOU OWN THE RETURNED MEMORY
  */
 extern char *
-coerceString (UInt256 x, int base);
+uint256CoerceString (UInt256 x, int base);
 
 extern char *
-coerceStringPrefaced (UInt256 x, int base, const char *preface);
+uint256CoerceStringPrefaced (UInt256 x, int base, const char *preface);
 
 /**
  * Returns a decimal string represention of `x` in base `0 with `decimals` digits after the
@@ -183,14 +183,14 @@ coerceStringPrefaced (UInt256 x, int base, const char *preface);
  * @warn YOU OWN THE RETURNED MEMORY
  */
 extern char *
-coerceStringDecimal (UInt256 x, int decimals);
+uint256CoerceStringDecimal (UInt256 x, int decimals);
 
 
 /**
  * Returns a '0x' prefaced hex string
  */
 extern char *
-coerceUInt256HashToString (UInt256 hash);
+uint256CoerceHashToString (UInt256 hash);
 
 
 //  static UInt256
@@ -211,13 +211,13 @@ coerceUInt256HashToString (UInt256 hash);
 //    return NULL;
 //  }
 
-inline static int
-eqUInt256 (UInt256 x, UInt256 y) {
+inline static int // Avoid a case-insensitive conflict with UInt256Eq
+uint256EQL (UInt256 x, UInt256 y) {
   return UInt256Eq (x, y);
 }
 
 inline static int
-gtUInt256 (UInt256 x, UInt256 y) {
+uint256GT (UInt256 x, UInt256 y) {
   return x.u64[3] > y.u64[3]
   || (x.u64[3] == y.u64[3]
       && (x.u64[2] > y.u64[2]
@@ -228,12 +228,12 @@ gtUInt256 (UInt256 x, UInt256 y) {
 }
 
 inline static int
-geUInt256 (UInt256 x, UInt256 y) {
-  return eqUInt256 (x, y) || gtUInt256 (x, y);
+uint256GE (UInt256 x, UInt256 y) {
+  return uint256EQL (x, y) || uint256GT (x, y);
 }
 
 inline static int
-ltUInt256 (UInt256 x, UInt256 y) {
+uint256LT (UInt256 x, UInt256 y) {
   return x.u64[3] < y.u64[3]
   || (x.u64[3] == y.u64[3]
       && (x.u64[2] < y.u64[2]
@@ -244,8 +244,8 @@ ltUInt256 (UInt256 x, UInt256 y) {
 }
 
 inline static int
-leUInt256 (UInt256 x, UInt256 y) {
-  return eqUInt256 (x, y) || ltUInt256 (x, y);
+uint256LE (UInt256 x, UInt256 y) {
+  return uint256EQL (x, y) || uint256LT (x, y);
 }
 
 /**
@@ -255,16 +255,16 @@ leUInt256 (UInt256 x, UInt256 y) {
  * +1 -> x  > y
  */
 extern int
-compareUInt256 (UInt256 x, UInt256 y);
+uint256Compare (UInt256 x, UInt256 y);
 
 //
 // Parsing
 //
 extern BRCoreParseStatus
-parseIsInteger (const char *number);
+stringParseIsInteger (const char *number);
 
 extern BRCoreParseStatus
-parseIsDecimal (const char *number);
+stringParseIsDecimal (const char *number);
 
 #ifdef __cplusplus
 }

--- a/ethereum/util/BRUtilMathParse.c
+++ b/ethereum/util/BRUtilMathParse.c
@@ -321,7 +321,7 @@ uint256CoerceString (UInt256 x, int base) {
             // We'll just hex encode the UInt256 based on the (little endian) bytes.  This WILL produce
             // a result with an even number of characters - as 15 becomes 0f (aka 0x0f).  This is
             // actually correct (or at least reasonably correct); if only because, if you want to convert
-            // back to a value, the decodeHex() WILL expect an even number of characters.
+            // back to a value, the hexDecode() WILL expect an even number of characters.
         case 16: {
             // Reverse and 'strip zeros'
             UInt256 xr = UInt256Reverse(x);  // TODO: LITTLE ENDIAN only
@@ -330,7 +330,7 @@ uint256CoerceString (UInt256 x, int base) {
             // eventually has a non-zero value.
             while (0 == xr.u8[xrIndex]) xrIndex++;
             // Encode
-            return encodeHexCreate (NULL, &xr.u8[xrIndex], sizeof (xr.u8) - xrIndex);
+            return hexEncodeCreate (NULL, &xr.u8[xrIndex], sizeof (xr.u8) - xrIndex);
         }
             
             // Repeatedly divide by 10; append the result with the remainder.

--- a/ethereum/util/BRUtilMathParse.c
+++ b/ethereum/util/BRUtilMathParse.c
@@ -43,12 +43,12 @@ parseInIntegerInBase (const char *number, int base) {
 }
 
 extern BRCoreParseStatus
-parseIsInteger(const char *number) {
+stringParseIsInteger(const char *number) {
     return parseInIntegerInBase (number, 10);
  }
 
 extern BRCoreParseStatus
-parseIsDecimal(const char *number) {
+stringParseIsDecimal(const char *number) {
     // Number contains one or more digits, a optional decimal point, and then digits.
     if (NULL == number || '\0' == *number || '.' == *number) return CORE_PARSE_STRANGE_DIGITS;
 
@@ -66,10 +66,10 @@ parseIsDecimal(const char *number) {
 #define SURELY_ENOUGH_CHARS 100     // No more than ~78 in UInt256
 
 extern UInt256
-createUInt256ParseDecimal (const char *string, int decimals, BRCoreParseStatus *status) {
+uint256CreateParseDecimal (const char *string, int decimals, BRCoreParseStatus *status) {
     // Check basic `string` content.
     *status = CORE_PARSE_OK;
-    if (CORE_PARSE_OK != parseIsDecimal(string))
+    if (CORE_PARSE_OK != stringParseIsDecimal(string))
         *status = CORE_PARSE_STRANGE_DIGITS;
     else if (strlen(string) >= SURELY_ENOUGH_CHARS)
         *status = CORE_PARSE_OVERFLOW;
@@ -118,7 +118,7 @@ createUInt256ParseDecimal (const char *string, int decimals, BRCoreParseStatus *
         *padding++ = '0';
     *padding = 0;
     
-    return createUInt256Parse(number, 10, status);
+    return uint256CreateParse(number, 10, status);
 }
 
 
@@ -180,7 +180,7 @@ parseUInt256Power (int base, int power, int *overflow) {
         result.u64[1] = 1;
         return result;
     }
-    else return createUInt256(value);
+    else return uint256Create(value);
 }
 
 // Compute (* value (expt base power))
@@ -189,7 +189,7 @@ parseUInt256ScaleByPower (UInt256 value, int base, int power, int *overflow) {
     UInt256 scale = parseUInt256Power(base, power, overflow);
     return (*overflow
             ? UINT256_ZERO
-            : mulUInt256_Overflow(value, scale, overflow));
+            : uint256Mul_Overflow(value, scale, overflow));
 }
 
 static UInt256
@@ -206,11 +206,11 @@ parseUInt64 (const char *string, int digits, int base) {
     uint64_t value = strtoull (number, &numberEnd, base);
     if (0 == errno && (*number == '\0' || numberEnd == NULL || *numberEnd != '\0'))
         errno = EINVAL;
-    return createUInt256 (value);
+    return uint256Create (value);
 }
 
 extern UInt256
-createUInt256Parse (const char *string, int base, BRCoreParseStatus *status) {
+uint256CreateParse (const char *string, int base, BRCoreParseStatus *status) {
     assert (NULL != status);
 
     // Strip '0x'
@@ -285,7 +285,7 @@ createUInt256Parse (const char *string, int base, BRCoreParseStatus *status) {
             value = parseUInt256ScaleByPower(value, base, scalingDigits, &scaleOverflow);
             
             // Add in the next chuck.
-            value = addUInt256_Overflow(value, parseUInt64(&string[index], stringChunks, base), &addOverflow);
+            value = uint256Add_Overflow(value, parseUInt64(&string[index], stringChunks, base), &addOverflow);
             if (scaleOverflow || addOverflow) {
                 *status = CORE_PARSE_OVERFLOW;
                 return UINT256_ZERO;
@@ -309,9 +309,9 @@ coerceReverseString (const char *s) {
 }
 
 extern char *
-coerceString (UInt256 x, int base) {
+uint256CoerceString (UInt256 x, int base) {
     // Handle 0 explicitly, rather than in each case
-    if (eqUInt256(x, UINT256_ZERO)) {
+    if (uint256EQL(x, UINT256_ZERO)) {
         char *result = calloc (2, 1);
         result[0] = '0';
         return result;
@@ -337,9 +337,9 @@ coerceString (UInt256 x, int base) {
         case 10: {
             char r[257];
             memset (r, 0, 257);
-            for (int i = 0; i < 256 && !eqUInt256(x, UINT256_ZERO); i++) {
+            for (int i = 0; i < 256 && !uint256EQL(x, UINT256_ZERO); i++) {
                 uint32_t rem;
-                x = divUInt256_Small(x, base, &rem);
+                x = uint256Div_Small(x, base, &rem);
                 r[i] = '0' + rem;
             }
             return coerceReverseString(r);
@@ -353,7 +353,7 @@ coerceString (UInt256 x, int base) {
                 [ 8] = "1000", [ 9] = "1001", [10] = "1010", [11] = "1011",
                 [12] = "1100", [13] = "1101", [14] = "1110", [15] = "1111",
             };
-            char * base16    = coerceString (x, 16);
+            char * base16    = uint256CoerceString (x, 16);
             size_t base16Len = strlen (base16);
             
             char *r = malloc (4 * base16Len + 1);
@@ -370,8 +370,8 @@ coerceString (UInt256 x, int base) {
 }
 
 extern char *
-coerceStringPrefaced (UInt256 x, int base, const char *preface) {
-    char *string = coerceString (x, base);
+uint256CoerceStringPrefaced (UInt256 x, int base, const char *preface) {
+    char *string = uint256CoerceString (x, base);
     if (NULL == preface || 0 == strcmp ("", preface)) return string;
     char *stringToFree = string; // save the pointer to string
 
@@ -388,8 +388,8 @@ coerceStringPrefaced (UInt256 x, int base, const char *preface) {
 }
 
 extern char * 
-coerceStringDecimal (UInt256 x, int decimals) {
-    char *string = coerceString(x, 10);
+uint256CoerceStringDecimal (UInt256 x, int decimals) {
+    char *string = uint256CoerceString(x, 10);
     
     if (0 == decimals)
         return string;
@@ -423,7 +423,7 @@ coerceStringDecimal (UInt256 x, int decimals) {
 }
 
 extern char *
-coerceUInt256HashToString (UInt256 hash) {
+uint256CoerceHashToString (UInt256 hash) {
     char result[67];
     result[0] = '0';
     result[1] = 'x';

--- a/ethereum/util/testUtil.c
+++ b/ethereum/util/testUtil.c
@@ -29,22 +29,22 @@ runMathAddTests () {
     UInt256 x7atOne = { .u32 = {          0, 0, 0, 0, 0, 0, 0, 1 }};
     UInt256 xMax    = { .u32 = { UINT32_MAX, UINT32_MAX, UINT32_MAX, UINT32_MAX, UINT32_MAX, UINT32_MAX, UINT32_MAX, UINT32_MAX }};
 
-    z = addUInt256_Overflow (xOne, xOne, &carry);
+    z = uint256Add_Overflow (xOne, xOne, &carry);
     assert (2 == z.u32[0] && 0 == carry);
 
-    z = addUInt256_Overflow (xOne, x0atMax, &carry);
+    z = uint256Add_Overflow (xOne, x0atMax, &carry);
     assert (1 == z.u32[1] && 0 == carry);
 
-    z = addUInt256_Overflow (xOne, x2to32, &carry);
+    z = uint256Add_Overflow (xOne, x2to32, &carry);
     assert (1 == z.u32[0] && 1 == z.u32[1] && 0 == carry);
 
-    z = addUInt256_Overflow (xTwo, x7atOne, &carry);
+    z = uint256Add_Overflow (xTwo, x7atOne, &carry);
     assert (2 == z.u32[0] && 1 == z.u32[7] && 0 == carry);
 
-    z = addUInt256_Overflow (x7atMax, z, &carry);
+    z = uint256Add_Overflow (x7atMax, z, &carry);
     assert (0 == z.u32[7] && 0 == z.u32[0] && 1 == carry);
 
-    z = addUInt256_Overflow (xMax, xOne, &carry);
+    z = uint256Add_Overflow (xMax, xOne, &carry);
     assert (1 == carry);
 }
 
@@ -61,23 +61,23 @@ runMathSubTests () {
     //  UInt256 x7atOne = { .u32 = {          0, 0, 0, 0, 0, 0, 0, 1 }};
     //  UInt256 xMax    = { .u32 = { UINT32_MAX, UINT32_MAX, UINT32_MAX, UINT32_MAX, UINT32_MAX, UINT32_MAX, UINT32_MAX, UINT32_MAX }};
 
-    z = subUInt256_Negative(xOne, xOne, &negative);
+    z = uint256Sub_Negative(xOne, xOne, &negative);
     assert (0 == z.u32[0] && 0 == negative);
 
-    z = subUInt256_Negative(xTwo, xOne, &negative);
+    z = uint256Sub_Negative(xTwo, xOne, &negative);
     assert (1 == z.u32[0] && 0 == negative);
 
-    z = subUInt256_Negative(xOne, xTwo, &negative);
+    z = uint256Sub_Negative(xOne, xTwo, &negative);
     assert (1 == z.u32[0] && 1 == negative);
 
-    z = subUInt256_Negative(xOne, x0atMax, &negative);
+    z = uint256Sub_Negative(xOne, x0atMax, &negative);
     assert ((UINT32_MAX - 1) == z.u32[0]
             && 0 == z.u32[7]
             && 1 == negative);
 
-    z = subUInt256_Negative(xOneOne, xTwo, &negative);
+    z = uint256Sub_Negative(xOneOne, xTwo, &negative);
     UInt256 zr5 = { .u32 = { UINT32_MAX, 0, 0, 0, 0, 0, 0, 0 }};
-    assert (eqUInt256(zr5, z) && 0 == negative);
+    assert (uint256EQL(zr5, z) && 0 == negative);
     assert (UINT32_MAX == z.u32[0]
             && 0 == z.u32[1]
             && 0 == z.u32[2]
@@ -101,23 +101,23 @@ runMathMulTests () {
     //  > (number->string xMax 2)
     //  "1111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111"
 
-    z = mulUInt256(xOne, x0atMax);
+    z = uint256Mul(xOne, x0atMax);
     assert (UINT32_MAX == z.u32[0] && 0 == z.u32[1] /* && ...*/);
 
-    z = mulUInt256(xOne, x7atOne);
+    z = uint256Mul(xOne, x7atOne);
     assert (1 == z.u32[7]);
 
-    z = mulUInt256(x2to31, xTwo);
+    z = uint256Mul(x2to31, xTwo);
     assert (0 == z.u32[0] && 1 == z.u32[1] && 0 == z.u32[2] /* && ... */);
 
-    z = mulUInt256(x2to32, x2to32);
+    z = uint256Mul(x2to32, x2to32);
     assert (0 == z.u32[0] && 0 == z.u32[1] && 1 == z.u32[2] && 0 == z.u32[3]);
 
     // (= (* (expt 2 255) (expt 2 255)) (expt 2 510))
-    z = mulUInt256(x7at2to31, x7at2to31);
+    z = uint256Mul(x7at2to31, x7at2to31);
     assert ((1<<30) == z.u32[15]);
 
-    z = mulUInt256(xMax, xMax);
+    z = uint256Mul(xMax, xMax);
     //  > (number->string (* xMax xMax) 2)
     //  "1111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111110 0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000001"
     //  define (factor m)
@@ -163,55 +163,55 @@ runMathMulDoubleTests () {
     int over, neg; double rem, v;
     UInt256 ai, ao, r;
 
-    ai = createUInt256Parse("1000000000000000", 10, &status);  // Input
-    ao = createUInt256Parse("1000000000000000", 10, &status);  // Output
-    r = mulUInt256_Double(ai, -1.0, &over, &neg, &rem);
-    assert (over == 0 && neg == 1 && eqUInt256(r, ao));
-    assert (0 == strcmp ("1000000000000000", coerceString(r, 10)));
+    ai = uint256CreateParse("1000000000000000", 10, &status);  // Input
+    ao = uint256CreateParse("1000000000000000", 10, &status);  // Output
+    r = uint256Mul_Double(ai, -1.0, &over, &neg, &rem);
+    assert (over == 0 && neg == 1 && uint256EQL(r, ao));
+    assert (0 == strcmp ("1000000000000000", uint256CoerceString(r, 10)));
 
-    ai = createUInt256Parse("1000000000000000", 10, &status);  // Input
-    ao = createUInt256Parse(  "10000000000000", 10, &status);  // Output
-    r = mulUInt256_Double(ai, 0.01, &over, &neg, &rem);
-    assert (over == 0 && neg == 0 && eqUInt256(r, ao));
-    assert (0 == strcmp ("10000000000000", coerceString(r, 10)));
+    ai = uint256CreateParse("1000000000000000", 10, &status);  // Input
+    ao = uint256CreateParse(  "10000000000000", 10, &status);  // Output
+    r = uint256Mul_Double(ai, 0.01, &over, &neg, &rem);
+    assert (over == 0 && neg == 0 && uint256EQL(r, ao));
+    assert (0 == strcmp ("10000000000000", uint256CoerceString(r, 10)));
 
-    ai = createUInt256Parse("1000000000000000", 10, &status);  // Input
-    ao = createUInt256Parse("10000000", 10, &status);  // Output
-    r = mulUInt256_Double(ai, 0.00000001, &over, &neg, &rem);
-    assert (over == 0 && neg == 0 && eqUInt256(r, ao));
-    assert (0 == strcmp ("10000000", coerceString(r, 10)));
+    ai = uint256CreateParse("1000000000000000", 10, &status);  // Input
+    ao = uint256CreateParse("10000000", 10, &status);  // Output
+    r = uint256Mul_Double(ai, 0.00000001, &over, &neg, &rem);
+    assert (over == 0 && neg == 0 && uint256EQL(r, ao));
+    assert (0 == strcmp ("10000000", uint256CoerceString(r, 10)));
 
-    ai = createUInt256Parse("1000000000000000", 10, &status);  // Input
-    ao = createUInt256Parse("100000000000000000000", 10, &status);  // Output
-    r = mulUInt256_Double(ai, 100000.0, &over, &neg, &rem);
-    assert (over == 0 && neg == 0 && eqUInt256(r, ao));
-    assert (0 == strcmp ("100000000000000000000", coerceString(r, 10)));
+    ai = uint256CreateParse("1000000000000000", 10, &status);  // Input
+    ao = uint256CreateParse("100000000000000000000", 10, &status);  // Output
+    r = uint256Mul_Double(ai, 100000.0, &over, &neg, &rem);
+    assert (over == 0 && neg == 0 && uint256EQL(r, ao));
+    assert (0 == strcmp ("100000000000000000000", uint256CoerceString(r, 10)));
 
 
-    ai = createUInt256Parse("1000000000000000", 10, &status);  // Input
-    ao = createUInt256Parse("100000000000000000000000000000000000", 10, &status);  // Output
-    r = mulUInt256_Double(ai, 10000000000.0, &over, &neg, &rem);
-    r = mulUInt256_Double(r,  10000000000.0, &over, &neg, &rem);
-    assert (over == 0 && neg == 0 && eqUInt256(r, ao));
-    assert (0 == strcmp ("100000000000000000000000000000000000", coerceString(r, 10)));
+    ai = uint256CreateParse("1000000000000000", 10, &status);  // Input
+    ao = uint256CreateParse("100000000000000000000000000000000000", 10, &status);  // Output
+    r = uint256Mul_Double(ai, 10000000000.0, &over, &neg, &rem);
+    r = uint256Mul_Double(r,  10000000000.0, &over, &neg, &rem);
+    assert (over == 0 && neg == 0 && uint256EQL(r, ao));
+    assert (0 == strcmp ("100000000000000000000000000000000000", uint256CoerceString(r, 10)));
 
-    ai = createUInt256Parse("1", 10, &status);  // Input
-    ao = createUInt256Parse("0", 10, &status);  // Output
-    r = mulUInt256_Double(ai, 0.123, &over, &neg, &rem);
-    assert (over == 0 && eqUInt256(r, ao));
-    assert (0 == strcmp ("0", coerceString(r, 10)));
+    ai = uint256CreateParse("1", 10, &status);  // Input
+    ao = uint256CreateParse("0", 10, &status);  // Output
+    r = uint256Mul_Double(ai, 0.123, &over, &neg, &rem);
+    assert (over == 0 && uint256EQL(r, ao));
+    assert (0 == strcmp ("0", uint256CoerceString(r, 10)));
     assert (0.123 == rem);
 
-    ai = createUInt256Parse("2000000000000000000", 10, &status);  // Output
-    ao = createUInt256 (2);
-    r  = mulUInt256_Double(ai, 1e-18, &over, &neg, &rem);
-    assert (over == 0 && eqUInt256(r, ao));
-    assert (0 == strcmp ("2", coerceString(r, 10)));
+    ai = uint256CreateParse("2000000000000000000", 10, &status);  // Output
+    ao = uint256Create (2);
+    r  = uint256Mul_Double(ai, 1e-18, &over, &neg, &rem);
+    assert (over == 0 && uint256EQL(r, ao));
+    assert (0 == strcmp ("2", uint256CoerceString(r, 10)));
 
     double x = 25.25434525155732538797258871;
-    r = createUInt256Double(x, 18, &over);
-    assert (!over && !eqUInt256(r, UINT256_ZERO));
-    v  = coerceDouble(r, &over);
+    r = uint256CreateDouble(x, 18, &over);
+    assert (!over && !uint256EQL(r, UINT256_ZERO));
+    v  = uint256CoerceDouble(r, &over);
     assert(!over && fabs(v*1e-18 - x) / x < 1e-10);
 }
 
@@ -225,7 +225,7 @@ runMathDivTests () {
     r.u64[1] = 54;
 
     // 10^15
-    UInt256 a = divUInt256_Small(r, 1000000, &rem);
+    UInt256 a = uint256Div_Small(r, 1000000, &rem);
     assert (0 == rem
             && a.u64[0] == 1000000000000000
             && a.u64[1] == 0
@@ -236,62 +236,62 @@ runMathDivTests () {
 static void
 runMathCoerceTests () {
     UInt256 a = { .u64 = { 1000000000000000, 0, 0, 0}};
-    const char *as = coerceString(a, 10);
+    const char *as = uint256CoerceString(a, 10);
     assert (0 == strcmp (as, "1000000000000000"));
     free ((char *) as);
 
     UInt256 b = { .u64 = { 3875820019684212736u, 54, 0, 0}};
-    const char *bs = coerceString(b, 10);
+    const char *bs = uint256CoerceString(b, 10);
     assert (0 == strcmp (bs, "1000000000000000000000"));
     free ((char *) bs);
 
     UInt256 c = { .u64 = { 15, 0, 0, 0}};
-    const char *cs = coerceString(c, 2);
+    const char *cs = uint256CoerceString(c, 2);
     assert (0 == strcmp (cs, "00001111"));  // unexpected
     free ((char *) cs);
 
     UInt256 d = { .u64 = { 0, UINT64_MAX, 0, 0}};
-    const char *ds = coerceString(d, 2);
+    const char *ds = uint256CoerceString(d, 2);
     assert (0 == strcmp (ds, "11111111111111111111111111111111111111111111111111111111111111110000000000000000000000000000000000000000000000000000000000000000"));
     free ((char *) ds);
 
     UInt256 e = { .u64 = { 15, 0, 0, 0}};
-    const char *es = coerceString(e, 16);
+    const char *es = uint256CoerceString(e, 16);
     assert (0 == strcmp (es, "0f"));  // unexpected
     free ((char *) es);
 
     // Value: 0, w/ and w/o a prefix
     UInt256 f = { .u64 = { 0, 0, 0, 0}};
-    const char *fs = coerceString (f, 10);
+    const char *fs = uint256CoerceString (f, 10);
     assert (0 == strcmp (fs, "0"));
     free ((char *) fs);
 
-    fs = coerceStringPrefaced (f, 10, NULL);
+    fs = uint256CoerceStringPrefaced (f, 10, NULL);
     assert (0 == strcmp (fs, "0"));
     free ((char *) fs);
 
-    fs = coerceStringPrefaced (f, 10, "");
+    fs = uint256CoerceStringPrefaced (f, 10, "");
     assert (0 == strcmp (fs, "0"));
     free ((char *) fs);
 
-    fs = coerceStringPrefaced (f, 10, "hex");
+    fs = uint256CoerceStringPrefaced (f, 10, "hex");
     assert (0 == strcmp (fs, "hex0"));
     free ((char *) fs);
 
-    fs = coerceStringPrefaced (f, 16, "0x");
+    fs = uint256CoerceStringPrefaced (f, 16, "0x");
     assert (0 == strcmp (fs, "0x0"));
     free ((char *) fs);
 
-    UInt256 g = createUInt256(0x0a);
-    const char *gs = coerceString (g, 10);
+    UInt256 g = uint256Create(0x0a);
+    const char *gs = uint256CoerceString (g, 10);
     assert (0 == strcmp (gs, "10"));
     free ((char *) gs);
 
-    gs = coerceStringPrefaced (g, 10, NULL);
+    gs = uint256CoerceStringPrefaced (g, 10, NULL);
     assert (0 == strcmp (gs, "10"));
     free ((char *) gs);
 
-    gs = coerceStringPrefaced (g, 16, "0x");
+    gs = uint256CoerceStringPrefaced (g, 16, "0x");
     assert (0 == strcmp (gs, "0xa"));
     free ((char *) gs);
 }
@@ -302,25 +302,25 @@ runMathParseTests () {
     UInt256 r = UINT256_ZERO;
     UInt256 a = UINT256_ZERO;
 
-    assert (CORE_PARSE_OK == parseIsInteger("0"));
-    assert (CORE_PARSE_OK == parseIsInteger("0123456789"));
-    assert (CORE_PARSE_OK != parseIsInteger("0123456789."));
-    assert (CORE_PARSE_OK != parseIsInteger(""));
-    assert (CORE_PARSE_OK != parseIsInteger("."));
-    assert (CORE_PARSE_OK != parseIsInteger("1."));
-    assert (CORE_PARSE_OK != parseIsInteger(".0"));
-    assert (CORE_PARSE_OK != parseIsInteger("a"));
+    assert (CORE_PARSE_OK == stringParseIsInteger("0"));
+    assert (CORE_PARSE_OK == stringParseIsInteger("0123456789"));
+    assert (CORE_PARSE_OK != stringParseIsInteger("0123456789."));
+    assert (CORE_PARSE_OK != stringParseIsInteger(""));
+    assert (CORE_PARSE_OK != stringParseIsInteger("."));
+    assert (CORE_PARSE_OK != stringParseIsInteger("1."));
+    assert (CORE_PARSE_OK != stringParseIsInteger(".0"));
+    assert (CORE_PARSE_OK != stringParseIsInteger("a"));
 
-    assert (CORE_PARSE_OK == parseIsDecimal ("1"));
-    assert (CORE_PARSE_OK == parseIsDecimal ("1."));
-    assert (CORE_PARSE_OK == parseIsDecimal ("1.1"));
-    assert (CORE_PARSE_OK == parseIsDecimal ("0.12"));
-    assert (CORE_PARSE_OK != parseIsDecimal (NULL));
-    assert (CORE_PARSE_OK != parseIsDecimal (""));
-    assert (CORE_PARSE_OK != parseIsDecimal (".12"));
-    assert (CORE_PARSE_OK != parseIsDecimal ("0.12."));
-    assert (CORE_PARSE_OK != parseIsDecimal ("0.12.34"));
-    assert (CORE_PARSE_OK != parseIsDecimal ("a"));
+    assert (CORE_PARSE_OK == stringParseIsDecimal ("1"));
+    assert (CORE_PARSE_OK == stringParseIsDecimal ("1."));
+    assert (CORE_PARSE_OK == stringParseIsDecimal ("1.1"));
+    assert (CORE_PARSE_OK == stringParseIsDecimal ("0.12"));
+    assert (CORE_PARSE_OK != stringParseIsDecimal (NULL));
+    assert (CORE_PARSE_OK != stringParseIsDecimal (""));
+    assert (CORE_PARSE_OK != stringParseIsDecimal (".12"));
+    assert (CORE_PARSE_OK != stringParseIsDecimal ("0.12."));
+    assert (CORE_PARSE_OK != stringParseIsDecimal ("0.12.34"));
+    assert (CORE_PARSE_OK != stringParseIsDecimal ("a"));
 
 
     assert (1 == encodeHexValidate("ab"));
@@ -334,143 +334,143 @@ runMathParseTests () {
 
 
     // "0x09184e72a000" // 10000000000000
-    r = createUInt256Parse("09184e72a000", 16, &status);
+    r = uint256CreateParse("09184e72a000", 16, &status);
     a.u64[0] = 10000000000000;
-    assert (CORE_PARSE_OK == status && eqUInt256(r, a));
+    assert (CORE_PARSE_OK == status && uint256EQL(r, a));
 
     // "0x0234c8a3397aab58" // 158972490234375000
-    r = createUInt256Parse("0234c8a3397aab58", 16, &status);
+    r = uint256CreateParse("0234c8a3397aab58", 16, &status);
     a.u64[0] = 158972490234375000;
-    assert (CORE_PARSE_OK == status && eqUInt256(r, a));
+    assert (CORE_PARSE_OK == status && uint256EQL(r, a));
 
     // 115792089237316195423570985008687907853269984665640564039457584007913129639935
-    r = createUInt256Parse("115792089237316195423570985008687907853269984665640564039457584007913129639935", 10, &status);
+    r = uint256CreateParse("115792089237316195423570985008687907853269984665640564039457584007913129639935", 10, &status);
     a.u64[0] = a.u64[1] = a.u64[2] = a.u64[3] = UINT64_MAX;
-    assert (CORE_PARSE_OK == status && eqUInt256(r, a));
+    assert (CORE_PARSE_OK == status && uint256EQL(r, a));
 
-    r = createUInt256Parse("1000000000000000000000000000000", 10, &status); // 1 TETHER (10^30)
+    r = uint256CreateParse("1000000000000000000000000000000", 10, &status); // 1 TETHER (10^30)
     assert (CORE_PARSE_OK == status
             && r.u64[0] == 5076944270305263616u
             && r.u64[1] == 54210108624
             && r.u64[2] == 0
             && r.u64[3] == 0);
 
-    r = createUInt256Parse("0000", 10, &status);
-    assert (CORE_PARSE_OK == status && eqUInt256 (r, UINT256_ZERO));
+    r = uint256CreateParse("0000", 10, &status);
+    assert (CORE_PARSE_OK == status && uint256EQL (r, UINT256_ZERO));
 
-    r = createUInt256Parse("0000", 2, &status);
-    assert (CORE_PARSE_OK == status && eqUInt256 (r, UINT256_ZERO));
+    r = uint256CreateParse("0000", 2, &status);
+    assert (CORE_PARSE_OK == status && uint256EQL (r, UINT256_ZERO));
 
-    r = createUInt256Parse("0x0000", 16, &status);
-    assert (CORE_PARSE_OK == status && eqUInt256 (r, UINT256_ZERO));
+    r = uint256CreateParse("0x0000", 16, &status);
+    assert (CORE_PARSE_OK == status && uint256EQL (r, UINT256_ZERO));
 
-    r = createUInt256Parse("0x", 16, &status);
-    assert (CORE_PARSE_OK == status && eqUInt256 (r, UINT256_ZERO));
+    r = uint256CreateParse("0x", 16, &status);
+    assert (CORE_PARSE_OK == status && uint256EQL (r, UINT256_ZERO));
 
-    r = createUInt256Parse("", 10, &status);
-    assert (CORE_PARSE_OK == status && eqUInt256 (r, UINT256_ZERO));
+    r = uint256CreateParse("", 10, &status);
+    assert (CORE_PARSE_OK == status && uint256EQL (r, UINT256_ZERO));
 
-    r = createUInt256Parse("", 2, &status);
-    assert (CORE_PARSE_OK == status && eqUInt256 (r, UINT256_ZERO));
+    r = uint256CreateParse("", 2, &status);
+    assert (CORE_PARSE_OK == status && uint256EQL (r, UINT256_ZERO));
 
-    r = createUInt256Parse("", 16, &status);
-    assert (CORE_PARSE_OK == status && eqUInt256 (r, UINT256_ZERO));
+    r = uint256CreateParse("", 16, &status);
+    assert (CORE_PARSE_OK == status && uint256EQL (r, UINT256_ZERO));
 
 
     char *s;
-    r = createUInt256Parse("425693205796080237694414176550132631862392541400559", 10, &status);
-    s = coerceString(r, 10);
+    r = uint256CreateParse("425693205796080237694414176550132631862392541400559", 10, &status);
+    s = uint256CoerceString(r, 10);
     assert (0 == strcmp("425693205796080237694414176550132631862392541400559", s));
     free (s);
 
-    s = coerceString(r, 16);
+    s = uint256CoerceString(r, 16);
     printf ("S: %s\n", s);
     assert (0 == strcasecmp("0123456789ABCDEFEDCBA98765432123456789ABCDEF", s));
     free(s);
 
-    r = createUInt256Parse("0123456789ABCDEFEDCBA98765432123456789ABCDEF", 16, &status);
-    s = coerceString(r, 16);
+    r = uint256CreateParse("0123456789ABCDEFEDCBA98765432123456789ABCDEF", 16, &status);
+    s = uint256CoerceString(r, 16);
     assert (0 == strcasecmp ("0123456789ABCDEFEDCBA98765432123456789ABCDEF", s));
     free (s);
 
-    s = coerceString(r, 10);
+    s = uint256CoerceString(r, 10);
     assert (0 == strcmp ("425693205796080237694414176550132631862392541400559", s));
     free (s);
 
     r = UINT256_ZERO;
-    s = coerceString(r, 10);
+    s = uint256CoerceString(r, 10);
     assert (0 == strcmp ("0", s));
     free (s);
 
-    s = coerceString(r, 16);
+    s = uint256CoerceString(r, 16);
     assert (0 == strcmp ("0", s));
     free (s);
 
-    r = createUInt256Parse("596877", 10, &status);
-    s = coerceString(r, 16);
+    r = uint256CreateParse("596877", 10, &status);
+    s = uint256CoerceString(r, 16);
     printf ("596877: %s\n", s);
 
-    r = createUInt256Parse
+    r = uint256CreateParse
     ("1111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111",
      2, &status);
     assert (CORE_PARSE_OK == status && UINT64_MAX == r.u64[0] && UINT64_MAX == r.u64[1] && UINT64_MAX == r.u64[2] && UINT64_MAX == r.u64[3]);
 
-    r = createUInt256Parse ("ffffffffffffffff", 16, &status);
+    r = uint256CreateParse ("ffffffffffffffff", 16, &status);
     assert (CORE_PARSE_OK == status && UINT64_MAX == r.u64[0] && 0 == r.u64[1] && 0 == r.u64[2] && 0 == r.u64[3]);
 
-    r = createUInt256Parse ("ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff", 16, &status);
+    r = uint256CreateParse ("ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff", 16, &status);
     assert (CORE_PARSE_OK == status && UINT64_MAX == r.u64[0] && UINT64_MAX == r.u64[1] && UINT64_MAX == r.u64[2] && UINT64_MAX == r.u64[3]);
 
-    r = createUInt256ParseDecimal(".01", 2, &status);
+    r = uint256CreateParseDecimal(".01", 2, &status);
     assert (CORE_PARSE_OK != status);
 
-    r = createUInt256ParseDecimal("0.01", 2, &status);
+    r = uint256CreateParseDecimal("0.01", 2, &status);
     assert (CORE_PARSE_OK == status && 1 == r.u64[0] && 0 == r.u64[1] && 0 == r.u64[2] && 0 == r.u64[3]);
 
-    r = createUInt256ParseDecimal("01.", 0, &status);
+    r = uint256CreateParseDecimal("01.", 0, &status);
     assert (CORE_PARSE_OK == status && 1 == r.u64[0] && 0 == r.u64[1] && 0 == r.u64[2] && 0 == r.u64[3]);
 
-    r = createUInt256ParseDecimal("01.", 2, &status);
+    r = uint256CreateParseDecimal("01.", 2, &status);
     assert (CORE_PARSE_OK == status && 100 == r.u64[0] && 0 == r.u64[1] && 0 == r.u64[2] && 0 == r.u64[3]);
 
-    r = createUInt256ParseDecimal("1", 2, &status);
+    r = uint256CreateParseDecimal("1", 2, &status);
     assert (CORE_PARSE_OK == status && 100 == r.u64[0] && 0 == r.u64[1] && 0 == r.u64[2] && 0 == r.u64[3]);
 
-    r = createUInt256ParseDecimal("2.5", 0, &status);
+    r = uint256CreateParseDecimal("2.5", 0, &status);
     assert (CORE_PARSE_UNDERFLOW == status);
 
 
     // Strings for: 0xa
 
-    r = createUInt256Parse("0xa", 16, &status);
-    s = coerceStringPrefaced(r, 16, "0x");
+    r = uint256CreateParse("0xa", 16, &status);
+    s = uint256CoerceStringPrefaced(r, 16, "0x");
     assert (0 == strcmp ("0xa", s));
     free (s);
 
-    r = createUInt256Parse("0x0a", 16, &status);
-    s = coerceStringPrefaced(r, 16, "0x");
+    r = uint256CreateParse("0x0a", 16, &status);
+    s = uint256CoerceStringPrefaced(r, 16, "0x");
     assert (0 == strcmp ("0xa", s));
     free (s);
 
-    r = createUInt256Parse("0x00a", 16, &status);
-    s = coerceStringPrefaced(r, 16, "0x");
+    r = uint256CreateParse("0x00a", 16, &status);
+    s = uint256CoerceStringPrefaced(r, 16, "0x");
     assert (0 == strcmp ("0xa", s));
     free (s);
 
     // Strings for 0x0
 
-    r = createUInt256Parse("0x", 16, &status);
-    s = coerceStringPrefaced(r, 16, "0x");
+    r = uint256CreateParse("0x", 16, &status);
+    s = uint256CoerceStringPrefaced(r, 16, "0x");
     assert (0 == strcmp ("0x0", s));
     free (s);
 
-    r = createUInt256Parse("0x0", 16, &status);
-    s = coerceStringPrefaced(r, 16, "0x");
+    r = uint256CreateParse("0x0", 16, &status);
+    s = uint256CoerceStringPrefaced(r, 16, "0x");
     assert (0 == strcmp ("0x0", s));
     free (s);
 
-    r = createUInt256Parse("0x00", 16, &status);
-    s = coerceStringPrefaced(r, 16, "0x");
+    r = uint256CreateParse("0x00", 16, &status);
+    s = uint256CoerceStringPrefaced(r, 16, "0x");
     assert (0 == strcmp ("0x0", s));
     free (s);
 }

--- a/ethereum/util/testUtil.c
+++ b/ethereum/util/testUtil.c
@@ -323,14 +323,14 @@ runMathParseTests () {
     assert (CORE_PARSE_OK != stringParseIsDecimal ("a"));
 
 
-    assert (1 == encodeHexValidate("ab"));
-    assert (1 == encodeHexValidate("ab01"));
-    assert (1 != encodeHexValidate(NULL));
-    assert (1 != encodeHexValidate(""));
-    assert (1 != encodeHexValidate("0"));
-    assert (1 != encodeHexValidate("f"));
-    assert (1 != encodeHexValidate("ff0"));
-    assert (1 != encodeHexValidate("1g"));
+    assert (1 == hexEncodeValidate("ab"));
+    assert (1 == hexEncodeValidate("ab01"));
+    assert (1 != hexEncodeValidate(NULL));
+    assert (1 != hexEncodeValidate(""));
+    assert (1 != hexEncodeValidate("0"));
+    assert (1 != hexEncodeValidate("f"));
+    assert (1 != hexEncodeValidate("ff0"));
+    assert (1 != hexEncodeValidate("1g"));
 
 
     // "0x09184e72a000" // 10000000000000

--- a/generic/BRGeneric.c
+++ b/generic/BRGeneric.c
@@ -337,7 +337,7 @@ genTransferGetHashForSet (const void *transferPtr) {
 
 static int
 genTransferIsEqualForSet (const void *transferPtr1, const void *transferPtr2) {
-    return eqUInt256 (genTransferGetHash((BRGenericTransfer) transferPtr1).value,
+    return uint256EQL (genTransferGetHash((BRGenericTransfer) transferPtr1).value,
                       genTransferGetHash((BRGenericTransfer) transferPtr2).value);
 }
 

--- a/generic/BRGenericBase.h
+++ b/generic/BRGenericBase.h
@@ -55,7 +55,7 @@ extern "C" {
 
     static inline char *
     genericHashAsString (BRGenericHash gen) {
-        return encodeHexCreate (NULL, gen.value.u8, sizeof (gen.value.u8));
+        return hexEncodeCreate (NULL, gen.value.u8, sizeof (gen.value.u8));
     }
 
     static inline uint32_t

--- a/generic/BRGenericBase.h
+++ b/generic/BRGenericBase.h
@@ -45,12 +45,12 @@ extern "C" {
 
     static inline int
     genericHashEqual (BRGenericHash gen1, BRGenericHash gen2) {
-        return eqUInt256 (gen1.value, gen2.value);
+        return uint256EQL (gen1.value, gen2.value);
     }
 
     static inline int
     genericHashIsEmpty (BRGenericHash gen) {
-        return eqUInt256 (gen.value, UINT256_ZERO);
+        return uint256EQL (gen.value, UINT256_ZERO);
     }
 
     static inline char *
@@ -93,7 +93,7 @@ extern "C" {
         double rem;
         int negative;
 
-        return mulUInt256_Double (feeBasis->pricePerCostFactor,
+        return uint256Mul_Double (feeBasis->pricePerCostFactor,
                                   feeBasis->costFactor,
                                   overflow,
                                   &negative,
@@ -102,7 +102,7 @@ extern "C" {
 
     static inline int genFeeBasisIsEqual (const BRGenericFeeBasis *fb1,
                                           const BRGenericFeeBasis *fb2) {
-        return (eqUInt256 (fb1->pricePerCostFactor, fb2->pricePerCostFactor) &&
+        return (uint256EQL (fb1->pricePerCostFactor, fb2->pricePerCostFactor) &&
                 fb1->costFactor == fb2->costFactor);
     }
 

--- a/generic/BRGenericManager.c
+++ b/generic/BRGenericManager.c
@@ -132,7 +132,7 @@ fileServiceTypeTransferV1Reader (BRFileServiceContext context,
 
     BRRlpCoder coder = rlpCoderCreate();
     BRRlpData  data  = (BRRlpData) { bytesCount, bytes };
-    BRRlpItem  item  = rlpGetItem (coder, data);
+    BRRlpItem  item  = rlpDataGetItem (coder, data);
 
     size_t itemsCount;
     const BRRlpItem *items = rlpDecodeList (coder, item, &itemsCount);
@@ -191,7 +191,7 @@ fileServiceTypeTransferV1Reader (BRFileServiceContext context,
     free (strSource);
     free (strUids);
 
-    rlpReleaseItem (coder, item);
+    rlpItemRelease (coder, item);
     rlpCoderRelease(coder);
 
     return transfer;
@@ -228,9 +228,9 @@ fileServiceTypeTransferV1Writer (BRFileServiceContext context,
                                     genTransferStateEncode (state, coder),
                                     genTransferAttributesEncode (transfer->attributes, coder));
 
-    BRRlpData data = rlpGetData (coder, item);
+    BRRlpData data = rlpItemGetData (coder, item);
 
-    rlpReleaseItem (coder, item);
+    rlpItemRelease (coder, item);
     rlpCoderRelease (coder);
 
     free (strSource); genAddressRelease (source);

--- a/generic/BRGenericManager.c
+++ b/generic/BRGenericManager.c
@@ -151,12 +151,12 @@ fileServiceTypeTransferV1Reader (BRFileServiceContext context,
     BRGenericHash *hash = (BRGenericHash*) hashData.bytes;
     char *strHash   = genericHashAsString (*hash);
 
-    char *strAmount = coerceString (amount, 10);
+    char *strAmount = uint256CoerceString (amount, 10);
 
     int overflow = 0;
     UInt256 fee = genFeeBasisGetFee (&feeBasis, &overflow);
     assert (!overflow);
-    char *strFee = coerceString (fee,    10);
+    char *strFee = uint256CoerceString (fee,    10);
 
     uint64_t timestamp = (GENERIC_TRANSFER_STATE_INCLUDED == state.type
                           ? state.u.included.timestamp

--- a/generic/BRGenericRipple.c
+++ b/generic/BRGenericRipple.c
@@ -399,7 +399,7 @@ genericRippleWalletManagerRecoverTransfer (const char *hash,
     BRRippleAddress fromAddress = rippleAddressCreateFromString(from);
     // Convert the hash string to bytes
     BRRippleTransactionHash txId;
-    decodeHex(txId.bytes, sizeof(txId.bytes), hash, strlen(hash));
+    hexDecode(txId.bytes, sizeof(txId.bytes), hash, strlen(hash));
 
     BRRippleTransfer transfer = rippleTransferCreate(fromAddress, toAddress, amountDrops, feeDrops, txId, timestamp, blockHeight, error);
 

--- a/generic/BRGenericRipple.c
+++ b/generic/BRGenericRipple.c
@@ -137,14 +137,14 @@ genericRippleTransferGetTargetAddress (BRGenericTransferRef transfer) {
 static UInt256
 genericRippleTransferGetAmount (BRGenericTransferRef transfer) {
     BRRippleUnitDrops drops = rippleTransferGetAmount ((BRRippleTransfer) transfer);
-    return createUInt256(drops);
+    return uint256Create(drops);
 }
 
 static BRGenericFeeBasis
 genericRippleTransferGetFeeBasis (BRGenericTransferRef transfer) {
     BRRippleUnitDrops rippleFee = rippleTransferGetFee ((BRRippleTransfer) transfer);
     return (BRGenericFeeBasis) {
-        createUInt256 (rippleFee),
+        uint256Create (rippleFee),
         1
     };
 }
@@ -183,14 +183,14 @@ genericRippleWalletFree (BRGenericWalletRef wallet) {
 
 static UInt256
 genericRippleWalletGetBalance (BRGenericWalletRef wallet) {
-    return createUInt256 (rippleWalletGetBalance ((BRRippleWallet) wallet));
+    return uint256Create (rippleWalletGetBalance ((BRRippleWallet) wallet));
 }
 
 static UInt256
 genericRippleWalletGetBalanceLimit (BRGenericWalletRef wallet,
                                     int asMaximum,
                                     int *hasLimit) {
-    return createUInt256 (rippleWalletGetBalanceLimit ((BRRippleWallet) wallet, asMaximum, hasLimit));
+    return uint256Create (rippleWalletGetBalanceLimit ((BRRippleWallet) wallet, asMaximum, hasLimit));
 }
 
 static BRGenericAddressRef
@@ -363,7 +363,7 @@ genericRippleWalletValidateTransactionAttribute (BRGenericWalletRef wallet,
     }
     else if (genericRippleCompareFieldOption (key, FIELD_OPTION_INVOICE_ID)) {
         BRCoreParseStatus status;
-        createUInt256Parse(val, 10, &status);
+        uint256CreateParse(val, 10, &status);
         return CORE_PARSE_OK == status;
     }
     else return 0;

--- a/support/BRFileService.c
+++ b/support/BRFileService.c
@@ -81,7 +81,7 @@ static int needSQLiteCompileOptions = 1;
 #define encodeChar(u)           ((char)    _hexc(u))
 
 static void
-decodeHex (uint8_t *target, size_t targetLen, const char *source, size_t sourceLen) {
+hexDecode (uint8_t *target, size_t targetLen, const char *source, size_t sourceLen) {
     //
     assert (0 == sourceLen % 2);
     assert (2 * targetLen == sourceLen);
@@ -92,7 +92,7 @@ decodeHex (uint8_t *target, size_t targetLen, const char *source, size_t sourceL
 }
 
 static void
-encodeHex (char *target, size_t targetLen, const uint8_t *source, size_t sourceLen) {
+hexEncode (char *target, size_t targetLen, const uint8_t *source, size_t sourceLen) {
     assert (targetLen == 2 * sourceLen  + 1);
 
     for (int i = 0; i < sourceLen; i++) {
@@ -577,7 +577,7 @@ _fileServiceSave (BRFileService fs,
     // Nex encode bytes
     size_t dataCount = 2 * bytesCount + 1;
     char *data = malloc (dataCount);
-    encodeHex (data, dataCount, bytes, bytesCount);
+    hexEncode (data, dataCount, bytes, bytesCount);
     free (bytes);
 
     // Fill out the SQL statement
@@ -683,7 +683,7 @@ fileServiceLoad (BRFileService fs,
         }
 
         // Actually decode `data` into `dataBytes`
-        decodeHex (dataBytes, dataCount/2, data, dataCount);
+        hexDecode (dataBytes, dataCount/2, data, dataCount);
 
         size_t offset = 0;
         BRFileServiceVersion version;


### PR DESCRIPTION
This only touches public interfaces and then only those currently used by 'Crypto C'.  Specifically, ethereum/ewm/BREthereum{Wallet,Transfer}.h are only used by ethereum/ewm/*.c - so the wallet and transfer functions are not renamed.

Nothing in les, bcs, mpt, nor blockchain are touched.

[Arguably everything should be renamed; perhaps later.]