### PR TITLE
CORE-816: Extend TransferConfirmation with success:Bool, error:String?

### DIFF
--- a/Java/corecrypto/src/main/java/com/breadwallet/corecrypto/Utilities.java
+++ b/Java/corecrypto/src/main/java/com/breadwallet/corecrypto/Utilities.java
@@ -161,7 +161,9 @@ final class Utilities {
                             UnsignedLong.fromLongBits(state.u.included.timestamp),
                             Optional.fromNullable(state.u.included.feeBasis)
                                     .transform(TransferFeeBasis::create)
-                                    .transform(TransferFeeBasis::getFee)
+                                    .transform(TransferFeeBasis::getFee),
+                            Boolean.valueOf(state.u.included.success),
+                            Optional.fromNullable(state.u.included.error)
                     )
             );
             default: throw new IllegalArgumentException("Unsupported state");

--- a/Java/corecrypto/src/main/java/com/breadwallet/corecrypto/Utilities.java
+++ b/Java/corecrypto/src/main/java/com/breadwallet/corecrypto/Utilities.java
@@ -162,8 +162,8 @@ final class Utilities {
                             Optional.fromNullable(state.u.included.feeBasis)
                                     .transform(TransferFeeBasis::create)
                                     .transform(TransferFeeBasis::getFee),
-                            Boolean.valueOf(state.u.included.success),
-                            Optional.fromNullable(state.u.included.error)
+                            Boolean.valueOf(state.u.included.getSuccess()),
+                            Optional.fromNullable(state.u.included.getError())
                     )
             );
             default: throw new IllegalArgumentException("Unsupported state");

--- a/Java/corenative/src/main/java/com/breadwallet/corenative/crypto/BRCryptoTransferState.java
+++ b/Java/corenative/src/main/java/com/breadwallet/corenative/crypto/BRCryptoTransferState.java
@@ -28,13 +28,14 @@ public class BRCryptoTransferState extends Structure {
         public errored_struct errored;
 
         public static class included_struct extends Structure {
+            private static int CRYPTO_TRANSFER_INCLUDED_ERROR_SIZE = 16;
 
             public long blockNumber;
             public long transactionIndex;
             public long timestamp;
             public BRCryptoFeeBasis feeBasis;
-            public int success;
-            public byte[] error = new byte[1];
+            public int success = BRCryptoBoolean.CRYPTO_TRUE;
+            public byte[] error = new byte[CRYPTO_TRANSFER_INCLUDED_ERROR_SIZE + 1];
 
             public included_struct() {
                 super();

--- a/Java/corenative/src/main/java/com/breadwallet/corenative/crypto/BRCryptoTransferState.java
+++ b/Java/corenative/src/main/java/com/breadwallet/corenative/crypto/BRCryptoTransferState.java
@@ -7,12 +7,15 @@
  */
 package com.breadwallet.corenative.crypto;
 
+import com.sun.jna.Native;
 import com.sun.jna.Pointer;
 import com.sun.jna.Structure;
 import com.sun.jna.Union;
 
 import java.util.Arrays;
 import java.util.List;
+
+import javax.annotation.Nullable;
 
 public class BRCryptoTransferState extends Structure {
 
@@ -30,8 +33,8 @@ public class BRCryptoTransferState extends Structure {
             public long transactionIndex;
             public long timestamp;
             public BRCryptoFeeBasis feeBasis;
-            public boolean success;
-            public String error;
+            public int success;
+            public byte[] error = new byte[1];
 
             public included_struct() {
                 super();
@@ -41,18 +44,26 @@ public class BRCryptoTransferState extends Structure {
                 return Arrays.asList("blockNumber", "transactionIndex", "timestamp", "feeBasis", "success", "error");
             }
 
-            public included_struct(long blockNumber, long transactionIndex, long timestamp, BRCryptoFeeBasis feeBasis, int success, String error) {
+            public included_struct(long blockNumber, long transactionIndex, long timestamp, BRCryptoFeeBasis feeBasis, int success, byte[] error) {
                 super();
                 this.blockNumber = blockNumber;
                 this.transactionIndex = transactionIndex;
                 this.timestamp = timestamp;
                 this.feeBasis = feeBasis;
-                this.success = (success == BRCryptoBoolean.CRYPTO_TRUE);
-                this.error = this.success ? null : error.toLowerCase();  // copy, somehow
+                this.success = success;
+                this.error = error;
             }
 
             public included_struct(Pointer peer) {
                 super(peer);
+            }
+
+            public @Nullable String getError () {
+                return getSuccess() ? null : Native.toString(this.error);
+            }
+
+            public boolean getSuccess () {
+                return BRCryptoBoolean.CRYPTO_TRUE == this.success;
             }
 
             public static class ByReference extends included_struct implements Structure.ByReference {

--- a/Java/corenative/src/main/java/com/breadwallet/corenative/crypto/BRCryptoTransferState.java
+++ b/Java/corenative/src/main/java/com/breadwallet/corenative/crypto/BRCryptoTransferState.java
@@ -30,21 +30,25 @@ public class BRCryptoTransferState extends Structure {
             public long transactionIndex;
             public long timestamp;
             public BRCryptoFeeBasis feeBasis;
+            public boolean success;
+            public String error;
 
             public included_struct() {
                 super();
             }
 
             protected List<String> getFieldOrder() {
-                return Arrays.asList("blockNumber", "transactionIndex", "timestamp", "feeBasis");
+                return Arrays.asList("blockNumber", "transactionIndex", "timestamp", "feeBasis", "success", "error");
             }
 
-            public included_struct(long blockNumber, long transactionIndex, long timestamp, BRCryptoFeeBasis feeBasis) {
+            public included_struct(long blockNumber, long transactionIndex, long timestamp, BRCryptoFeeBasis feeBasis, int success, String error) {
                 super();
                 this.blockNumber = blockNumber;
                 this.transactionIndex = transactionIndex;
                 this.timestamp = timestamp;
                 this.feeBasis = feeBasis;
+                this.success = (success == BRCryptoBoolean.CRYPTO_TRUE);
+                this.error = this.success ? null : error.toLowerCase();  // copy, somehow
             }
 
             public included_struct(Pointer peer) {

--- a/Java/crypto/src/main/java/com/breadwallet/crypto/TransferConfirmation.java
+++ b/Java/crypto/src/main/java/com/breadwallet/crypto/TransferConfirmation.java
@@ -21,12 +21,16 @@ public final class TransferConfirmation {
     private final UnsignedLong transactionIndex;
     private final Date timestamp;
     private final Optional<Amount> fee;
+    private final Boolean success;
+    private final Optional<String> error;
 
-    public TransferConfirmation(UnsignedLong blockNumber, UnsignedLong transactionIndex, UnsignedLong timestamp, Optional<Amount> fee) {
+    public TransferConfirmation(UnsignedLong blockNumber, UnsignedLong transactionIndex, UnsignedLong timestamp, Optional<Amount> fee, Boolean success, Optional<String> error) {
         this.blockNumber = blockNumber;
         this.transactionIndex = transactionIndex;
         this.timestamp = new Date(TimeUnit.SECONDS.toMillis(timestamp.longValue()));
         this.fee = fee;
+        this.success = success;
+        this.error = error;
     }
 
     public UnsignedLong getBlockNumber() {
@@ -43,5 +47,13 @@ public final class TransferConfirmation {
 
     public Optional<Amount> getFee() {
         return fee;
+    }
+
+    public boolean getSuccess() {
+        return success;
+    }
+
+    public Optional<String> getError() {
+        return error;
     }
 }

--- a/Java/crypto/src/main/java/com/breadwallet/crypto/TransferConfirmation.java
+++ b/Java/crypto/src/main/java/com/breadwallet/crypto/TransferConfirmation.java
@@ -21,10 +21,10 @@ public final class TransferConfirmation {
     private final UnsignedLong transactionIndex;
     private final Date timestamp;
     private final Optional<Amount> fee;
-    private final Boolean success;
+    private final boolean success;
     private final Optional<String> error;
 
-    public TransferConfirmation(UnsignedLong blockNumber, UnsignedLong transactionIndex, UnsignedLong timestamp, Optional<Amount> fee, Boolean success, Optional<String> error) {
+    public TransferConfirmation(UnsignedLong blockNumber, UnsignedLong transactionIndex, UnsignedLong timestamp, Optional<Amount> fee, boolean success, Optional<String> error) {
         this.blockNumber = blockNumber;
         this.transactionIndex = transactionIndex;
         this.timestamp = new Date(TimeUnit.SECONDS.toMillis(timestamp.longValue()));

--- a/Java/cryptodemo-android/src/main/java/com/breadwallet/cryptodemo/CoreCryptoApplication.java
+++ b/Java/cryptodemo-android/src/main/java/com/breadwallet/cryptodemo/CoreCryptoApplication.java
@@ -142,7 +142,8 @@ public class CoreCryptoApplication extends Application {
                     "btc",
                     "eth",
                     "bch",
-                    "xrp");
+                    "xrp"
+            );
             systemListener = new DispatchingSystemListener();
             systemListener.addSystemListener(new CoreSystemListener(mode, isMainnet, currencyCodesNeeded));
 

--- a/Java/cryptodemo-android/src/main/java/com/breadwallet/cryptodemo/TransferDetailsActivity.java
+++ b/Java/cryptodemo-android/src/main/java/com/breadwallet/cryptodemo/TransferDetailsActivity.java
@@ -28,6 +28,7 @@ import com.breadwallet.crypto.Transfer;
 import com.breadwallet.crypto.TransferAttribute;
 import com.breadwallet.crypto.TransferConfirmation;
 import com.breadwallet.crypto.TransferHash;
+import com.breadwallet.crypto.TransferState;
 import com.breadwallet.crypto.Wallet;
 import com.breadwallet.crypto.WalletManager;
 import com.breadwallet.crypto.events.system.DefaultSystemListener;
@@ -251,6 +252,7 @@ public class TransferDetailsActivity extends AppCompatActivity implements Defaul
             this.transfer = transfer;
 
             Optional<TransferConfirmation> conf = transfer.getConfirmation();
+            TransferState state = transfer.getState();
 
             this.amountText = transfer.getAmountDirected().toString();
             this.feeText = transfer.getFee().toString();
@@ -261,7 +263,12 @@ public class TransferDetailsActivity extends AppCompatActivity implements Defaul
             this.confirmationCountText = transfer.getConfirmations().transform(String::valueOf).or("");
             this.dateText = conf.transform((c) -> DATE_FORMAT.get().format(c.getConfirmationTime())).or("<pending>");
             this.confirmationCountVisible = conf.isPresent();
-            this.stateText = transfer.getState().toString();
+            this.stateText = conf.transform((c) ->
+                    state.toString() +
+                            (c.getSuccess()
+                                ? ""
+                                : String.format (" (%s)", c.getError().or("err"))))
+                .or(state.toString());
             this.directionText = transfer.getDirection().toString();
 
             StringBuffer sb = new StringBuffer();

--- a/Java/cryptodemo-android/src/main/java/com/breadwallet/cryptodemo/TransferListActivity.java
+++ b/Java/cryptodemo-android/src/main/java/com/breadwallet/cryptodemo/TransferListActivity.java
@@ -455,7 +455,12 @@ public class TransferListActivity extends AppCompatActivity implements DefaultSy
 
             this.amountText = Suppliers.memoize(() -> transfer.getAmountDirected().toString());
             this.feeText = Suppliers.memoize(() -> String.format("Fee: %s", transfer.getFee()));
-            this.stateText = Suppliers.memoize(() -> String.format("State: %s", state()));
+            this.stateText = Suppliers.memoize(() -> {
+                        String text = String.format("State: %s", state());
+                        return confirmation().transform((c) -> text +
+                                (c.getSuccess() ? "" : String.format(" (%s)", c.getError().or("<err>"))))
+                                .or(text);
+                    });
             this.dateText = Suppliers.memoize(() -> confirmation()
                     .transform(TransferConfirmation::getConfirmationTime)
                     .transform(t -> DATE_FORMAT.get().format(t))

--- a/Swift/BRCryptoDemo/TransferTableViewCell.swift
+++ b/Swift/BRCryptoDemo/TransferTableViewCell.swift
@@ -42,10 +42,8 @@ class TransferTableViewCell: UITableViewCell {
         switch state {
         case .created: return UIColor.gray
         case .submitted: return UIColor.yellow
-        case .included: return UIColor.green
-//       case .errored:  return UIColor.red
-//       case .cancelled: return UIColor.blue
-//       case .replaced: return UIColor.blue
+        case .included: return
+            transfer!.confirmation!.success ? UIColor.green : UIColor.red
         case .deleted: return UIColor.black
 
         case .signed: return UIColor.yellow

--- a/Swift/BRCryptoDemo/TransferViewController.swift
+++ b/Swift/BRCryptoDemo/TransferViewController.swift
@@ -55,10 +55,8 @@ class TransferViewController: UIViewController, TransferListener, WalletManagerL
         switch state {
         case .created: return UIColor.gray
         case .submitted: return UIColor.yellow
-        case .included: return UIColor.green
-            //       case .errored:  return UIColor.red
-            //       case .cancelled: return UIColor.blue
-        //       case .replaced: return UIColor.blue
+        case .included:
+            return transfer!.confirmation!.success ? UIColor.green : UIColor.red
         case .deleted: return UIColor.black
 
         case .signed: return UIColor.yellow

--- a/crypto/BRCryptoTransfer.c
+++ b/crypto/BRCryptoTransfer.c
@@ -876,11 +876,28 @@ extern BRCryptoTransferState
 cryptoTransferStateIncludedInit (uint64_t blockNumber,
                                  uint64_t transactionIndex,
                                  uint64_t timestamp,
-                                 BRCryptoFeeBasis feeBasis) {
-    return (BRCryptoTransferState) {
+                                 BRCryptoFeeBasis feeBasis,
+                                 BRCryptoBoolean success,
+                                 const char *error) {
+    BRCryptoTransferState result = (BRCryptoTransferState) {
         CRYPTO_TRANSFER_STATE_INCLUDED,
-        { .included = { blockNumber, transactionIndex, timestamp, cryptoFeeBasisTake(feeBasis) }}
+        { .included = {
+            blockNumber,
+            transactionIndex,
+            timestamp,
+            cryptoFeeBasisTake(feeBasis),
+            success
+        }}
     };
+
+    memset (result.u.included.error, 0, CRYPTO_TRANSFER_INCLUDED_ERROR_SIZE + 1);
+    if (CRYPTO_FALSE == success) {
+        strlcpy (result.u.included.error,
+                 (NULL == error ? "unknown error" : error),
+                 CRYPTO_TRANSFER_INCLUDED_ERROR_SIZE + 1);
+    }
+
+    return result;
 }
 
 extern BRCryptoTransferState

--- a/crypto/BRCryptoWalletManager.c
+++ b/crypto/BRCryptoWalletManager.c
@@ -736,7 +736,9 @@ cryptoTransferStateCreateGEN (BRGenericTransferState generic,
             BRCryptoTransferState state = cryptoTransferStateIncludedInit (generic.u.included.blockNumber,
                                                                            generic.u.included.transactionIndex,
                                                                            generic.u.included.timestamp,
-                                                                           basis);
+                                                                           basis,
+                                                                           generic.u.included.success,
+                                                                           generic.u.included.error);
             cryptoFeeBasisGive (basis);
             return state;
         }

--- a/generic/BRGeneric.h
+++ b/generic/BRGeneric.h
@@ -313,7 +313,8 @@ extern "C" {
                                                   uint8_t *bytes,
                                                   size_t   bytesCount,
                                                   uint64_t timestamp,
-                                                  uint64_t blockHeight);
+                                                  uint64_t blockHeight,
+                                                  int error);
 
     extern int
     genManagerSignTransfer (BRGenericManager gwm,

--- a/generic/BRGenericBase.h
+++ b/generic/BRGenericBase.h
@@ -136,6 +136,8 @@ extern "C" {
         GENERIC_TRANSFER_STATE_DELETED,
     } BRGenericTransferStateType;
 
+#define GENERIC_TRANSFER_INCLUDED_ERROR_SIZE     16
+
     typedef struct {
         BRGenericTransferStateType type;
         union {
@@ -144,6 +146,8 @@ extern "C" {
                 uint64_t transactionIndex;
                 uint64_t timestamp;
                 BRGenericFeeBasis feeBasis;
+                BRCryptoBoolean success;
+                char error [GENERIC_TRANSFER_INCLUDED_ERROR_SIZE + 1];
             } included;
             BRGenericTransferSubmitError errored;
         } u;
@@ -157,11 +161,29 @@ extern "C" {
     genTransferStateCreateIncluded (uint64_t blockNumber,
                                     uint64_t transactionIndex,
                                     uint64_t timestamp,
-                                    BRGenericFeeBasis feeBasis) {
-        return (BRGenericTransferState) {
+                                    BRGenericFeeBasis feeBasis,
+                                    BRCryptoBoolean success,
+                                    const char *error) {
+        BRGenericTransferState result = (BRGenericTransferState) {
             GENERIC_TRANSFER_STATE_INCLUDED,
-            { .included = { blockNumber, transactionIndex, timestamp, feeBasis }}
+            { .included = {
+                blockNumber,
+                transactionIndex,
+                timestamp,
+                feeBasis,
+                success
+            }}
         };
+
+        memset (result.u.included.error, 0, GENERIC_TRANSFER_INCLUDED_ERROR_SIZE + 1);
+        if (CRYPTO_FALSE == success) {
+            strlcpy (result.u.included.error,
+                     (NULL == error ? "unknown error" : error),
+                     GENERIC_TRANSFER_INCLUDED_ERROR_SIZE + 1);
+        }
+
+        return result;
+
     }
 
     static inline BRGenericTransferState

--- a/generic/BRGenericManager.c
+++ b/generic/BRGenericManager.c
@@ -697,15 +697,19 @@ genTransferStateDecode (BRRlpItem item,
         case GENERIC_TRANSFER_STATE_INCLUDED:
             assert (5 == itemsCount);
 
-            return (BRGenericTransferState) {
+            BRGenericTransferState state = (BRGenericTransferState) {
                 type,
                 { .included = {
                     rlpDecodeUInt64  (coder, items[1], 0),
                     rlpDecodeUInt64  (coder, items[2], 0),
                     rlpDecodeUInt64  (coder, items[3], 0),
-                    genFeeBasisDecode (items[4], coder)
+                    genFeeBasisDecode (items[4], coder),
+                    CRYPTO_TRUE
                 }}
             };
+
+            memcpy (state.u.included.error, 0, sizeof(state.u.included.error));
+            return state;
 
         case GENERIC_TRANSFER_STATE_ERRORED: {
             assert (2 == itemsCount);

--- a/generic/BRGenericManager.c
+++ b/generic/BRGenericManager.c
@@ -173,6 +173,10 @@ fileServiceTypeTransferV1Reader (BRFileServiceContext context,
                                                             blockHeight,
                                                             GENERIC_TRANSFER_STATE_ERRORED == state.type);
 
+    // Set the transfer's `state` and `attributes` from the read values.  For`state`, this will
+    // overwrite what `genManagerRecoverTransfer()` assigned but will be correct with the saved
+    // values.  Later, perhaps based on a BlocksetDB query, the state change to 'included error'.
+    genTransferSetState (transfer, state);
     genTransferSetAttributes (transfer, attributes);
 
     genTransferAttributeReleaseAll(attributes);

--- a/generic/BRGenericManager.c
+++ b/generic/BRGenericManager.c
@@ -460,7 +460,9 @@ genManagerRecoverTransfer (BRGenericManager gwm,
                          genTransferStateCreateIncluded (blockHeight,
                                                          GENERIC_TRANSFER_TRANSACTION_INDEX_UNKNOWN,
                                                          timestamp,
-                                                         feeBasis));
+                                                         feeBasis,
+                                                         0 == error,
+                                                         NULL));
 
     genAddressRelease (source);
     genAddressRelease (target);
@@ -472,7 +474,8 @@ genManagerRecoverTransfersFromRawTransaction (BRGenericManager gwm,
                                               uint8_t *bytes,
                                               size_t   bytesCount,
                                               uint64_t timestamp,
-                                              uint64_t blockHeight) {
+                                              uint64_t blockHeight,
+                                              int error) {
     pthread_mutex_lock (&gwm->lock);
     BRArrayOf(BRGenericTransferRef) refs = gwm->handlers->manager.transfersRecoverFromRawTransaction (bytes, bytesCount);
     BRArrayOf(BRGenericTransfer) transfers;
@@ -483,7 +486,9 @@ genManagerRecoverTransfersFromRawTransaction (BRGenericManager gwm,
                              genTransferStateCreateIncluded (blockHeight,
                                                              GENERIC_TRANSFER_TRANSACTION_INDEX_UNKNOWN,
                                                              timestamp,
-                                                             genTransferGetFeeBasis (transfer)));
+                                                             genTransferGetFeeBasis (transfer),
+                                                             0 == error,
+                                                             NULL));
         array_add (transfers, transfer);
     }
     pthread_mutex_unlock (&gwm->lock);

--- a/generic/BRGenericPrivate.h
+++ b/generic/BRGenericPrivate.h
@@ -14,6 +14,7 @@
 
 #include "BRGeneric.h"
 #include "BRGenericHandlers.h"
+#include "ethereum/rlp/BRRlp.h"
 
 #if !defined(private_extern)
 #define private_extern extern
@@ -81,6 +82,20 @@ struct BRGenericWalletRecord {
 private_extern BRGenericWallet
 genWalletAllocAndInit (const char *type,
                        BRGenericWalletRef ref);
+
+typedef enum {
+    GEN_TRANSFER_STATE_ENCODE_V1,
+    GEN_TRANSFER_STATE_ENCODE_V2
+} BRGenericTransferStateEncodeVersion;
+
+extern BRRlpItem
+genTransferStateEncode (BRGenericTransferState state,
+                        BRGenericTransferStateEncodeVersion version,
+                        BRRlpCoder coder);
+
+extern BRGenericTransferState
+genTransferStateDecode (BRRlpItem item,
+                        BRRlpCoder coder);
 
 //DECLARE_GENERIC_TYPE(Manager)
 

--- a/include/BRCryptoTransfer.h
+++ b/include/BRCryptoTransfer.h
@@ -66,6 +66,7 @@ extern "C" {
     extern const char *
     cryptoTransferStateTypeString (BRCryptoTransferStateType type);
 
+#define CRYPTO_TRANSFER_INCLUDED_ERROR_SIZE     16
     typedef struct {
         BRCryptoTransferStateType type;
         union {
@@ -76,6 +77,10 @@ extern "C" {
                 // timestamp which varies depending on how the transaction was discovered.
                 uint64_t timestamp;
                 BRCryptoFeeBasis feeBasis;
+
+                // transfer that have failed can be included too
+                BRCryptoBoolean success;
+                char error[CRYPTO_TRANSFER_INCLUDED_ERROR_SIZE + 1];
             } included;
 
             struct {
@@ -91,7 +96,9 @@ extern "C" {
     cryptoTransferStateIncludedInit (uint64_t blockNumber,
                                      uint64_t transactionIndex,
                                      uint64_t timestamp,
-                                     BRCryptoFeeBasis feeBasis);
+                                     BRCryptoFeeBasis feeBasis,
+                                     BRCryptoBoolean success,
+                                     const char *error);
 
     extern BRCryptoTransferState
     cryptoTransferStateErroredInit (BRCryptoTransferSubmitError error);


### PR DESCRIPTION
Modify BRCryptoTransferState for 'included' to add 'BRCryptoBoolean success; char error[...]' and follow through for all of Crypto, Gen, Swift, Java.

The Java 'JNA Struct' seems to cause a crash.. on 'String error'. 