### PR TITLE
CORE-670: Generate GEN Wallet Manager Events.

### DIFF
--- a/Swift/BRCrypto/BRCryptoSystem.swift
+++ b/Swift/BRCrypto/BRCryptoSystem.swift
@@ -958,7 +958,7 @@ extension System {
                     walletManagerEvent = WalletManagerEvent.syncStarted
 
                 case CRYPTO_WALLET_MANAGER_EVENT_SYNC_CONTINUES:
-                    let timestamp: Date? = (0 == event.u.syncContinues.timestamp // CRYPTO_NO_SYNC_TIMESTAMP
+                    let timestamp: Date? = (0 == event.u.syncContinues.timestamp // NO_CRYPTO_SYNC_TIMESTAMP
                         ? nil
                         : Date (timeIntervalSince1970: TimeInterval(event.u.syncContinues.timestamp)))
 

--- a/Swift/BRCryptoTests/BRCryptoBaseTests.swift
+++ b/Swift/BRCryptoTests/BRCryptoBaseTests.swift
@@ -337,7 +337,7 @@ class CryptoTestSystemListener: SystemListener {
             EventMatcher (event: WalletManagerEvent.changed (oldState: WalletManagerState.connected,
                                                              newState: WalletManagerState.disconnected (reason: disconnectReason)),
                           strict: !lenientDisconnect,
-                          scan: false)
+                          scan: true)       // block height updates might intervene.
 
         return checkManagerEvents(
             [EventMatcher (event: WalletManagerEvent.created),

--- a/Swift/BRCryptoTests/BRCryptoWalletTests.swift
+++ b/Swift/BRCryptoTests/BRCryptoWalletTests.swift
@@ -307,14 +307,9 @@ class BRCryptoWalletTests: BRCryptoSystemBaseTests {
     }
 
     func testWalletXRP() {
-        isMainnet = false
+        isMainnet = true
         currencyCodesToMode = ["xrp":WalletManagerMode.api_only]
-        prepareAccount (AccountSpecification (dict: [
-            "identifier": "ginger",
-            "paperKey":   "ginger settle marine tissue robot crane night number ramp coast roast critic",
-            "timestamp":  "2018-01-01",
-            "network":    (isMainnet ? "mainnet" : "testnet")
-            ]))
+        prepareAccount (identifier: "loan(C)")
 
         prepareSystem()
 

--- a/crypto/BRCryptoWalletManager.c
+++ b/crypto/BRCryptoWalletManager.c
@@ -314,7 +314,6 @@ cryptoWalletManagerCreate (BRCryptoCWMListener listener,
                                                    CRYPTO_WALLET_EVENT_BALANCE_UPDATED,
                                                    { .balanceUpdated = { balance }}
                                                });
-
             break;
         }
     }
@@ -835,6 +834,13 @@ cryptoWalletManagerSetTransferStateGEN (BRCryptoWalletManager cwm,
                                                CRYPTO_WALLET_EVENT_BALANCE_UPDATED,
                                                { .balanceUpdated = { balance }}
                                            });
+
+        cwm->listener.walletManagerEventCallback (cwm->listener.context,
+                                                  cryptoWalletManagerTake (cwm),
+                                                  (BRCryptoWalletManagerEvent) {
+            CRYPTO_WALLET_MANAGER_EVENT_WALLET_CHANGED,
+            { .wallet = cryptoWalletTake (cwm->wallet) }
+        });
     }
 
     pthread_mutex_unlock (&cwm->lock);
@@ -1494,6 +1500,22 @@ cryptoWalletManagerHandleTransferGEN (BRCryptoWalletManager cwm,
                                            (BRCryptoWalletEvent) {
             CRYPTO_WALLET_EVENT_TRANSFER_ADDED,
             { .transfer = { cryptoTransferTake (transfer) }}
+        });
+
+        BRCryptoAmount balance = cryptoWalletGetBalance(wallet);
+        cwm->listener.walletEventCallback (cwm->listener.context,
+                                           cryptoWalletManagerTake (cwm),
+                                           cryptoWalletTake (cwm->wallet),
+                                           (BRCryptoWalletEvent) {
+                                               CRYPTO_WALLET_EVENT_BALANCE_UPDATED,
+                                               { .balanceUpdated = { balance }}
+                                           });
+
+        cwm->listener.walletManagerEventCallback (cwm->listener.context,
+                                                  cryptoWalletManagerTake (cwm),
+                                                  (BRCryptoWalletManagerEvent) {
+            CRYPTO_WALLET_MANAGER_EVENT_WALLET_CHANGED,
+            { .wallet = cryptoWalletTake (cwm->wallet) }
         });
     }
 

--- a/generic/BRGeneric.h
+++ b/generic/BRGeneric.h
@@ -18,6 +18,8 @@
 #include "BRGenericBase.h"
 #include "BRGenericClient.h"
 
+#include "BRCryptoSync.h"
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -242,6 +244,13 @@ extern "C" {
 
     // MARK: Generic (Wallet) Manager
 
+    typedef void *BRGenericManagerSyncContext;
+    typedef void (*BRGenericManagerSyncCallback) (BRGenericManagerSyncContext context,
+                                                  BRGenericManager manager,
+                                                  uint64_t begBlockHeight,
+                                                  uint64_t endBlockHeight,
+                                                  uint64_t fullSyncIncrement);
+
     extern BRGenericManager
     genManagerCreate (BRGenericClient client,
                       const char *type,
@@ -250,6 +259,8 @@ extern "C" {
                       uint64_t accountTimestamp,
                       const char *storagePath,
                       uint32_t syncPeriodInSeconds,
+                      BRGenericManagerSyncContext  syncContext,
+                      BRGenericManagerSyncCallback syncCallback,
                       uint64_t blockHeight);
 
     extern void
@@ -264,8 +275,15 @@ extern "C" {
     extern void
     genManagerDisconnect (BRGenericManager gwm);
 
+    extern int
+    genManagerIsConnected (BRGenericManager gwm);
+
     extern void
     genManagerSync (BRGenericManager gwm);
+
+    extern void
+    genManagerSyncToDepth (BRGenericManager gwm,
+                           BRCryptoSyncDepth depth);
 
     #if 0
     extern BRArrayOf (BRGenericTransfer) // BRSetOf

--- a/include/BRCryptoWalletManager.h
+++ b/include/BRCryptoWalletManager.h
@@ -133,8 +133,6 @@ extern "C" {
         } u;
     } BRCryptoWalletManagerEvent;
 
-#define CRYPTO_NO_SYNC_TIMESTAMP        (NO_SYNC_TIMESTAMP)
-
     /// MARK: Listener
 
     typedef void *BRCryptoCWMListenerContext;


### PR DESCRIPTION
[Will cherry-pick to WalletKit]

SBI noticed XRP events being inconsistent with BTC API/P2P Events.  Added GEN events in all the right places.  Added a unit test for XRP that uses the same 'checkManagerEventsCommonlyWith()` function.

Implemented genManager{Sync,SyncToDepth} - removed assert()